### PR TITLE
Updated BitCodeModule to prepare for SharedModule use in OrcJIT

### DIFF
--- a/Samples/CodeGenWithDebugInfo/Program.cs
+++ b/Samples/CodeGenWithDebugInfo/Program.cs
@@ -40,7 +40,7 @@ namespace TestDebugInfo
                 var target = Target.FromTriple( TargetDetails.Triple );
                 using( var context = new Context( ) )
                 using( var targetMachine = target.CreateTargetMachine( TargetDetails.Triple, TargetDetails.Cpu, TargetDetails.Features, CodeGenOpt.Aggressive, Reloc.Default, CodeModel.Small ) )
-                using( var module = new BitcodeModule( moduleName, context ) )
+                using( var module = new BitcodeModule( context, moduleName ) )
                 {
                     module.SourceFileName = Path.GetFileName( srcPath );
                     TargetDependentAttributes = TargetDetails.BuildTargetDependentFunctionAttributes( context );

--- a/src/Llvm.NETTests/ContextTests.cs
+++ b/src/Llvm.NETTests/ContextTests.cs
@@ -144,7 +144,7 @@ namespace Llvm.NET.Tests
             using( var context = new Context( ) )
             using( var targetMachine = TargetTests.GetTargetMachine( ) )
             {
-                var module = new BitcodeModule( "test.bc", context, SourceLanguage.CSharp, "test.cs", "unittests" );
+                var module = new BitcodeModule( context, "test.bc", SourceLanguage.CSharp, "test.cs", "unittests" );
                 Assert.IsNotNull( module );
                 module.Layout = targetMachine.TargetData;
 
@@ -194,7 +194,7 @@ namespace Llvm.NET.Tests
             using( var context = new Context( ) )
             using( var targetMachine = TargetTests.GetTargetMachine( ) )
             {
-                var module = new BitcodeModule( "test.bc", context, SourceLanguage.CSharp, "test.cs", "unittests" );
+                var module = new BitcodeModule( context, "test.bc", SourceLanguage.CSharp, "test.cs", "unittests" );
                 Assert.IsNotNull( module );
                 module.Layout = targetMachine.TargetData;
 

--- a/src/Llvm.NETTests/DebugInfo/DebugUnionTypeTests.cs
+++ b/src/Llvm.NETTests/DebugInfo/DebugUnionTypeTests.cs
@@ -16,7 +16,8 @@ namespace Llvm.NET.DebugInfo.Tests
         [TestMethod]
         public void DebugUnionTypeTest( )
         {
-            using( var module = new BitcodeModule( ) )
+            using( var context = new Context( ) )
+            using( var module = new BitcodeModule( context ) )
             {
                 const string nativeUnionName = "union.testUnion";
                 const string unionSymbolName = "testUnion";
@@ -90,7 +91,7 @@ namespace Llvm.NET.DebugInfo.Tests
             var target = Target.FromTriple( testTriple );
             using( var ctx = new Context( ) )
             using( var targetMachine = target.CreateTargetMachine( testTriple ) )
-            using( var module = new BitcodeModule( "testModule", ctx ) { Layout= targetMachine.TargetData } )
+            using( var module = new BitcodeModule( ctx, "testModule" ) { Layout= targetMachine.TargetData } )
             {
                 const string nativeUnionName = "union.testUnion";
                 const string unionSymbolName = "testUnion";

--- a/src/Llvm.NETTests/MDNodeTests.cs
+++ b/src/Llvm.NETTests/MDNodeTests.cs
@@ -25,7 +25,8 @@ namespace Llvm.NET.Tests
         [TestMethod]
         public void OperandsAreAccessibleTest()
         {
-            using( var module = new BitcodeModule( "test.bc", SourceLanguage.CSharp, "test.cs", "unittests" ) )
+            using( var ctx = new Context( ) )
+            using( var module = new BitcodeModule( ctx, "test.bc", SourceLanguage.CSharp, "test.cs", "unittests" ) )
             using( var targetMachine = TargetTests.GetTargetMachine( ) )
             {
                 module.Layout = targetMachine.TargetData;


### PR DESCRIPTION
Updated BitCode Module to prepare support for SharedModule use in OrcJIT

# Breaking Changes
The constructors for BitcodeModule now all require a Context. The idea of auto creating the context was convenient at first but is actually an inversion of the real ownership, which made the code more complex for clean up and tragically broken in the face of the ref counted shared module refs for OrcJIT. Thus it is time to unwind that choice.