### PR TITLE
Fixes #7 - Hardcoded platform string text in Unit tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,7 @@ after_build:
 
 test_script:
   - ps: .\Invoke-UnitTests.ps1
+  - ps: { Set-Culture fr-FR; .\Invoke-UnitTests.ps1 }
 
 artifacts:
   - path: .\BuildOutput\Nuget\LLvm.NET.*.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ after_build:
 
 test_script:
   - ps: .\Invoke-UnitTests.ps1
-  - ps: { Set-Culture fr-FR; .\Invoke-UnitTests.ps1 }
+  - ps: Set-Culture fr-FR; .\Invoke-UnitTests.ps1
 
 artifacts:
   - path: .\BuildOutput\Nuget\LLvm.NET.*.nupkg

--- a/src/Llvm.NETTests/ExpectedArgumentException.cs
+++ b/src/Llvm.NETTests/ExpectedArgumentException.cs
@@ -35,13 +35,11 @@ namespace Llvm.NETTests
             RethrowIfAssertException(exception);
 
             Assert.IsInstanceOfType(exception, typeof(ArgumentException), WrongExceptionMessage );
-            Assert.AreEqual( ExpectedName, ( ( ArgumentException )exception ).ParamName );
+            var argException = ( ArgumentException )exception;
+            Assert.AreEqual( ExpectedName, argException.ParamName );
             if( !string.IsNullOrWhiteSpace( ExpectedExceptionMessage ) )
             {
-                Assert.AreEqual( $"{ExpectedExceptionMessage}\r\nParameter name: {ExpectedName}"
-                               , exception.Message
-                               , "Could not verify the exception message."
-                               );
+                Assert.IsTrue( exception.Message.StartsWith( ExpectedExceptionMessage, StringComparison.Ordinal ), "Could not verify the exception message." );
             }
         }
 


### PR DESCRIPTION
- This change simply alters the test for the exception message to verify the part provided by the Llvm.NET library itself, ignoring the trailing part provided by the  BCL, which is subject to Locale differences.
- Appveyor.yml is set to run test in a second locale to help catch any future issues.