### PR TITLE
Refactoring and more docs

### DIFF
--- a/docfx/llvm-xref.yml
+++ b/docfx/llvm-xref.yml
@@ -11,3 +11,6 @@ references:
   - uid: llvm_docs_passes
     name: LLVM Analysis and Transform Passes
     href: http://releases.llvm.org/5.0.0/docs/Passes.html
+  - uid: llvm_releases_docs
+    name: LLVM Documentation
+    href: http://releases.llvm.org/5.0.0/docs

--- a/src/LibLLVM/DIBuilderBindings.h
+++ b/src/LibLLVM/DIBuilderBindings.h
@@ -453,22 +453,24 @@ extern "C" {
                                                  , /*Instruction **/ LLVMValueRef InsertBefore
                                                  );
 
-    // caller must call LLVMDisposeMessage() on the returned string
-    char const* LLVMMetadataAsString( LLVMMetadataRef descriptor );
-
-    void LLVMMDNodeReplaceAllUsesWith( LLVMMetadataRef oldDescriptor, LLVMMetadataRef newDescriptor );
-
     LLVMMetadataRef LLVMDILocation( LLVMContextRef context, unsigned Line, unsigned Column, LLVMMetadataRef scope, LLVMMetadataRef InlinedAt );
     LLVMBool LLVMSubProgramDescribes( LLVMMetadataRef subProgram, LLVMValueRef /*const Function **/F );
     LLVMMetadataRef LLVMDIBuilderCreateNamespace( LLVMDIBuilderRef Dref, LLVMMetadataRef scope, char const* name, LLVMBool exportSymbols );
+    /*DISubProgram*/ LLVMMetadataRef LLVMDILocalScopeGetSubProgram( LLVMMetadataRef /*DILocalScope*/ localScope );
+    unsigned int LLVMDIBasicTypeGetEncoding( LLVMMetadataRef /*DIBasicType*/ basicType );
+
+// TODO: Move these general Metadata manipulators to a distinct module as they aren't really DIBuilder functions
+    void LLVMMDNodeReplaceAllUsesWith( LLVMMetadataRef oldDescriptor, LLVMMetadataRef newDescriptor );
+
     LLVMContextRef LLVMGetNodeContext( LLVMMetadataRef /*MDNode*/ node );
     LLVMMetadataKind LLVMGetMetadataID( LLVMMetadataRef /*Metadata*/ md );
+
+    // caller must call LLVMDisposeMessage() on the returned string
+    char const* LLVMMetadataAsString( LLVMMetadataRef descriptor );
 
     uint32_t LLVMMDNodeGetNumOperands( LLVMMetadataRef /*MDNode*/ node );
     LLVMMDOperandRef LLVMMDNodeGetOperand( LLVMMetadataRef /*MDNode*/ node, uint32_t index );
     LLVMMetadataRef LLVMGetOperandNode( LLVMMDOperandRef operand );
-    /*DISubProgram*/ LLVMMetadataRef LLVMDILocalScopeGetSubProgram( LLVMMetadataRef /*DILocalScope*/ localScope );
-    unsigned int LLVMDIBasicTypeGetEncoding( LLVMMetadataRef /*DIBasicType*/ basicType );
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/Llvm.NET/BitcodeModule.cs
+++ b/src/Llvm.NET/BitcodeModule.cs
@@ -53,7 +53,7 @@ namespace Llvm.NET
             Comdats = new ComdatCollection( this );
         }
 
-        /// <summary>Creates a named module with a root <see cref="DICompileUnit"/> to contain debugging information</summary>
+        /// <summary>Initializes a new instance of the <see cref="BitcodeModule"/> class with a root <see cref="DICompileUnit"/> to contain debugging information</summary>
         /// <param name="context">Context for the module</param>
         /// <param name="moduleId">Module name</param>
         /// <param name="language">Language to store in the debugging information</param>
@@ -184,10 +184,6 @@ namespace Llvm.NET
             set
             {
                 ValidateHandle( );
-                if( Layout_ != null )
-                {
-                    Layout_.Dispose( );
-                }
 
                 Layout_ = value;
                 LLVMSetDataLayout( ModuleHandle, value?.ToString( ) ?? string.Empty );

--- a/src/Llvm.NET/DebugInfo/DICompileUnit.cs
+++ b/src/Llvm.NET/DebugInfo/DICompileUnit.cs
@@ -11,7 +11,7 @@ namespace Llvm.NET.DebugInfo
     public class DICompileUnit
         : DIScope
     {
-        /* non-operand properties
+        /* TODO: non-operand properties
         SourceLanguage SourcLanguage {get;}
         bool IsOptimized {get;}
         uint RunTimeVersion {get;}

--- a/src/Llvm.NET/DebugInfo/DIDerivedType.cs
+++ b/src/Llvm.NET/DebugInfo/DIDerivedType.cs
@@ -15,7 +15,7 @@ namespace Llvm.NET.DebugInfo
     public class DIDerivedType
         : DIType
     {
-        /* non-operand properties
+        /* TODO: non-operand properties
             uint? AddressSpace { get; }
         */
 
@@ -62,7 +62,7 @@ namespace Llvm.NET.DebugInfo
             }
         }
 
-        /// <summary>Creates a new <see cref="DIDerivedType"/> from an <see cref="LLVMMetadataRef"/></summary>
+        /// <summary>Initializes a new instance of the <see cref="DIDerivedType"/> class from an <see cref="LLVMMetadataRef"/></summary>
         /// <param name="handle">Handle to wrap</param>
         internal DIDerivedType( LLVMMetadataRef handle )
             : base( handle )

--- a/src/Llvm.NET/DebugInfo/DIEnumerator.cs
+++ b/src/Llvm.NET/DebugInfo/DIEnumerator.cs
@@ -6,7 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.DebugInfo
 {
-    /// <summary>Debug Information for an enumerated type</summary>
+    /// <summary>Debug Information for a name value par of an enumerated type</summary>
     /// <seealso href="xref:llvm_langref#dienumerator">LLVM DIEnumerator</seealso>
     public class DIEnumerator
         : DINode
@@ -18,7 +18,7 @@ namespace Llvm.NET.DebugInfo
         /// <summary>Gets the Name of the enumerated value</summary>
         public string Name => GetOperand<MDString>( 0 ).ToString( );
 
-        /// <summary>Creates a new <see cref="DIEnumerator"/> from an LLVM handle</summary>
+        /// <summary>Initializes a new instance of the <see cref="DIEnumerator"/> class from an LLVM handle</summary>
         /// <param name="handle">Native LLVM reference for an enumerator</param>
         internal DIEnumerator( LLVMMetadataRef handle )
             : base( handle )

--- a/src/Llvm.NET/DebugInfo/DIExpression.cs
+++ b/src/Llvm.NET/DebugInfo/DIExpression.cs
@@ -11,7 +11,7 @@ namespace Llvm.NET.DebugInfo
     public class DIExpression
         : MDNode
     {
-        /* non-operand properties
+        /* TODO: non-operand properties
         // pretty much all of the LLVM DIExpression implementation.
         // most of the focus is on a sequence of expression operands
         */

--- a/src/Llvm.NET/DebugInfo/DIFile.cs
+++ b/src/Llvm.NET/DebugInfo/DIFile.cs
@@ -11,7 +11,7 @@ namespace Llvm.NET.DebugInfo
     public class DIFile
         : DIScope
     {
-        /* non-operand properties
+        /* TODO: non-operand properties
             ChecksumKind CheckSumKind {get;}
         */
 

--- a/src/Llvm.NET/DebugInfo/DIGlobalVariable.cs
+++ b/src/Llvm.NET/DebugInfo/DIGlobalVariable.cs
@@ -11,7 +11,7 @@ namespace Llvm.NET.DebugInfo
     public class DIGlobalVariable
         : DIVariable
     {
-        /* non-operand properties
+        /* TODO: non-operand properties
             bool IsLocalToUnit {get;}
             bool IsDefinition {get;}
         */

--- a/src/Llvm.NET/DebugInfo/DILexicalBlock.cs
+++ b/src/Llvm.NET/DebugInfo/DILexicalBlock.cs
@@ -11,7 +11,7 @@ namespace Llvm.NET.DebugInfo
     public class DILexicalBlock
         : DILexicalBlockBase
     {
-        /* non-operand properties
+        /* TODO: non-operand properties
         uint Line { get; }
         uint Coulmn { get; }
         */

--- a/src/Llvm.NET/DebugInfo/DILexicalBlockFile.cs
+++ b/src/Llvm.NET/DebugInfo/DILexicalBlockFile.cs
@@ -11,7 +11,7 @@ namespace Llvm.NET.DebugInfo
     public class DILexicalBlockFile
         : DILexicalBlockBase
     {
-        /* non-operand property
+        /* TODO: non-operand property
         unsigned Discriminator { get; }
         */
 

--- a/src/Llvm.NET/DebugInfo/DILocalVariable.cs
+++ b/src/Llvm.NET/DebugInfo/DILocalVariable.cs
@@ -6,12 +6,12 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.DebugInfo
 {
-    /// <summary>see <a href="http://llvm.org/docs/LangRef.html#dilocalvariable"/></summary>
+    /// <summary>Debug information for a local variable</summary>
     /// <seealso href="xref:llvm_langref#dilocalvariable">LLVM DILocalVariable</seealso>
     public class DILocalVariable
         : DIVariable
     {
-        /* non-operand properties
+        /* TODO: non-operand properties
         public DebugInfoFlags => LLVMDILocalVariableGetFlags( MetadataHandle );
         public UInt16 ArgIndex => LLVMDILocalVariableGetArg( MetadataHandle );
         public bool IsParameter => ArgIndex != 0;

--- a/src/Llvm.NET/DebugInfo/DIMacro.cs
+++ b/src/Llvm.NET/DebugInfo/DIMacro.cs
@@ -10,7 +10,7 @@ namespace Llvm.NET.DebugInfo
     public class DIMacro
         : DIMacroNode
     {
-        /* non-operand property
+        /* TODO: non-operand property
         public uint Line { get; }
         */
 

--- a/src/Llvm.NET/DebugInfo/DINamespace.cs
+++ b/src/Llvm.NET/DebugInfo/DINamespace.cs
@@ -11,7 +11,7 @@ namespace Llvm.NET.DebugInfo
     public class DINamespace
         : DIScope
     {
-        /* non-operand properties
+        /* TODO: non-operand properties
         public bool ExportSymbols => LLVMDINamespaceGetExportSymbols( MetadataHandle );
         */
 

--- a/src/Llvm.NET/DebugInfo/DINode.cs
+++ b/src/Llvm.NET/DebugInfo/DINode.cs
@@ -2,7 +2,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // </copyright>
 
+using System.Runtime.InteropServices;
 using Llvm.NET.Native;
+
+using static Llvm.NET.Native.NativeMethods;
 
 namespace Llvm.NET.DebugInfo
 {
@@ -20,7 +23,7 @@ namespace Llvm.NET.DebugInfo
                     return (Tag)ushort.MaxValue;
                 }
 
-                return ( Tag )NativeMethods.LLVMDIDescriptorGetTag( MetadataHandle );
+                return ( Tag )LLVMDIDescriptorGetTag( MetadataHandle );
             }
         }
 
@@ -28,5 +31,8 @@ namespace Llvm.NET.DebugInfo
             : base( handle )
         {
         }
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl)]
+        private static extern LLVMDwarfTag LLVMDIDescriptorGetTag( LLVMMetadataRef descriptor );
     }
 }

--- a/src/Llvm.NET/DebugInfo/DIObjCProperty.cs
+++ b/src/Llvm.NET/DebugInfo/DIObjCProperty.cs
@@ -15,6 +15,7 @@ namespace Llvm.NET.DebugInfo
         public uint Attributes {get;}
         */
 
+        /// <summary>Gets teh Debug information for the file containing this property</summary>
         public DIFile File => GetOperand<DIFile>( 1 );
 
         /// <summary>Gets the name of the property</summary>

--- a/src/Llvm.NET/DebugInfo/DISubProgram.cs
+++ b/src/Llvm.NET/DebugInfo/DISubProgram.cs
@@ -9,7 +9,8 @@ using Ubiquity.ArgValidators;
 
 namespace Llvm.NET.DebugInfo
 {
-    /// <summary>see <a href="http://llvm.org/docs/LangRef.html#disubprogram"/></summary>
+    /// <summary>Debug information for a SubProgram</summary>
+    /// <seealso href="xref:llvm_langref#disubprogram"/>
     [SuppressMessage( "Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", Justification = "It is already correct 8^)" )]
     public class DISubProgram
         : DILocalScope

--- a/src/Llvm.NET/DebugInfo/DISubRange.cs
+++ b/src/Llvm.NET/DebugInfo/DISubRange.cs
@@ -11,7 +11,7 @@ namespace Llvm.NET.DebugInfo
     public class DISubRange
         : DINode
     {
-        /* Non-operand properties need direct API to extract...
+        /* TODO: non-operand properties need direct API to extract...
         public int64 LowerBound {get;}
         public int64 Count {get;}
         */

--- a/src/Llvm.NET/DebugInfo/DISubroutineType.cs
+++ b/src/Llvm.NET/DebugInfo/DISubroutineType.cs
@@ -11,9 +11,8 @@ namespace Llvm.NET.DebugInfo
     public class DISubroutineType
         : DIType
     {
-        /* non-operand properities
+        /* TODO: non-operand properities
             CallingConvention CallingConvention {get;}
-
         */
 
         /// <summary>Gets the types for the sub routine</summary>

--- a/src/Llvm.NET/DebugInfo/DIVariable.cs
+++ b/src/Llvm.NET/DebugInfo/DIVariable.cs
@@ -6,17 +6,22 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.DebugInfo
 {
+    /// <summary>Debug information for a variable</summary>
     public class DIVariable
         : DINode
     {
         /* TODO: UInt32 Line => NativeMethods.LLVMDIVariableGetLine( MetadataHandle ); */
 
+        /// <summary>Gets the Debug information scope for this variable</summary>
         public DIScope Scope => Operands[ 0 ]?.Metadata as DIScope;
 
+        /// <summary>Gets the Debug information name for this variable</summary>
         public string Name => ( Operands[ 1 ]?.Metadata as MDString )?.ToString( ) ?? string.Empty;
 
+        /// <summary>Gets the Debug information file for this variable</summary>
         public DIFile File => Operands[ 2 ]?.Metadata as DIFile;
 
+        /// <summary>Gets the Debug information type for this variable</summary>
         public DIType DIType => Operands[ 3 ]?.Metadata as DIType;
 
         internal DIVariable( LLVMMetadataRef handle )

--- a/src/Llvm.NET/DebugInfo/DebugType.cs
+++ b/src/Llvm.NET/DebugInfo/DebugType.cs
@@ -9,7 +9,7 @@ using Llvm.NET.Types;
 using Llvm.NET.Values;
 using Ubiquity.ArgValidators;
 
-#pragma warning disable SA1649 // File name must match first type ( Justification -  Interface + Impl )
+#pragma warning disable SA1649 // File name must match first type ( Justification -  Interface + internal Impl + public extensions )
 
 namespace Llvm.NET.DebugInfo
 {
@@ -231,6 +231,7 @@ namespace Llvm.NET.DebugInfo
             NativeType = llvmType ?? throw new ArgumentNullException( nameof( llvmType ) );
         }
 
+        // this can't be an auto property as the setter needs Enforce Set Once semantics
         [SuppressMessage( "StyleCop.CSharp.NamingRules"
                         , "SA1310:Field names must not contain underscore"
                         , Justification = "Trailing _ indicates value MUST NOT be written to directly, even internally"
@@ -238,6 +239,7 @@ namespace Llvm.NET.DebugInfo
         ]
         private TNative NativeType_;
 
+        // this can't be an auto property as the setter needs Enforce Set Once semantics
         [SuppressMessage( "StyleCop.CSharp.NamingRules"
                         , "SA1310:Field names must not contain underscore"
                         , Justification = "Trailing _ indicates value MUST NOT be written to directly, even internally"
@@ -248,6 +250,7 @@ namespace Llvm.NET.DebugInfo
         private readonly ExtensiblePropertyContainer PropertyContainer = new ExtensiblePropertyContainer( );
     }
 
+    /// <summary>Utility class to provide mix-in type extensions and support for Debug Types</summary>
     public static class DebugType
     {
         /// <summary>Creates a new <see cref="DebugType"/>instance inferring the generic arguments from the parameters</summary>

--- a/src/Llvm.NET/DebugInfo/DwarfEnumerations.cs
+++ b/src/Llvm.NET/DebugInfo/DwarfEnumerations.cs
@@ -6,8 +6,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Llvm.NET.Native;
 
-// TEMP: disable this until all values are properly doc'd
-#pragma warning disable SA1602 // Enumeration items must be documented
+// TEMP: Disable these until all values are properly doc'd
+#pragma warning disable SA1600, SA1602 // Enumeration items must be documented
 
 namespace Llvm.NET.DebugInfo
 {

--- a/src/Llvm.NET/DebugInfo/GenericDINode.cs
+++ b/src/Llvm.NET/DebugInfo/GenericDINode.cs
@@ -6,8 +6,17 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.DebugInfo
 {
-    public class GenericDINode : DINode
+    /// <summary>Generic tagged DWARF-like Metadata node</summary>
+    public class GenericDINode
+        : DINode
     {
+        /// <summary>Gets the header for this node</summary>
+        /// <remarks>
+        /// The header is a, possibly empty, null separated string
+        /// header that contains arbitrary fields.
+        /// </remarks>
+        public string Header => GetOperand<MDString>( 0 ).ToString( );
+
         internal GenericDINode( LLVMMetadataRef handle )
             : base( handle )
         {

--- a/src/Llvm.NET/DisposableAction.cs
+++ b/src/Llvm.NET/DisposableAction.cs
@@ -15,7 +15,7 @@ namespace Llvm.NET
     internal sealed class DisposableAction
         : IDisposable
     {
-        /// <summary>Constructs a new <see cref="DisposableAction"/></summary>
+        /// <summary>Initializes a new instance of the <see cref="DisposableAction"/> class.</summary>
         /// <param name="onDispose">Action to run when <see cref="Dispose"/>is called.</param>
         public DisposableAction( Action onDispose )
         {

--- a/src/Llvm.NET/Enumerations.cs
+++ b/src/Llvm.NET/Enumerations.cs
@@ -5,8 +5,10 @@
 using System.Diagnostics.CodeAnalysis;
 using Llvm.NET.Native;
 
-// TEMP: disable this until all values are properly doc'd
-#pragma warning disable SA1602 // Enumeration items must be documented
+// TODO: Split these out to appropriate defining class as this has grown to an unwieldy size and makes finding the enums more difficult
+
+// TEMP: Disable these until all values are properly doc'd
+#pragma warning disable SA1600, SA1602 // Enumeration items must be documented
 
 namespace Llvm.NET
 {
@@ -326,6 +328,64 @@ namespace Llvm.NET
         /// <summary>Any value Greater than or equal to this is not valid for Icmp operations</summary>
         BadIcmpPredicate = LastIcmpPredicate + 1
     }
+
+    /*
+    TODO: extensions for predicate:
+      static bool isFPPredicate(Predicate P) {
+        return P >= FIRST_FCMP_PREDICATE && P <= LAST_FCMP_PREDICATE;
+      }
+
+      static bool isIntPredicate(Predicate P) {
+        return P >= FIRST_ICMP_PREDICATE && P <= LAST_ICMP_PREDICATE;
+      }
+
+      /// For example, EQ->EQ, SLE->SGE, ULT->UGT,
+      ///              OEQ->OEQ, ULE->UGE, OLT->OGT, etc.
+      /// @returns the predicate that would be the result of exchanging the two
+      /// operands of the CmpInst instruction without changing the result
+      /// produced.
+      /// @brief Return the predicate as if the operands were swapped
+      static Predicate getSwappedPredicate(Predicate pred);
+
+      /// For example, EQ -> NE, UGT -> ULE, SLT -> SGE,
+      ///              OEQ -> UNE, UGT -> OLE, OLT -> UGE, etc.
+      /// @returns the inverse predicate for predicate provided in \p pred.
+      /// @brief Return the inverse of a given predicate
+      static Predicate getInversePredicate(Predicate pred);
+
+      /// For example, ULT->SLT, ULE->SLE, UGT->SGT, UGE->SGE, SLT->Failed assert
+      /// @returns the signed version of the unsigned predicate pred.
+      /// @brief return the signed version of a predicate
+      static Predicate getSignedPredicate(Predicate pred);
+
+      /// @returns true if the predicate is unsigned, false otherwise.
+      /// @brief Determine if the predicate is an unsigned operation.
+      static bool isUnsigned(Predicate predicate);
+
+      /// @returns true if the predicate is signed, false otherwise.
+      /// @brief Determine if the predicate is an signed operation.
+      static bool isSigned(Predicate predicate);
+
+      /// @brief Determine if the predicate is an ordered operation.
+      static bool isOrdered(Predicate predicate);
+
+      /// @brief Determine if the predicate is an unordered operation.
+      static bool isUnordered(Predicate predicate);
+
+      /// Determine if the predicate is true when comparing a value with itself.
+      static bool isTrueWhenEqual(Predicate predicate);
+
+      /// Determine if the predicate is false when comparing a value with itself.
+      static bool isFalseWhenEqual(Predicate predicate);
+
+      /// Determine if Pred1 implies Pred2 is true when two compares have matching
+      /// operands.
+      static bool isImpliedTrueByMatchingCmp(Predicate Pred1, Predicate Pred2);
+
+      /// Determine if Pred1 implies Pred2 is false when two compares have matching
+      /// operands.
+      static bool isImpliedFalseByMatchingCmp(Predicate Pred1, Predicate Pred2);
+    */
 
     /// <summary>Predicate enumeration for integer comparison</summary>
     public enum IntPredicate

--- a/src/Llvm.NET/ExtensiblePropertyDescriptor.cs
+++ b/src/Llvm.NET/ExtensiblePropertyDescriptor.cs
@@ -20,7 +20,7 @@ namespace Llvm.NET
     /// </remarks>
     public class ExtensiblePropertyDescriptor<T>
     {
-        /// <summary>Creates a new instance of a property descriptor</summary>
+        /// <summary>Initializes a new instance of the <see cref="ExtensiblePropertyDescriptor{T}"/> class.</summary>
         /// <param name="name">Name of the extended property</param>
         public ExtensiblePropertyDescriptor( string name )
         {

--- a/src/Llvm.NET/HandleInterningMap.cs
+++ b/src/Llvm.NET/HandleInterningMap.cs
@@ -10,6 +10,9 @@ using JetBrains.Annotations;
 // interface and common base implementation are a matched pair
 #pragma warning disable SA1649 // File name must match first type name
 
+// These are internal and intellisene can't seem to grasp it isn't supposed to compain about internal types
+#pragma warning disable SA1600 // Elements must be documented
+
 namespace Llvm.NET
 {
     internal interface IHandleInterning<THandle, TMappedType>

--- a/src/Llvm.NET/Instructions/BinaryOperator.cs
+++ b/src/Llvm.NET/Instructions/BinaryOperator.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Base class for a binry operator</summary>
     public class BinaryOperator
         : Instruction
     {

--- a/src/Llvm.NET/Instructions/BitCast.cs
+++ b/src/Llvm.NET/Instructions/BitCast.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>This class represents a no-op cast from one type to another</summary>
     public class BitCast
         : Cast
     {

--- a/src/Llvm.NET/Instructions/Branch.cs
+++ b/src/Llvm.NET/Instructions/Branch.cs
@@ -2,13 +2,43 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // </copyright>
 
+using System.Collections.Generic;
+using JetBrains.Annotations;
 using Llvm.NET.Native;
+using Llvm.NET.Values;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Branch instruction</summary>
     public class Branch
         : Terminator
     {
+        /// <summary>Gets a value indicating whether this branch is unconditional</summary>
+        public bool IsUnconitional => Operands.Count == 1;
+
+        /// <summary>Gets a value indicating whether this branch is conditional</summary>
+        public bool IsConditional => Operands.Count == 3;
+
+        /// <summary>Gets the condition for the branch, if any</summary>
+        [property: CanBeNull]
+        public Value Condition => IsConditional ? GetOperand<Value>( -3 ) : null;
+
+        /// <summary>Gets the succesor block(s) for this branch</summary>
+        public IReadOnlyList<BasicBlock> Successors
+        {
+            get
+            {
+                var retVal = new List<BasicBlock>( );
+                if( IsConditional )
+                {
+                    retVal.Add( GetOperand<BasicBlock>( -2 ) );
+                }
+
+                retVal.Add( GetOperand<BasicBlock>( -1 ) );
+                return retVal;
+            }
+        }
+
         internal Branch( LLVMValueRef valueRef)
             : base( valueRef )
         {

--- a/src/Llvm.NET/Instructions/CallInstruction.cs
+++ b/src/Llvm.NET/Instructions/CallInstruction.cs
@@ -12,31 +12,39 @@ using static Llvm.NET.Native.NativeMethods;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Call instruction</summary>
+    /// <seealso href="xref:llvm_langref#call-instruction"/>
     public class CallInstruction
         : Instruction
         , IAttributeAccessor
     {
+        /// <summary>Gets the target function of the call</summary>
         public Function TargetFunction => FromHandle<Function>( LLVMGetCalledValue( ValueHandle ) );
 
+        /// <summary>Gets or sets a value indicating whether the call is a tail call</summary>
         public bool IsTailCall
         {
             get => LLVMIsTailCall( ValueHandle );
             set => LLVMSetTailCall( ValueHandle, value );
         }
 
+        /// <summary>Gets the attributes for this call site</summary>
         public IAttributeDictionary Attributes { get; }
 
+        /// <inheritdoc/>
         public void AddAttributeAtIndex( FunctionAttributeIndex index, AttributeValue attrib )
         {
             attrib.VerifyValidOn( index, this );
             LLVMAddCallSiteAttribute( ValueHandle, ( LLVMAttributeIndex )index, attrib.NativeAttribute );
         }
 
+        /// <inheritdoc/>
         public uint GetAttributeCountAtIndex( FunctionAttributeIndex index )
         {
             return LLVMGetCallSiteAttributeCount( ValueHandle, ( LLVMAttributeIndex )index );
         }
 
+        /// <inheritdoc/>
         public IEnumerable<AttributeValue> GetAttributesAtIndex( FunctionAttributeIndex index )
         {
             uint count = GetAttributeCountAtIndex( index );
@@ -51,12 +59,14 @@ namespace Llvm.NET.Instructions
                    select AttributeValue.FromHandle( Context, attribRef );
         }
 
+        /// <inheritdoc/>
         public AttributeValue GetAttributeAtIndex( FunctionAttributeIndex index, AttributeKind kind )
         {
             var handle = LLVMGetCallSiteEnumAttribute( ValueHandle, ( LLVMAttributeIndex )index, kind.GetEnumAttributeId( ) );
             return AttributeValue.FromHandle( Context, handle );
         }
 
+        /// <inheritdoc/>
         public AttributeValue GetAttributeAtIndex( FunctionAttributeIndex index, string name )
         {
             if( string.IsNullOrWhiteSpace( name ) )
@@ -68,11 +78,13 @@ namespace Llvm.NET.Instructions
             return AttributeValue.FromHandle( Context, handle );
         }
 
+        /// <inheritdoc/>
         public void RemoveAttributeAtIndex( FunctionAttributeIndex index, AttributeKind kind )
         {
             LLVMRemoveCallSiteEnumAttribute( ValueHandle, ( LLVMAttributeIndex )index, kind.GetEnumAttributeId( ) );
         }
 
+        /// <inheritdoc/>
         public void RemoveAttributeAtIndex( FunctionAttributeIndex index, string name )
         {
             LLVMRemoveCallSiteStringAttribute( ValueHandle, ( LLVMAttributeIndex )index, name, ( uint )name.Length );

--- a/src/Llvm.NET/Instructions/Cast.cs
+++ b/src/Llvm.NET/Instructions/Cast.cs
@@ -3,12 +3,21 @@
 // </copyright>
 
 using Llvm.NET.Native;
+using Llvm.NET.Types;
+using Llvm.NET.Values;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Base class for cast instructions</summary>
     public class Cast
         : UnaryInstruction
     {
+        /// <summary>Gets the source type of the cast</summary>
+        public ITypeRef FromType => GetOperand<Value>(0).NativeType;
+
+        /// <summary>Gets the destination type of the cast</summary>
+        public ITypeRef ToType => NativeType;
+
         internal Cast( LLVMValueRef valueRef )
             : base( valueRef )
         {

--- a/src/Llvm.NET/Instructions/CatchPad.cs
+++ b/src/Llvm.NET/Instructions/CatchPad.cs
@@ -3,12 +3,26 @@
 // </copyright>
 
 using Llvm.NET.Native;
+using Llvm.NET.Values;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Marks a <see cref="BasicBlock"/> as a catch handler</summary>
+    /// <remarks>
+    /// Like the <see cref="LandingPad"/>, instruction this must be the first non-phi instruction
+    /// in the block.
+    /// </remarks>
+    /// <seealso href="xref:llvm_langref#catchpad-instruction">LLVM 'catchpad' Instruction</seealso>
+    /// <seealso href="xref:llvm_releases_docs/ExceptionHandling.html">Exception Handling in LLVM</seealso>
+    /// <seealso href="xref:llvm_releases_docs/ExceptionHandle.html#wineh">Exception Handling using the Windows Runtime</seealso>
     public class CatchPad
         : FuncletPad
     {
+        /// <summary>Gets the <seealso cref="Llvm.NET.Instructions.CatchSwitch"/> for this pad</summary>
+        public CatchSwitch CatchSwitch => GetOperand<CatchSwitch>( -1 );
+
+        /* TODO: Switch {set;} */
+
         internal CatchPad( LLVMValueRef valueRef )
             : base( valueRef )
         {

--- a/src/Llvm.NET/Instructions/CatchReturn.cs
+++ b/src/Llvm.NET/Instructions/CatchReturn.cs
@@ -2,13 +2,26 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // </copyright>
 
+using System.Collections.Generic;
 using Llvm.NET.Native;
+using Llvm.NET.Values;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Catch return instruction</summary>
     public class CatchReturn
         : Terminator
     {
+        /// <summary>Gets the <see cref="CatchPad"/> instruction associated with this <see cref="CatchReturn"/></summary>
+        public CatchPad CatchPad => GetOperand<CatchPad>( 0 );
+
+        /// <summary>Gets the Successor <see cref="BasicBlock"/>s for this instruction</summary>
+        public IReadOnlyList<BasicBlock> Successors => new List<BasicBlock> { GetOperand<BasicBlock>( 1 ) };
+
+        /// <summary>Gets the <see cref="CatchSwitch.ParentPad"/> property from the <see cref="CatchPad.CatchSwitch"/>
+        /// of the <see cref="CatchReturn.CatchPad"/> property</summary>
+        public Value CatchSwitchParentPad => CatchPad.CatchSwitch.ParentPad;
+
         internal CatchReturn( LLVMValueRef valueRef )
             : base( valueRef )
         {

--- a/src/Llvm.NET/Instructions/CatchSwitch.cs
+++ b/src/Llvm.NET/Instructions/CatchSwitch.cs
@@ -3,12 +3,42 @@
 // </copyright>
 
 using Llvm.NET.Native;
+using Llvm.NET.Values;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Describes the set of possible catch handlers that may be executed by an
+    /// <see href="xref:llvm_langref#personalityfn">EH personality routine</see></summary>
+    /// <seealso href="xref:llvm_langref#i-catchswitch">LLVM 'catchswitch' instruction</seealso>
+    /// <seealso href="xref:llvm_releases_docs/ExceptionHandling.html">Exception Handling in LLVM</seealso>
+    /// <seealso href="xref:llvm_releases_docs/ExceptionHandle.html#wineh">Exception Handling using the Windows Runtime</seealso>
     public class CatchSwitch
         : Instruction
     {
+        /// <summary>Gets the Parent pad for this <see cref="CatchSwitch"/></summary>
+        public Value ParentPad => GetOperand<Value>( 0 );
+        /* TODO: ParentPad { set; } */
+
+        /* TODO:
+            BasicBlock UnwindDestination
+            {
+                get => HasUnwindDestination ? GetOperand<BasicBlock>( 1 );
+                set
+                {
+                    if(!HasUnwindDestination)
+                    {
+                        throw new ArgumentException();
+                    }
+                    SetOperand(1, value);
+                }
+            }
+        */
+
+        /* TODO: non-operand properties
+            bool HasUnwindDestination { get; }
+            bool UnwindsToCaller { get; }
+        */
+
         internal CatchSwitch( LLVMValueRef valueRef )
             : base( valueRef )
         {

--- a/src/Llvm.NET/Instructions/CleanupPad.cs
+++ b/src/Llvm.NET/Instructions/CleanupPad.cs
@@ -3,9 +3,14 @@
 // </copyright>
 
 using Llvm.NET.Native;
+using Llvm.NET.Values;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Specifies that a <see cref="BasicBlock"/> is a cleanup block</summary>
+    /// <seealso href="xref:llvm_langref#i-cleanuppad">LLVM 'cleanuppad' instruction</seealso>
+    /// <seealso href="xref:llvm_releases_docs/ExceptionHandling.html">Exception Handling in LLVM</seealso>
+    /// <seealso href="xref:llvm_releases_docs/ExceptionHandle.html#wineh">Exception Handling using the Windows Runtime</seealso>
     public class CleanupPad
         : FuncletPad
     {

--- a/src/Llvm.NET/Instructions/CleanupReturn.cs
+++ b/src/Llvm.NET/Instructions/CleanupReturn.cs
@@ -6,9 +6,36 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction that indicates to the personality function that one <see cref="CleanupPad"/> it transferred control to has ended</summary>
+    /// <seealso href="xref:llvm_langref#cleanupret-instruction">LLVM 'cleanupret' instruction</seealso>
+    /// <seealso href="xref:llvm_releases_docs/ExceptionHandling.html">Exception Handling in LLVM</seealso>
+    /// <seealso href="xref:llvm_releases_docs/ExceptionHandle.html#wineh">Exception Handling using the Windows Runtime</seealso>
     public class CleanupReturn
         : Terminator
     {
+        /// <summary>Gets the <see cref="CleanupPad"/> for this instruction</summary>
+        public CleanupPad CleanupPad => GetOperand<CleanupPad>( 0 );
+        /* TODO: CleanupPad { set; } */
+
+        /* TODO:
+            BasicBlock UnwindDestination
+            {
+                get => HasUnwindDestination ? GetOperand<BasicBlock>( 1 );
+                set
+                {
+                    if(!HasUnwindDestination)
+                    {
+                        throw new ArgumentException();
+                    }
+                    SetOperand(1, value);
+                }
+            }
+        */
+
+        /* TODO: non-operand properties
+            bool HasUnwindDestination { get; }
+            bool UnwindsToCaller { get; }
+        */
         internal CleanupReturn( LLVMValueRef valueRef )
             : base( valueRef )
         {

--- a/src/Llvm.NET/Instructions/Cmp.cs
+++ b/src/Llvm.NET/Instructions/Cmp.cs
@@ -8,9 +8,11 @@ using static Llvm.NET.Native.NativeMethods;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Base class for compare instructions</summary>
     public class Cmp
         : Instruction
     {
+        /// <summary>Gets teh predicate for the comparison</summary>
         public Predicate Predicate
         {
             get
@@ -28,6 +30,8 @@ namespace Llvm.NET.Instructions
                 }
             }
         }
+
+        /* TODO: Predicate {set;} */
 
         internal Cmp( LLVMValueRef valueRef )
             : base( valueRef )

--- a/src/Llvm.NET/Instructions/DebugDeclare.cs
+++ b/src/Llvm.NET/Instructions/DebugDeclare.cs
@@ -3,9 +3,13 @@
 // </copyright>
 
 using Llvm.NET.Native;
+using Llvm.NET.Values;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instrinsic LLVM IR instruction to declare Debug information for a <see cref="Value"/></summary>
+    /// <seealso href="xref:llvm_release_docs/SourceLevelDebugging.html#llvm-dbg-declare">llvm.dbg.declare</seealso>
+    /// <seealso href="xref:llvm_release_docs/SourceLevelDebugging.html">LLVM Source Level Debugging</seealso>
     public class DebugDeclare
         : DebugInfoIntrinsic
     {

--- a/src/Llvm.NET/Instructions/DebugInfoIntrinsic.cs
+++ b/src/Llvm.NET/Instructions/DebugInfoIntrinsic.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Base class for deubg information instrinsic functions in LLVM IR</summary>
     public class DebugInfoIntrinsic
         : Intrinsic
     {

--- a/src/Llvm.NET/Instructions/ExtractElement.cs
+++ b/src/Llvm.NET/Instructions/ExtractElement.cs
@@ -6,6 +6,8 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to extract a single scalar element from a vector at a specified index.</summary>
+    /// <seealso href="xref:llvm_langref#extractelement-instruction">LLVM 'extractelement' Instruction</seealso>
     public class ExtractElement
         : Instruction
     {

--- a/src/Llvm.NET/Instructions/ExtractValue.cs
+++ b/src/Llvm.NET/Instructions/ExtractValue.cs
@@ -6,6 +6,8 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to exctract the value of a member field from an aggregate value</summary>
+    /// <seealso href="xref:llvm_langref#extractvalue-instruction">LLVM 'extractvalue' Instruction</seealso>
     public class ExtractValue
         : UnaryInstruction
     {

--- a/src/Llvm.NET/Instructions/FCmp.cs
+++ b/src/Llvm.NET/Instructions/FCmp.cs
@@ -6,6 +6,8 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to perform comparison of floating point values</summary>
+    /// <seealso href="xref:llvm_langref#fcmp-instruction">LLVM 'fcmp' Instruction</seealso>
     public class FCmp
         : Cmp
     {

--- a/src/Llvm.NET/Instructions/FPExt.cs
+++ b/src/Llvm.NET/Instructions/FPExt.cs
@@ -6,7 +6,10 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
-    public class FPExt : Cast
+    /// <summary>Extends a floating point value to a larger floting point value</summary>
+    /// <seealso href="xref:llvm_langref#fpext-to-instruction">LLVM 'fpext .. to' instruction</seealso>
+    public class FPExt
+        : Cast
     {
         internal FPExt( LLVMValueRef valueRef )
             : base( valueRef )

--- a/src/Llvm.NET/Instructions/FuncletPad.cs
+++ b/src/Llvm.NET/Instructions/FuncletPad.cs
@@ -2,13 +2,26 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // </copyright>
 
+using System.Collections.Generic;
 using Llvm.NET.Native;
+using Llvm.NET.Values;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Funclet pad for exception handling</summary>
     public class FuncletPad
         : Instruction
     {
+        /// <summary>Gets the outer EH-pad this funclet is nested withing</summary>
+        /// <remarks>
+        /// <note type="note">This returns the associated <see cref="CatchSwitch"/> if this
+        /// <see cref="FuncletPad"/> is a <see cref="CleanupPad"/> instruction.</note>
+        /// </remarks>
+        public Value ParentPad => GetOperand<Value>( -1 );
+
+        /// <summary>Gets the argument operands for this <see cref="FuncletPad"/>.</summary>
+        public IReadOnlyList<Value> ArgOperands => new UserOperandList( this, 1 );
+
         internal FuncletPad( LLVMValueRef valueRef )
             : base( valueRef )
         {

--- a/src/Llvm.NET/Instructions/InstructionBuilder.cs
+++ b/src/Llvm.NET/Instructions/InstructionBuilder.cs
@@ -436,8 +436,9 @@ namespace Llvm.NET.Instructions
         /// or an exception is thrown.</para>
         /// </returns>
         /// <remarks>
-        /// For details on GetElementPointer (GEP) see http://llvm.org/docs/GetElementPtr.html. The
-        /// basic gist is that the GEP instruction does not access memory, it only computes a pointer
+        /// For details on GetElementPointer (GEP) see
+        /// <see href="xref:llvm_releases_docs/GetElementPtr.html">The Often Misunderstood GEP Instruction</see>.
+        /// The basic gist is that the GEP instruction does not access memory, it only computes a pointer
         /// offset from a base. A common confusion is around the first index and what it means. For C
         /// and C++ programmers an expression like pFoo->bar seems to only have a single offset or
         /// index. However, that is only syntactic sugar where the compiler implicitly hides the first
@@ -469,8 +470,9 @@ namespace Llvm.NET.Instructions
         /// or an exception is thrown.</para>
         /// </returns>
         /// <remarks>
-        /// For details on GetElementPointer (GEP) see http://llvm.org/docs/GetElementPtr.html. The
-        /// basic gist is that the GEP instruction does not access memory, it only computes a pointer
+        /// For details on GetElementPointer (GEP) see
+        /// <see href="xref:llvm_releases_docs/GetElementPtr.html">The Often Misunderstood GEP Instruction</see>.
+        /// The basic gist is that the GEP instruction does not access memory, it only computes a pointer
         /// offset from a base. A common confusion is around the first index and what it means. For C
         /// and C++ programmers an expression like pFoo->bar seems to only have a single offset or
         /// index. However that is only syntactic sugar where the compiler implicitly hides the first
@@ -492,8 +494,9 @@ namespace Llvm.NET.Instructions
         /// or an exception is thrown.</para>
         /// </returns>
         /// <remarks>
-        /// For details on GetElementPointer (GEP) see http://llvm.org/docs/GetElementPtr.html. The
-        /// basic gist is that the GEP instruction does not access memory, it only computes a pointer
+        /// For details on GetElementPointer (GEP) see
+        /// <see href="xref:llvm_releases_docs/GetElementPtr.html">The Often Misunderstood GEP Instruction</see>.
+        /// The basic gist is that the GEP instruction does not access memory, it only computes a pointer
         /// offset from a base. A common confusion is around the first index and what it means. For C
         /// and C++ programmers an expression like pFoo->bar seems to only have a single offset or
         /// index. However, that is only syntactic sugar where the compiler implicitly hides the first
@@ -525,8 +528,9 @@ namespace Llvm.NET.Instructions
         /// or an exception is thrown.</para>
         /// </returns>
         /// <remarks>
-        /// For details on GetElementPointer (GEP) see http://llvm.org/docs/GetElementPtr.html. The
-        /// basic gist is that the GEP instruction does not access memory, it only computes a pointer
+        /// For details on GetElementPointer (GEP) see
+        /// <see href="xref:llvm_releases_docs/GetElementPtr.html">The Often Misunderstood GEP Instruction</see>.
+        /// The basic gist is that the GEP instruction does not access memory, it only computes a pointer
         /// offset from a base. A common confusion is around the first index and what it means. For C
         /// and C++ programmers an expression like pFoo->bar seems to only have a single offset or
         /// index. However that is only syntactic sugar where the compiler implicitly hides the first

--- a/src/Llvm.NET/JIT/LegacyExecutionEngine.cs
+++ b/src/Llvm.NET/JIT/LegacyExecutionEngine.cs
@@ -131,7 +131,7 @@ namespace Llvm.NET.JIT
                     return null;
                 }
 
-                return DataLayout.FromHandle( handle, isDisposable: false );
+                return DataLayout.FromHandle( handle );
             }
         }
 

--- a/src/Llvm.NET/Metadata/MDNodeOperandList.cs
+++ b/src/Llvm.NET/Metadata/MDNodeOperandList.cs
@@ -4,11 +4,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Llvm.NET.Native;
+using Ubiquity.ArgValidators;
 
 using static Llvm.NET.Native.NativeMethods;
 
 /* TODO: Consider an interface that allows updating elements without growing the list */
+/* TODO: Consider a generic implementation of this as it is mosly a duplicate of the UserOperandList operand list support
+         (core difference is the GetOperand() and GetNumOperands calls)
+*/
 
 namespace Llvm.NET
 {
@@ -20,13 +25,9 @@ namespace Llvm.NET
         {
             get
             {
-                if( index >= Count || index < 0 )
-                {
-                    throw new ArgumentOutOfRangeException( nameof( index ) );
-                }
+                index.ValidateRange( 0, Count - 1, nameof( index ) );
 
-                var handle = LLVMMDNodeGetOperand( OwningNode.MetadataHandle, ( uint )index );
-                return MDOperand.FromHandle( OwningNode, handle );
+                return GetElement( index );
             }
         }
 
@@ -34,32 +35,58 @@ namespace Llvm.NET
         {
             get
             {
-                uint count = LLVMMDNodeGetNumOperands( OwningNode.MetadataHandle );
+                long count = LLVMMDNodeGetNumOperands( OwningNode.MetadataHandle ) - Offset;
                 return ( int )Math.Min( count, int.MaxValue );
             }
         }
 
+        /// <inheritdoc/>
         public IEnumerator<MDOperand> GetEnumerator( )
         {
-            for( uint i = 0; i < Count; ++i )
+            for( int i = 0; i < Count; ++i )
             {
-                LLVMMDOperandRef handle = LLVMMDNodeGetOperand( OwningNode.MetadataHandle, i );
-                if( handle == default )
+                var element = GetElement( i );
+                if( element == null )
                 {
                     yield break;
                 }
 
-                yield return MDOperand.FromHandle( OwningNode, handle );
+                yield return element;
             }
         }
 
+        /// <inheritdoc/>
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator( ) => GetEnumerator( );
 
         internal MDNodeOperandList( MDNode owningNode )
+            : this( owningNode, 0 )
         {
+        }
+
+        internal MDNodeOperandList( MDNode owningNode, int offset )
+        {
+            Offset = offset;
             OwningNode = owningNode;
         }
 
+        private MDOperand GetElement( int index )
+        {
+            var handle = LLVMMDNodeGetOperand( OwningNode.MetadataHandle, checked(( uint )( index + Offset ) ) );
+            if( handle == default )
+            {
+                return null;
+            }
+
+            return MDOperand.FromHandle( OwningNode, handle );
+        }
+
+        private int Offset;
         private readonly MDNode OwningNode;
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl )]
+        private static extern UInt32 LLVMMDNodeGetNumOperands( LLVMMetadataRef /*MDNode*/ node );
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl )]
+        private static extern LLVMMDOperandRef LLVMMDNodeGetOperand( LLVMMetadataRef /*MDNode*/ node, UInt32 index );
     }
 }

--- a/src/Llvm.NET/Native/CustomGenerated.cs
+++ b/src/Llvm.NET/Native/CustomGenerated.cs
@@ -451,119 +451,11 @@ namespace Llvm.NET.Native
         internal static extern void LLVMSetCurrentDebugLocation2( LLVMBuilderRef @Bref, UInt32 @Line, UInt32 @Col, LLVMMetadataRef @Scope, LLVMMetadataRef @InlinedAt );
 
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMDIBuilderRef LLVMNewDIBuilder( LLVMModuleRef @m, [MarshalAs(UnmanagedType.Bool)]bool allowUnresolved );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern void LLVMDIBuilderDestroy( LLVMDIBuilderRef @d );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern void LLVMDIBuilderFinalize( LLVMDIBuilderRef @d );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern void LLVMDIBuilderFinalizeSubProgram( LLVMDIBuilderRef dref, LLVMMetadataRef /*DISubProgram*/ subProgram );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateCompileUnit( LLVMDIBuilderRef @D, UInt32 @Language, [MarshalAs( UnmanagedType.LPStr )] string @File, [MarshalAs( UnmanagedType.LPStr )] string @Dir, [MarshalAs( UnmanagedType.LPStr )] string @Producer, int @Optimized, [MarshalAs( UnmanagedType.LPStr )] string @Flags, UInt32 @RuntimeVersion );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateFile( LLVMDIBuilderRef @D, [MarshalAs( UnmanagedType.LPStr )] string @File, [MarshalAs( UnmanagedType.LPStr )] string @Dir );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateLexicalBlock( LLVMDIBuilderRef @D, LLVMMetadataRef @Scope, LLVMMetadataRef @File, UInt32 @Line, UInt32 @Column );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateLexicalBlockFile( LLVMDIBuilderRef @D, LLVMMetadataRef @Scope, LLVMMetadataRef @File, UInt32 @Discriminator );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateFunction( LLVMDIBuilderRef @D, LLVMMetadataRef @Scope, [MarshalAs( UnmanagedType.LPStr )] string @Name, [MarshalAs( UnmanagedType.LPStr )] string @LinkageName, LLVMMetadataRef @File, UInt32 @Line, LLVMMetadataRef @CompositeType, int @IsLocalToUnit, int @IsDefinition, UInt32 @ScopeLine, UInt32 @Flags, int @IsOptimized, LLVMMetadataRef TParam, LLVMMetadataRef Decl );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateTempFunctionFwdDecl( LLVMDIBuilderRef @D, LLVMMetadataRef @Scope, [MarshalAs( UnmanagedType.LPStr )] string @Name, [MarshalAs( UnmanagedType.LPStr )] string @LinkageName, LLVMMetadataRef @File, UInt32 @Line, LLVMMetadataRef @CompositeType, int @IsLocalToUnit, int @IsDefinition, UInt32 @ScopeLine, UInt32 @Flags, int @IsOptimized, LLVMMetadataRef TParam, LLVMMetadataRef Decl );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateAutoVariable( LLVMDIBuilderRef @D, LLVMMetadataRef @Scope, [MarshalAs( UnmanagedType.LPStr )] string @Name, LLVMMetadataRef @File, UInt32 @Line, LLVMMetadataRef @Ty, int @AlwaysPreserve, UInt32 @Flags );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateParameterVariable( LLVMDIBuilderRef @D, LLVMMetadataRef @Scope, [MarshalAs( UnmanagedType.LPStr )] string @Name, UInt32 @ArgNo, LLVMMetadataRef @File, UInt32 @Line, LLVMMetadataRef @Ty, int @AlwaysPreserve, UInt32 @Flags );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateBasicType( LLVMDIBuilderRef @D, [MarshalAs( UnmanagedType.LPStr )] string @Name, UInt64 @SizeInBits, UInt32 @Encoding );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreatePointerType( LLVMDIBuilderRef @D, LLVMMetadataRef @PointeeType, UInt64 @SizeInBits, UInt32 @AlignInBits, [MarshalAs( UnmanagedType.LPStr )] string @Name );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateQualifiedType( LLVMDIBuilderRef Dref, UInt32 Tag, LLVMMetadataRef BaseType );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateSubroutineType( LLVMDIBuilderRef @D, LLVMMetadataRef @ParameterTypes, UInt32 @Flags );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateStructType( LLVMDIBuilderRef @D, LLVMMetadataRef @Scope, [MarshalAs( UnmanagedType.LPStr )] string @Name, LLVMMetadataRef @File, UInt32 @Line, UInt64 @SizeInBits, UInt32 @AlignInBits, UInt32 @Flags, LLVMMetadataRef @DerivedFrom, LLVMMetadataRef @ElementTypes );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateUnionType( LLVMDIBuilderRef @D, LLVMMetadataRef @Scope, [MarshalAs( UnmanagedType.LPStr )] string @Name, LLVMMetadataRef @File, UInt32 @Line, UInt64 @SizeInBits, UInt32 @AlignInBits, UInt32 @Flags, LLVMMetadataRef @ElementTypes );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateMemberType( LLVMDIBuilderRef @D, LLVMMetadataRef @Scope, [MarshalAs( UnmanagedType.LPStr )] string @Name, LLVMMetadataRef @File, UInt32 @Line, UInt64 @SizeInBits, UInt32 @AlignInBits, UInt64 @OffsetInBits, UInt32 @Flags, LLVMMetadataRef @Ty );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateArrayType( LLVMDIBuilderRef @D, UInt64 @SizeInBits, UInt32 @AlignInBits, LLVMMetadataRef @ElementType, LLVMMetadataRef @Subscripts );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateVectorType( LLVMDIBuilderRef @D, UInt64 @SizeInBits, UInt32 @AlignInBits, LLVMMetadataRef @ElementType, LLVMMetadataRef @Subscripts );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateTypedef( LLVMDIBuilderRef @D, LLVMMetadataRef @Ty, [MarshalAs( UnmanagedType.LPStr )] string @Name, LLVMMetadataRef @File, UInt32 @Line, LLVMMetadataRef @Context );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderGetOrCreateSubrange( LLVMDIBuilderRef @D, Int64 @Lo, Int64 @Count );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderGetOrCreateArray( LLVMDIBuilderRef @D, out LLVMMetadataRef @Data, UInt64 @Length );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderGetOrCreateTypeArray( LLVMDIBuilderRef @D, out LLVMMetadataRef @Data, UInt64 @Length );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateExpression( LLVMDIBuilderRef @Dref, out Int64 @Addr, UInt64 @Length );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMValueRef LLVMDIBuilderInsertDeclareAtEnd( LLVMDIBuilderRef @D, LLVMValueRef @Storage, LLVMMetadataRef @VarInfo, LLVMMetadataRef @Expr, LLVMMetadataRef Location, LLVMBasicBlockRef @Block );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMValueRef LLVMDIBuilderInsertValueAtEnd( LLVMDIBuilderRef @D, LLVMValueRef @Val, UInt64 @Offset, LLVMMetadataRef @VarInfo, LLVMMetadataRef @Expr, LLVMMetadataRef Location, LLVMBasicBlockRef @Block );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateEnumerationType( LLVMDIBuilderRef @D, LLVMMetadataRef @Scope, [MarshalAs( UnmanagedType.LPStr )] string @Name, LLVMMetadataRef @File, UInt32 @LineNumber, UInt64 @SizeInBits, UInt32 @AlignInBits, LLVMMetadataRef @Elements, LLVMMetadataRef @UnderlyingType, [MarshalAs( UnmanagedType.LPStr )]string @UniqueId );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateEnumeratorValue( LLVMDIBuilderRef @D, [MarshalAs( UnmanagedType.LPStr )]string @Name, Int64 @Val );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMDwarfTag LLVMDIDescriptorGetTag( LLVMMetadataRef descriptor );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateGlobalVariableExpression( LLVMDIBuilderRef Dref, LLVMMetadataRef Context, [MarshalAs( UnmanagedType.LPStr )] string Name, [MarshalAs( UnmanagedType.LPStr )] string LinkageName, LLVMMetadataRef File, UInt32 LineNo, LLVMMetadataRef Ty, [MarshalAs( UnmanagedType.Bool )]bool isLocalToUnit, LLVMMetadataRef expression, LLVMMetadataRef Decl, UInt32 AlignInBits );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMValueRef LLVMDIBuilderInsertDeclareBefore( LLVMDIBuilderRef Dref, LLVMValueRef Storage, LLVMMetadataRef VarInfo, LLVMMetadataRef Expr, LLVMMetadataRef Location, LLVMValueRef InsertBefore );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMValueRef LLVMDIBuilderInsertValueBefore( LLVMDIBuilderRef Dref, /*llvm::Value **/LLVMValueRef Val, UInt64 Offset, /*DILocalVariable **/ LLVMMetadataRef VarInfo, /*DIExpression **/ LLVMMetadataRef Expr, /*const DILocation **/ LLVMMetadataRef DL, /*Instruction **/ LLVMValueRef InsertBefore );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(StringMarshaler), MarshalCookie="DisposeMessage")]
         internal static extern string LLVMMetadataAsString( LLVMMetadataRef descriptor );
 
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
         internal static extern void LLVMMDNodeReplaceAllUsesWith( LLVMMetadataRef oldDescriptor, LLVMMetadataRef newDescriptor );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateReplaceableCompositeType( LLVMDIBuilderRef Dref, UInt32 Tag, [MarshalAs( UnmanagedType.LPStr )] string Name, LLVMMetadataRef Scope, LLVMMetadataRef File, UInt32 Line, UInt32 RuntimeLang, UInt64 SizeInBits, UInt64 AlignInBits, UInt32 Flags );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMetadataRef LLVMDIBuilderCreateNamespace( LLVMDIBuilderRef Dref, LLVMMetadataRef scope, [MarshalAs( UnmanagedType.LPStr )] string name, [MarshalAs( UnmanagedType.Bool )]bool exportSymbols );
 
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
         internal static extern LLVMMetadataRef LLVMDILocation( LLVMContextRef context, UInt32 Line, UInt32 Column, LLVMMetadataRef scope, LLVMMetadataRef InlinedAt );
@@ -650,12 +542,6 @@ namespace Llvm.NET.Native
 
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
         internal static extern LLVMMetadataKind LLVMGetMetadataID( LLVMMetadataRef /*Metadata*/ md );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern UInt32 LLVMMDNodeGetNumOperands( LLVMMetadataRef /*MDNode*/ node );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMMDOperandRef LLVMMDNodeGetOperand( LLVMMetadataRef /*MDNode*/ node, UInt32 index );
 
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
         internal static extern LLVMMetadataRef LLVMGetOperandNode( LLVMMDOperandRef operand );

--- a/src/Llvm.NET/Native/Generated.cs
+++ b/src/Llvm.NET/Native/Generated.cs
@@ -1288,17 +1288,8 @@ namespace Llvm.NET.Native
         [DllImport( LibraryPath, EntryPoint = "LLVMGetUsedValue", CallingConvention = CallingConvention.Cdecl )]
         internal static extern LLVMValueRef LLVMGetUsedValue( LLVMUseRef @U );
 
-        [DllImport( LibraryPath, EntryPoint = "LLVMGetOperand", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern LLVMValueRef LLVMGetOperand( LLVMValueRef @Val, uint @Index );
-
         [DllImport( LibraryPath, EntryPoint = "LLVMGetOperandUse", CallingConvention = CallingConvention.Cdecl )]
         internal static extern LLVMUseRef LLVMGetOperandUse( LLVMValueRef @Val, uint @Index );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMSetOperand", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern void LLVMSetOperand( LLVMValueRef @User, uint @Index, LLVMValueRef @Val );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMGetNumOperands", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern int LLVMGetNumOperands( LLVMValueRef @Val );
 
         [DllImport( LibraryPath, EntryPoint = "LLVMConstNull", CallingConvention = CallingConvention.Cdecl )]
         internal static extern LLVMValueRef LLVMConstNull( LLVMTypeRef @Ty );
@@ -1749,11 +1740,6 @@ namespace Llvm.NET.Native
         [DllImport( LibraryPath, EntryPoint = "LLVMSetGC", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
         internal static extern void LLVMSetGC( LLVMValueRef @Fn, [MarshalAs( UnmanagedType.LPStr )] string @Name );
 
-        /* Removed from LLVM-C APIs in LLVM 4.0.0
-        // [DllImport(libraryPath, EntryPoint = "LLVMAddFunctionAttr", CallingConvention = CallingConvention.Cdecl)]
-        // internal static extern void LLVMAddFunctionAttrLLVMValueRef( @Fn, LLVMAttribute @PA);
-        */
-
         [DllImport( LibraryPath, EntryPoint = "LLVMAddAttributeAtIndex", CallingConvention = CallingConvention.Cdecl )]
         internal static extern void LLVMAddAttributeAtIndex( LLVMValueRef @F, LLVMAttributeIndex @Idx, LLVMAttributeRef @A );
 
@@ -1774,53 +1760,6 @@ namespace Llvm.NET.Native
 
         [DllImport( LibraryPath, EntryPoint = "LLVMRemoveStringAttributeAtIndex", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
         internal static extern void LLVMRemoveStringAttributeAtIndex( LLVMValueRef @F, LLVMAttributeIndex @Idx, [MarshalAs( UnmanagedType.LPStr )] string @K, uint @KLen );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMAddTargetDependentFunctionAttr", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
-        internal static extern void LLVMAddTargetDependentFunctionAttr( LLVMValueRef @Fn, [MarshalAs( UnmanagedType.LPStr )] string @A, [MarshalAs( UnmanagedType.LPStr )] string @V );
-
-        /* Removed from LLVM-C APIs in LLVM 4.0.0
-        // [DllImport(libraryPath, EntryPoint = "LLVMGetFunctionAttr", CallingConvention = CallingConvention.Cdecl)]
-        // internal static extern LLVMAttribute LLVMGetFunctionAttrLLVMValueRef( @Fn);
-        */
-
-        /* Removed from LLVM-C APIs in LLVM 4.0.0
-        // [DllImport(libraryPath, EntryPoint = "LLVMRemoveFunctionAttr", CallingConvention = CallingConvention.Cdecl)]
-        // internal static extern void LLVMRemoveFunctionAttrLLVMValueRef( @Fn, LLVMAttribute @PA);
-        */
-        #endregion
-
-        #region Metadata
-        [DllImport( LibraryPath, EntryPoint = "LLVMGetMDKindID", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
-        internal static extern uint LLVMGetMDKindID( [MarshalAs( UnmanagedType.LPStr )] string @Name, uint @SLen );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMMDStringInContext", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
-        internal static extern LLVMValueRef LLVMMDStringInContext( LLVMContextRef @C, [MarshalAs( UnmanagedType.LPStr )] string @Str, uint @SLen );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMMDString", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
-        internal static extern LLVMValueRef LLVMMDString( [MarshalAs( UnmanagedType.LPStr )] string @Str, uint @SLen );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMMDNodeInContext", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern LLVMValueRef LLVMMDNodeInContext( LLVMContextRef @C, out LLVMValueRef @Vals, uint @Count );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMMDNode", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern LLVMValueRef LLVMMDNode( out LLVMValueRef @Vals, uint @Count );
-
-        // Added to LLVM-C API in LLVM 5.0.0
-        [DllImport( LibraryPath, EntryPoint = "LLVMMetadataAsValue", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern LLVMValueRef LLVMMetadataAsValue( LLVMContextRef context, LLVMMetadataRef metadataRef );
-
-        // Added to LLVM-C API in LLVM 5.0.0
-        [DllImport( LibraryPath, EntryPoint = "LLVMValueAsMetadata", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern LLVMMetadataRef LLVMValueAsMetadata( LLVMValueRef Val );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMGetMDString", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern IntPtr LLVMGetMDString( LLVMValueRef @V, out uint @Length );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMGetMDNodeNumOperands", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern uint LLVMGetMDNodeNumOperands( LLVMValueRef @V );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMGetMDNodeOperands", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern void LLVMGetMDNodeOperands( LLVMValueRef @V, out LLVMValueRef @Dest );
         #endregion
 
         #region Basic Blocks
@@ -1932,15 +1871,6 @@ namespace Llvm.NET.Native
 
         [DllImport( LibraryPath, EntryPoint = "LLVMGetInstructionCallConv", CallingConvention = CallingConvention.Cdecl )]
         internal static extern uint LLVMGetInstructionCallConv( LLVMValueRef @Instr );
-
-        /* Removed from LLVM-C APIs in LLVM 4.0.0
-        // [DllImport(libraryPath, EntryPoint = "LLVMAddInstrAttribute", CallingConvention = CallingConvention.Cdecl)]
-        // internal static extern void LLVMAddInstrAttributeLLVMValueRef( @Instr, uint @index, LLVMAttribute @param2);
-
-        // Removed from LLVM-C APIs in LLVM 4.0.0
-        // [DllImport(libraryPath, EntryPoint = "LLVMRemoveInstrAttribute", CallingConvention = CallingConvention.Cdecl)]
-        // internal static extern void LLVMRemoveInstrAttributeLLVMValueRef( @Instr, uint @index, LLVMAttribute @param2);
-        */
 
         [DllImport( LibraryPath, EntryPoint = "LLVMSetInstrParamAlignment", CallingConvention = CallingConvention.Cdecl )]
         internal static extern void LLVMSetInstrParamAlignment( LLVMValueRef @Instr, uint @index, uint @Align );
@@ -2064,9 +1994,6 @@ namespace Llvm.NET.Native
 
         [DllImport( LibraryPath, EntryPoint = "LLVMInsertIntoBuilderWithName", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
         internal static extern void LLVMInsertIntoBuilderWithName( LLVMBuilderRef @Builder, LLVMValueRef @Instr, [MarshalAs( UnmanagedType.LPStr )] string @Name );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMDisposeBuilder", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern void LLVMDisposeBuilder( IntPtr @Builder );
 
         [DllImport( LibraryPath, EntryPoint = "LLVMSetCurrentDebugLocation", CallingConvention = CallingConvention.Cdecl )]
         internal static extern void LLVMSetCurrentDebugLocation( LLVMBuilderRef @Builder, LLVMValueRef @L );
@@ -2716,9 +2643,6 @@ namespace Llvm.NET.Native
         [DllImport( LibraryPath, EntryPoint = "LLVMCreateTargetData", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
         internal static extern LLVMTargetDataRef LLVMCreateTargetData( [MarshalAs( UnmanagedType.LPStr )] string @StringRep );
 
-        [DllImport( LibraryPath, EntryPoint = "LLVMDisposeTargetData", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern void LLVMDisposeTargetData( LLVMTargetDataRef @TD );
-
         [DllImport( LibraryPath, EntryPoint = "LLVMAddTargetLibraryInfo", CallingConvention = CallingConvention.Cdecl )]
         internal static extern void LLVMAddTargetLibraryInfo( LLVMTargetLibraryInfoRef @TLI, LLVMPassManagerRef @PM );
 
@@ -2928,7 +2852,7 @@ namespace Llvm.NET.Native
         */
 
         [DllImport( LibraryPath, EntryPoint = "LLVMGetExecutionEngineTargetData", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern LLVMTargetDataRef LLVMGetExecutionEngineTargetData( LLVMExecutionEngineRef @EE );
+        internal static extern LLVMTargetDataAlias LLVMGetExecutionEngineTargetData( LLVMExecutionEngineRef @EE );
 
         [DllImport( LibraryPath, EntryPoint = "LLVMGetExecutionEngineTargetMachine", CallingConvention = CallingConvention.Cdecl )]
         internal static extern LLVMTargetMachineAlias LLVMGetExecutionEngineTargetMachine( LLVMExecutionEngineRef @EE );

--- a/src/Llvm.NET/Native/Handles/LLVMBuilderRef.cs
+++ b/src/Llvm.NET/Native/Handles/LLVMBuilderRef.cs
@@ -3,7 +3,10 @@
 // </copyright>
 
 using System;
+using System.Runtime.InteropServices;
 using System.Security;
+
+using static Llvm.NET.Native.NativeMethods;
 
 namespace Llvm.NET.Native
 {
@@ -20,7 +23,7 @@ namespace Llvm.NET.Native
         [SecurityCritical]
         protected override bool ReleaseHandle( )
         {
-            NativeMethods.LLVMDisposeBuilder( handle );
+            LLVMDisposeBuilder( handle );
             return true;
         }
 
@@ -28,5 +31,8 @@ namespace Llvm.NET.Native
             : base( true )
         {
         }
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl )]
+        private static extern void LLVMDisposeBuilder( IntPtr @Builder );
     }
 }

--- a/src/Llvm.NET/Native/Handles/LLVMContextRef.cs
+++ b/src/Llvm.NET/Native/Handles/LLVMContextRef.cs
@@ -49,6 +49,7 @@ namespace Llvm.NET.Native
 
     #pragma warning disable SA1402
 
+    // Context alias
     internal class LLVMContextAlias
         : LLVMContextRef
     {

--- a/src/Llvm.NET/Native/Handles/LLVMMemoryBufferRef.cs
+++ b/src/Llvm.NET/Native/Handles/LLVMMemoryBufferRef.cs
@@ -7,7 +7,9 @@ using System.Collections.Generic;
 
 namespace Llvm.NET.Native
 {
-    internal struct LLVMMemoryBufferRef
+     // TODO: replace with LlvmObject impl so that MemoryBuffer can remove the IDisposable interface and function like any other
+     // garbage collected type in .NET
+     internal struct LLVMMemoryBufferRef
         : IEquatable<LLVMMemoryBufferRef>
     {
         public override int GetHashCode( ) => Handle.GetHashCode( );

--- a/src/Llvm.NET/Native/Handles/LLVMTargetDataRef.cs
+++ b/src/Llvm.NET/Native/Handles/LLVMTargetDataRef.cs
@@ -3,30 +3,48 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Security;
+
+using static Llvm.NET.Native.NativeMethods;
 
 namespace Llvm.NET.Native
 {
-    // TODO: CHange this to use LlvmObject as base
-    internal struct LLVMTargetDataRef
-        : IEquatable<LLVMTargetDataRef>
+    [SecurityCritical]
+    internal class LLVMTargetDataRef
+        : LlvmObjectRef
     {
-        public override int GetHashCode( ) => Handle.GetHashCode( );
-
-        public override bool Equals( object obj ) => !( obj is null ) && ( obj is LLVMTargetDataRef r ) && r.Handle == Handle;
-
-        public bool Equals( LLVMTargetDataRef other ) => Handle == other.Handle;
-
-        public static bool operator ==( LLVMTargetDataRef lhs, LLVMTargetDataRef rhs )
-            => EqualityComparer<LLVMTargetDataRef>.Default.Equals( lhs, rhs );
-
-        public static bool operator !=( LLVMTargetDataRef lhs, LLVMTargetDataRef rhs ) => !( lhs == rhs );
-
-        internal LLVMTargetDataRef( IntPtr pointer )
+        public LLVMTargetDataRef( IntPtr handle, bool owner )
+            : base( owner )
         {
-            Handle = pointer;
+            SetHandle( handle );
         }
 
-        private readonly IntPtr Handle;
+        [SecurityCritical]
+        protected override bool ReleaseHandle( )
+        {
+            LLVMDisposeTargetData( handle );
+            return true;
+        }
+
+        private LLVMTargetDataRef( )
+            : base( true )
+        {
+        }
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl )]
+        private static extern void LLVMDisposeTargetData( IntPtr @TargetData );
+    }
+
+#pragma warning disable SA1402
+
+    // TargetData alias
+    internal class LLVMTargetDataAlias
+        : LLVMTargetDataRef
+    {
+        private LLVMTargetDataAlias( )
+            : base( IntPtr.Zero, false )
+        {
+        }
     }
 }

--- a/src/Llvm.NET/Native/Handles/LLVMValueRef.cs
+++ b/src/Llvm.NET/Native/Handles/LLVMValueRef.cs
@@ -24,6 +24,7 @@ namespace Llvm.NET.Native
 
         public static bool operator !=( LLVMValueRef lhs, LLVMValueRef rhs ) => !( lhs == rhs );
 
+        // FIXME: Move this out of here to the Value as it is a layering violation
         public Context Context
         {
             get

--- a/src/Llvm.NET/Native/Handles/ReadMe.md
+++ b/src/Llvm.NET/Native/Handles/ReadMe.md
@@ -1,0 +1,120 @@
+﻿## LLVM-C Handle wrappers
+
+Handles for LLVM are just opaque pointers. THey geenrally come in one of three forms.
+
+  1. Context owned  
+     Where there is always a well known owner that ultimately is responsibile for
+     disposing/releasing the resource.
+  2. Global resources  
+     Where there is no parent child ownership relationship and callers must manualy release the resource
+  3. An unowned alias to a global resource  
+     This occurs when a child of a global resource contains a reference to the parent. In such
+     a case the handle should be considered like an alias and not disposed.
+
+The Handle implementations here follow consistent patterns for implementing each form of handle.
+
+### Contextual handles
+
+These handles are never manually released or disposed, though releasing their containers will make them
+invalid. The general pattern for implementing such handles is as follows:
+
+``` C#
+using System;
+using System.Collections.Generic;
+
+namespace Llvm.NET.Native
+{
+    internal struct LLVMxyzRef
+        : IEquatable<LLVMxyzRef>
+    {
+        public override int GetHashCode( ) => Handle.GetHashCode( );
+
+        public override bool Equals( object obj )
+            => !( obj is null )
+             && ( obj is LLVMxyxRef r )
+             && ( r.Handle == Handle );
+
+        public bool Equals( LLVMxyxRef other )
+            => Handle == other.Handle;
+
+        public static bool operator ==( LLVMxyxRef lhs, LLVMxyxRef rhs )
+            => EqualityComparer<LLVMxyxRef>.Default.Equals( lhs, rhs );
+
+        public static bool operator !=( LLVMxyxRef lhs, LLVMxyxRef rhs )
+            => !( lhs == rhs );
+
+        internal LLVMxyxRef( IntPtr pointer )
+        {
+            Handle = pointer;
+        }
+
+        private readonly IntPtr Handle;
+    }
+}
+```
+
+### Global Handles
+Global handles require the caller to explicity release the resources.
+In Llvm.NET these are managed with the .NET SafeHandles types through
+an Llvm.NET specific derived type LlvmObject. Thus, all resources in
+LLVM requiring explicit release are handled consistently using the
+following basic pattern:
+
+``` C#
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+using static Llvm.NET.Native.NativeMethods;
+
+namespace Llvm.NET.Native
+{
+    [SecurityCritical]
+    internal class LLVMxyzRef
+        : LlvmObjectRef
+    {
+        public LLVMxyzRef( IntPtr handle, bool owner )
+            : base( owner )
+        {
+            SetHandle( handle );
+        }
+
+        [SecurityCritical]
+        protected override bool ReleaseHandle( )
+        {
+            LLVMDisposeXyz( handle );
+            return true;
+        }
+
+        private LLVMxyzRef( )
+            : base( true )
+        {
+        }
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl )]
+        private static extern void LLVMDisposeXyz( IntPtr @xyz );
+    }
+}
+```
+
+### Global Alias handles
+Global alias handles are a specialized form of global handles where they do not
+participate in ownership control/release. These are commonly used when a child
+of a global container exposes a property that references the parent container.
+In such cases the reference retrieved from the child shouldn't be used to destroy
+the parent when no longer used. 
+
+In Llvm.NET this is represented as a distinct handle type derived from the global
+handle as follows:
+
+``` C#
+// xyz alias
+internal class LLVMxyzAlias
+    : LLVMxyzRef
+{
+    private LLVMxyzAlias()
+        : base( IntPtr.Zero, false )
+    {
+    }
+}
+```

--- a/src/Llvm.NET/Native/LLVMVersionInfo.cs
+++ b/src/Llvm.NET/Native/LLVMVersionInfo.cs
@@ -7,6 +7,8 @@ using System.Runtime.InteropServices;
 
 namespace Llvm.NET.Native
 {
+    // Version information pulled from LibLLVM.dll
+    // to use in detection of mismatched components
     internal struct LLVMVersionInfo
     {
         public readonly int Major;

--- a/src/Llvm.NET/Native/StringMarshaler.cs
+++ b/src/Llvm.NET/Native/StringMarshaler.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 
 namespace Llvm.NET.Native
 {
+    // Performs string marshalling for various forms of strings used in LLVM interop
     // use with:
     //   [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(StringMarshaler))]
     //   [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(StringMarshaler), MarshalCookie="DisposeMessage")]

--- a/src/Llvm.NET/Native/readme.md
+++ b/src/Llvm.NET/Native/readme.md
@@ -5,21 +5,35 @@ P/Invoke declarations, enums, structures and handle types for interop with the L
 This is deliberately all marked as internal to keep developers from needing to deal with the
 idiosyncracies of the API in the context of a managed runtime.
 
+Originally this was all one "LLVM" static class with all P/Invoke declarations in a single file
+generated from the LLVM headers. This was helpful to get over the tedious stage of mapping all
+the P/Invoke calls. However, the generated signatures were of low quality. They were functional
+for many cases but string marshalling was generally wrong for any strings provided by LLVM. (see
+below for more information on string marshalling). Thus, they were updated manually and the
+"generated" moniker was misleading at best. In addition many new/extended APIs were added to
+extend the LLVM-C APIs for more full support in language projections. This, created two such
+"generated" files with a plethora of P/Invoke delcarations, which makes maintanance more difficult.
+Thus, the plan is to move the P/Invoke declarations to the classes that use them and eliminate
+the large "generated" files. This, is an ongoing process but, when finished will help keep things
+better organized and more flexible.
+
 ## Handles
-LLVM Handles are value types that wrap a raw pointer owned by the underlying native library and
+LLVM-C Handles are essentially opaque pointers. Llvm.NET represents these as .NET Value types that
 include equality checks and marshaling support. These are typically named LLVMxxxRef where xxx
-is the name of the underlying type the hadle (i.e. LLVMModuleRef )
+is the name of the underlying type of the handle (i.e. LLVMModuleRef ). See the [handles readme](Handles\readme.md)
+for more information. 
 
 ## String Marshalling
 LLVM is written as portable standard C++ and therefore doesn't use string types like BSTR, or
 SAFESTRING that the CLR has built-in support for. Occasionally strings returned are just raw
 pointers to const string data, which would ordinarily require unsafe constructs to work with
-in C# or other .NET languages. Furthermore, the LLVM libraries that do produce strings don't
+in C# or other .NET languages. Furthermore, the LLVM libraries that work with strings don't
 take platform line endings into account (it just uses \n always). To manage these variations
 Llvm.NET uses custom marshalling for strings so that cleanup of allocations is done automatically
-as is converion to proper line endings in a central place.
+as is converion to proper line endings - all in a central place.
 
 ## Enums
 The enums in the native layer match the underlying LLVM form in both value and naming. These,
 deliberately don't conform to the .NET style rules used throughout the rest of the code. Thus,
-they tend to suppress the normal style rules.
+they tend to suppress the normal style rules. Whenever enumerations are required in the public API
+a new .NET style conformant enumeration is created.

--- a/src/Llvm.NET/TargetMachine.cs
+++ b/src/Llvm.NET/TargetMachine.cs
@@ -40,7 +40,7 @@ namespace Llvm.NET
                     return null;
                 }
 
-                return DataLayout.FromHandle( handle, isDisposable: false );
+                return DataLayout.FromHandle( handle );
             }
         }
 

--- a/src/Llvm.NET/Triple.cs
+++ b/src/Llvm.NET/Triple.cs
@@ -35,7 +35,7 @@ namespace Llvm.NET
     public sealed class Triple
         : IEquatable<Triple>
     {
-        /// <summary>Constructs a new <see cref="Triple"/> instance from a triple string</summary>
+        /// <summary>Initializes a new instance of the <see cref="Triple"/> class from a triple string</summary>
         /// <param name="tripleTxt">Triple string to parse</param>
         /// <remarks>
         /// The <paramref name="tripleTxt"/> string is normalized before parsing to allow for

--- a/src/Llvm.NET/Values/AttributeKindExtensions.cs
+++ b/src/Llvm.NET/Values/AttributeKindExtensions.cs
@@ -9,6 +9,9 @@ using Llvm.NET.Instructions;
 using Llvm.NET.Native;
 using Ubiquity.ArgValidators;
 
+// TEMP: Disable these until all values are properly doc'd
+#pragma warning disable SA1600, SA1602 // Enumeration items must be documented
+
 namespace Llvm.NET.Values
 {
     /// <summary>Enumeration for the known LLVM attributes</summary>

--- a/src/Llvm.NET/Values/IAttributeAccessor.cs
+++ b/src/Llvm.NET/Values/IAttributeAccessor.cs
@@ -8,7 +8,7 @@ namespace Llvm.NET.Values
 {
     /// <summary>Interface for raw attribute access</summary>
     /// <remarks>
-    /// As of v3.9x and later, Functions and call sites use distinct LLVM-C API sets for
+    /// As of LLVM v3.9x and later, Functions and call sites use distinct LLVM-C API sets for
     /// manipulating attributes. Fortunately they have consistent signatures so these
     /// are used to abstract the difference via derived types specialized for each case.
     /// Going forward this is the simplest and most direct way to manipulate attributes

--- a/src/Llvm.NET/Values/Use.cs
+++ b/src/Llvm.NET/Values/Use.cs
@@ -18,7 +18,7 @@ namespace Llvm.NET.Values
         /// <summary>Gets the <see cref="Value"/> used</summary>
         public Value Value => Value.FromHandle( NativeMethods.LLVMGetUsedValue( OpaqueHandle ) );
 
-        /// <summary>Creates a new <see cref="Use"/> from  low level LLVM <see cref="LLVMUseRef"/></summary>
+        /// <summary>Initializes a new instance of the <see cref="Use"/> class from low level LLVM <see cref="LLVMUseRef"/></summary>
         /// <param name="useRef">LLVM raw reference</param>
         internal Use( LLVMUseRef useRef )
         {

--- a/src/Llvm.NET/Values/User.cs
+++ b/src/Llvm.NET/Values/User.cs
@@ -2,8 +2,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using Llvm.NET.Native;
+using Ubiquity.ArgValidators;
 
 namespace Llvm.NET.Values
 {
@@ -17,6 +19,14 @@ namespace Llvm.NET.Values
         : Value
     {
         /// <summary>Gets a collection of operands for this <see cref="User"/></summary>
+        /// <remarks>
+        /// This property is intended as a temporary measure and is expected to be removed
+        /// in the future. (e.g. callers should consider this obsolete for the most part
+        /// and only use it when the properties of a <see cref="User"/> or derived type
+        /// do not provide a more appropriate explicit property. When all such types have
+        /// properties to wrap this low level list, this property will be officially
+        /// obsoleted.
+        /// </remarks>
         public IReadOnlyList<Value> Operands => OperandList;
 
         /// <summary>Gets a collection of <see cref="Use"/>s used by this User</summary>
@@ -41,6 +51,18 @@ namespace Llvm.NET.Values
         public T GetOperand<T>( int index )
             where T : Value
         {
+            if( Operands.Count == 0 )
+            {
+                throw new InvalidOperationException( "Cannot index into an empty list" );
+            }
+
+            if( index < 0 )
+            {
+                index = Operands.Count - 1 - index;
+            }
+
+            index.ValidateRange( 0, Operands.Count - 1, nameof( index ) );
+
             return ( T )Operands[ index ];
         }
 

--- a/stylecop.json
+++ b/stylecop.json
@@ -35,7 +35,10 @@
             "headerDecoration": "-----------------------------------------------------------------------",
             "documentExposedElements": true,
             "documentInterfaces": true,
-            "documentInternalElements": false
+            "documentInternalElements": false,
+            "documentPrivateElements": false,
+            "documentPrivateFields": false,
+            "documentationCulture":"en-us"
         }
   }
 }


### PR DESCRIPTION
## Breaking Change
DataLoyout is no longer IDisposable, the underlying handle is based on SafeHandle now and clean up isn't time sensitive.

## Other changes
* Moved P/Invoke declarations for DebugInfoBuilder into DebugInfoBuilder directly. Except dispose, which is in the handle wrapper class to ensure it is the only place the handle is disposed.
* additional doc comments and readme.md information on the internals
* Set TODO: comment marker for all of the commented non-operator properties of DIxyz so they are easier to find and can be implemented in a single PR.
* removed all http://* links in favor of xref:*
* Moved more P/InVoke calls to the components that directly use them
* Fixed resource leak in TargetMachine.TargetData that treated the returned layout as owned by the TargetMachine
   That isn't correct for the underlying LLVM API - each call returns a new layout instance.
