### PR TITLE
Removed use of 'xyz' in LLVM instruction links

### DIFF
--- a/src/Llvm.NET/Instructions/CatchPad.cs
+++ b/src/Llvm.NET/Instructions/CatchPad.cs
@@ -12,7 +12,7 @@ namespace Llvm.NET.Instructions
     /// Like the <see cref="LandingPad"/>, instruction this must be the first non-phi instruction
     /// in the block.
     /// </remarks>
-    /// <seealso href="xref:llvm_langref#catchpad-instruction">LLVM 'catchpad' Instruction</seealso>
+    /// <seealso href="xref:llvm_langref#catchpad-instruction">LLVM catchpad Instruction</seealso>
     /// <seealso href="xref:llvm_exception_handling#exception-handling-in-llvm">Exception Handling in LLVM</seealso>
     /// <seealso href="xref:llvm_exception_handling#wineh">Exception Handling using the Windows Runtime</seealso>
     public class CatchPad

--- a/src/Llvm.NET/Instructions/CatchSwitch.cs
+++ b/src/Llvm.NET/Instructions/CatchSwitch.cs
@@ -9,7 +9,7 @@ namespace Llvm.NET.Instructions
 {
     /// <summary>Describes the set of possible catch handlers that may be executed by an
     /// <see href="xref:llvm_langref#personalityfn">EH personality routine</see></summary>
-    /// <seealso href="xref:llvm_langref#i-catchswitch">LLVM 'catchswitch' instruction</seealso>
+    /// <seealso href="xref:llvm_langref#i-catchswitch">LLVM catchswitch instruction</seealso>
     /// <seealso href="xref:llvm_exception_handling#exception-handling-in-llvm">Exception Handling in LLVM</seealso>
     /// <seealso href="xref:llvm_exception_handling#wineh">Exception Handling using the Windows Runtime</seealso>
     public class CatchSwitch

--- a/src/Llvm.NET/Instructions/CleanupPad.cs
+++ b/src/Llvm.NET/Instructions/CleanupPad.cs
@@ -8,7 +8,7 @@ using Llvm.NET.Values;
 namespace Llvm.NET.Instructions
 {
     /// <summary>Specifies that a <see cref="BasicBlock"/> is a cleanup block</summary>
-    /// <seealso href="xref:llvm_langref#i-cleanuppad">LLVM 'cleanuppad' instruction</seealso>
+    /// <seealso href="xref:llvm_langref#i-cleanuppad">LLVM cleanuppad instruction</seealso>
     /// <seealso href="xref:llvm_exception_handling#exception-handling-in-llvm">Exception Handling in LLVM</seealso>
     /// <seealso href="xref:llvm_exception_handling#wineh">Exception Handling using the Windows Runtime</seealso>
     public class CleanupPad

--- a/src/Llvm.NET/Instructions/CleanupReturn.cs
+++ b/src/Llvm.NET/Instructions/CleanupReturn.cs
@@ -7,7 +7,7 @@ using Llvm.NET.Native;
 namespace Llvm.NET.Instructions
 {
     /// <summary>Instruction that indicates to the personality function that one <see cref="CleanupPad"/> it transferred control to has ended</summary>
-    /// <seealso href="xref:llvm_langref#cleanupret-instruction">LLVM 'cleanupret' instruction</seealso>
+    /// <seealso href="xref:llvm_langref#cleanupret-instruction">LLVM cleanupret instruction</seealso>
     /// <seealso href="xref:llvm_exception_handling#exception-handling-in-llvm">Exception Handling in LLVM</seealso>
     /// <seealso href="xref:llvm_exception_handling#wineh">Exception Handling using the Windows Runtime</seealso>
     public class CleanupReturn

--- a/src/Llvm.NET/Instructions/ExtractElement.cs
+++ b/src/Llvm.NET/Instructions/ExtractElement.cs
@@ -7,7 +7,7 @@ using Llvm.NET.Native;
 namespace Llvm.NET.Instructions
 {
     /// <summary>Instruction to extract a single scalar element from a vector at a specified index.</summary>
-    /// <seealso href="xref:llvm_langref#extractelement-instruction">LLVM 'extractelement' Instruction</seealso>
+    /// <seealso href="xref:llvm_langref#extractelement-instruction">LLVM extractelement Instruction</seealso>
     public class ExtractElement
         : Instruction
     {

--- a/src/Llvm.NET/Instructions/ExtractValue.cs
+++ b/src/Llvm.NET/Instructions/ExtractValue.cs
@@ -7,7 +7,7 @@ using Llvm.NET.Native;
 namespace Llvm.NET.Instructions
 {
     /// <summary>Instruction to exctract the value of a member field from an aggregate value</summary>
-    /// <seealso href="xref:llvm_langref#extractvalue-instruction">LLVM 'extractvalue' Instruction</seealso>
+    /// <seealso href="xref:llvm_langref#extractvalue-instruction">LLVM extractvalue Instruction</seealso>
     public class ExtractValue
         : UnaryInstruction
     {

--- a/src/Llvm.NET/Instructions/FCmp.cs
+++ b/src/Llvm.NET/Instructions/FCmp.cs
@@ -7,7 +7,7 @@ using Llvm.NET.Native;
 namespace Llvm.NET.Instructions
 {
     /// <summary>Instruction to perform comparison of floating point values</summary>
-    /// <seealso href="xref:llvm_langref#fcmp-instruction">LLVM 'fcmp' Instruction</seealso>
+    /// <seealso href="xref:llvm_langref#fcmp-instruction">LLVM fcmp Instruction</seealso>
     public class FCmp
         : Cmp
     {

--- a/src/Llvm.NET/Instructions/FPExt.cs
+++ b/src/Llvm.NET/Instructions/FPExt.cs
@@ -7,7 +7,7 @@ using Llvm.NET.Native;
 namespace Llvm.NET.Instructions
 {
     /// <summary>Extends a floating point value to a larger floting point value</summary>
-    /// <seealso href="xref:llvm_langref#fpext-to-instruction">LLVM 'fpext .. to' instruction</seealso>
+    /// <seealso href="xref:llvm_langref#fpext-to-instruction">LLVM fpext .. to instruction</seealso>
     public class FPExt
         : Cast
     {


### PR DESCRIPTION
docx doesn't render them correctly