### PR TITLE
Updated ModuleFlags accessor

### DIFF
--- a/Build-docs.ps1
+++ b/Build-docs.ps1
@@ -29,7 +29,7 @@ try
         Write-Information "Cleaning output folder from previous builds"
         rd -Recurse -Force -Path $buildPaths.BuildOutputPath
     }
-    
+
     if( Test-Path -PathType Container src\Llvm.NET\obj\xdoc )
     {
         rd -Recurse -Force -Path src\Llvm.NET\obj\xdoc

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -1,5 +1,6 @@
 Param(
-    [string]$Configuration="Release"
+    [string]$Configuration="Release",
+    [switch]$AllowVsPreReleases
 )
 
 . .\buildutils.ps1
@@ -12,7 +13,7 @@ $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
 try
 {
-    $msbuild = Find-MSBuild
+    $msbuild = Find-MSBuild -AllowVsPrereleases:$AllowVsPreReleases
     if( !$msbuild )
     {
         throw "MSBuild not found"

--- a/Samples/CodeGenWithDebugInfo/CortexM3Details.cs
+++ b/Samples/CodeGenWithDebugInfo/CortexM3Details.cs
@@ -19,7 +19,7 @@ namespace TestDebugInfo
 
         public string ShortName => "M3";
 
-        public string Triple => "thumbv7m-none--eabi";
+        public Triple Triple => new Triple("thumbv7m-none--eabi");
 
         public void AddABIAttributesForByValueStructure( Function function, int paramIndex )
         {

--- a/Samples/CodeGenWithDebugInfo/ITargetDependentDetails.cs
+++ b/Samples/CodeGenWithDebugInfo/ITargetDependentDetails.cs
@@ -12,7 +12,7 @@ namespace TestDebugInfo
     {
         string ShortName { get; }
 
-        string Triple { get; }
+        Triple Triple { get; }
 
         string Cpu { get; }
 

--- a/Samples/CodeGenWithDebugInfo/Program.cs
+++ b/Samples/CodeGenWithDebugInfo/Program.cs
@@ -41,9 +41,14 @@ namespace TestDebugInfo
             using( StaticState.InitializeLLVM() )
             {
                 StaticState.RegisterAll( );
-                var target = Target.FromTriple( TargetDetails.Triple );
+                var targetMachine = TargetMachine.FromTriple( TargetDetails.Triple
+                                                            , TargetDetails.Cpu
+                                                            , TargetDetails.Features
+                                                            , CodeGenOpt.Aggressive
+                                                            , Reloc.Default
+                                                            , CodeModel.Small
+                                                            );
                 using( var context = new Context( ) )
-                using( var targetMachine = target.CreateTargetMachine( TargetDetails.Triple, TargetDetails.Cpu, TargetDetails.Features, CodeGenOpt.Aggressive, Reloc.Default, CodeModel.Small ) )
                 using( var module = new BitcodeModule( context, moduleName ) )
                 {
                     module.SourceFileName = Path.GetFileName( srcPath );
@@ -71,13 +76,14 @@ namespace TestDebugInfo
                     var i32Array_0_32 = i32.CreateArrayType( module, 0, 32 );
 
                     // create the LLVM structure type and body with full debug information
-    #pragma warning disable SA1500 // "Warning SA1500  Braces for multi - line statements must not share line" (simple table format)
+                    #pragma warning disable SA1500 // "Warning SA1500  Braces for multi - line statements must not share line" (simple table format)
                     var fooBody = new[ ]
                         { new DebugMemberInfo { File = diFile, Line = 3, Name = "a", DebugType = i32, Index = 0 }
                         , new DebugMemberInfo { File = diFile, Line = 4, Name = "b", DebugType = f32, Index = 1 }
                         , new DebugMemberInfo { File = diFile, Line = 5, Name = "c", DebugType = i32Array_0_32, Index = 2 }
                         };
-    #pragma warning restore
+                    #pragma warning restore
+
                     var fooType = new DebugStructType( module, "struct.foo", cu, "foo", diFile, 1, DebugInfoFlags.None, fooBody );
 
                     // add global variables and constants

--- a/Samples/CodeGenWithDebugInfo/X64Details.cs
+++ b/Samples/CodeGenWithDebugInfo/X64Details.cs
@@ -19,7 +19,7 @@ namespace TestDebugInfo
 
         public string ShortName => "x86";
 
-        public string Triple => "x86_64-pc-windows-msvc18.0.0";
+        public Triple Triple => new Triple( "x86_64-pc-windows-msvc18.0.0" );
 
         public void AddABIAttributesForByValueStructure( Function function, int paramIndex )
         {

--- a/Samples/Kaleidoscope/Chapter7/Chapter7.csproj
+++ b/Samples/Kaleidoscope/Chapter7/Chapter7.csproj
@@ -6,10 +6,6 @@
     <RootNamespace>Kaleidoscope</RootNamespace>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
-    <DebugType>portable</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
 
   <ItemGroup>
       <ProjectReference Include="$(BuildRootDir)src\Llvm.NET\Llvm.NET.csproj">

--- a/Samples/Kaleidoscope/Chapter8/Chapter8.csproj
+++ b/Samples/Kaleidoscope/Chapter8/Chapter8.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Kaleidoscope</RootNamespace>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
       <ProjectReference Include="$(BuildRootDir)src\Llvm.NET\Llvm.NET.csproj">
           <Name>Llvm.NET</Name>

--- a/Samples/Kaleidoscope/Chapter8/Program.cs
+++ b/Samples/Kaleidoscope/Chapter8/Program.cs
@@ -21,7 +21,7 @@ namespace Kaleidoscope
             using( StaticState.InitializeLLVM( ) )
             {
                 StaticState.RegisterNative( );
-                using( var machine = TargetMachine.FromTriple( Triple.HostTriple ) )
+                var machine = new TargetMachine( Triple.HostTriple );
                 using( var generator = new CodeGenerator( LanguageLevel.MutableVariables, machine ) )
                 {
                     RunReplLoop( generator );

--- a/Samples/Kaleidoscope/Chapter9/Chapter9.csproj
+++ b/Samples/Kaleidoscope/Chapter9/Chapter9.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Kaleidoscope</RootNamespace>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
       <ProjectReference Include="$(BuildRootDir)src\Llvm.NET\Llvm.NET.csproj">
           <Name>Llvm.NET</Name>

--- a/Samples/Kaleidoscope/Chapter9/Program.cs
+++ b/Samples/Kaleidoscope/Chapter9/Program.cs
@@ -21,7 +21,7 @@ namespace Kaleidoscope
             using( StaticState.InitializeLLVM( ) )
             {
                 StaticState.RegisterNative( );
-                using( var machine = TargetMachine.FromTriple( Triple.HostTriple ) )
+                var machine = new TargetMachine( Triple.HostTriple );
                 using( var generator = new CodeGenerator( LanguageLevel.MutableVariables, machine ) )
                 {
                     RunReplLoop( generator );

--- a/buildutils.ps1
+++ b/buildutils.ps1
@@ -21,8 +21,13 @@ function Invoke-NuGet
     if( !$NuGetPath )
     {
         $nugetToolsPath = "$PSScriptRoot\Tools\NuGet.exe"
-        if( !(Test-Path $nugetToolsPath))
+        if( !(Test-Path -PathType Leaf $nugetToolsPath))
         {
+            if(!(Test-Path -PathType Container "$PSScriptRoot\Tools" ) )
+            {
+                md "$PSScriptRoot\Tools" | Out-Null 
+            }
+
             # Download it from official NuGet release location
             Write-Verbose "Downloading Nuget.exe to $nugetToolsPath"
             Invoke-WebRequest -UseBasicParsing -Uri https://dist.NuGet.org/win-x86-commandline/latest/NuGet.exe -OutFile $nugetToolsPath
@@ -131,14 +136,14 @@ function Initialize-VCVars($vsInstance = (Find-VSInstance))
     }
 }
 
-function Find-MSBuild
+function Find-MSBuild([switch]$AllowVsPreReleases)
 {
     $foundOnPath = $true
     $msBuildPath = Find-OnPath msbuild.exe -ErrorAction Continue
     if( !$msBuildPath )
     {
         Write-Verbose "MSBuild not found attempting to locate VS installation"
-        $vsInstall = Find-VSInstance
+        $vsInstall = Find-VSInstance -Prerelease:$AllowVsPreReleases
         if( !$vsInstall )
         {
             throw "MSBuild not found on PATH and No instances of VS found to use"

--- a/src/LibLLVM/EXPORTS.DEF
+++ b/src/LibLLVM/EXPORTS.DEF
@@ -36,6 +36,7 @@ LLVMPassRegistryDispose
 LLVMAddModuleFlag
 LLVMAddModuleFlagMetadata
 LLVMModuleGetModuleFlagsMetadata
+LLVMNamedMDNodeGetName
 LLVMNamedMDNodeGetNumOperands
 LLVMNamedMDNodeGetOperand
 LLVMNamedMDNodeGetParentModule

--- a/src/LibLLVM/ModuleBindings.cpp
+++ b/src/LibLLVM/ModuleBindings.cpp
@@ -64,6 +64,11 @@ extern "C"
         return wrap( pModule->getModuleFlagsMetadata( ) );
     }
 
+    char const* LLVMNamedMDNodeGetName( LLVMNamedMDNodeRef namedMDNode )
+    {
+        return unwrap( namedMDNode )->getName().data();
+    }
+
     unsigned LLVMNamedMDNodeGetNumOperands( LLVMNamedMDNodeRef namedMDNode )
     {
         auto pMDNode = unwrap( namedMDNode );

--- a/src/LibLLVM/ModuleBindings.h
+++ b/src/LibLLVM/ModuleBindings.h
@@ -54,6 +54,7 @@ extern "C" {
     LLVMValueRef LLVMGetGlobalAlias( LLVMModuleRef module, char const* name );
 
     LLVMNamedMDNodeRef LLVMModuleGetModuleFlagsMetadata( LLVMModuleRef module );
+    char const* LLVMNamedMDNodeGetName( LLVMNamedMDNodeRef namedMDNode );
     unsigned LLVMNamedMDNodeGetNumOperands( LLVMNamedMDNodeRef namedMDNode );
     /*MDNode*/ LLVMMetadataRef LLVMNamedMDNodeGetOperand( LLVMNamedMDNodeRef namedMDNode, unsigned index );
     LLVMModuleRef LLVMNamedMDNodeGetParentModule( LLVMNamedMDNodeRef namedMDNode );

--- a/src/Llvm.NET/BitcodeModule.cs
+++ b/src/Llvm.NET/BitcodeModule.cs
@@ -882,6 +882,7 @@ namespace Llvm.NET
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl )]
         private static extern LLVMSharedModuleRef LLVMOrcMakeSharedModule( LLVMModuleRef Mod );
 
+        // TODO: Leverage a generic WriteOnce<T> of some sort to enforce intentions in code rather than "by convention"
         [SuppressMessage( "StyleCop.CSharp.NamingRules"
                         , "SA1310:Field names must not contain underscore"
                         , Justification = "Trailing _ indicates it must not be written to directly even directly"

--- a/src/Llvm.NET/BitcodeModule.cs
+++ b/src/Llvm.NET/BitcodeModule.cs
@@ -7,9 +7,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using JetBrains.Annotations;
 using Llvm.NET.DebugInfo;
+using Llvm.NET.Metadata;
 using Llvm.NET.Native;
 using Llvm.NET.Native.Handles;
 using Llvm.NET.Types;
@@ -131,13 +133,16 @@ namespace Llvm.NET
         }
 
         /// <summary>Gets the Metadata for module level flags</summary>
-        public NamedMDNode ModuleFlags
+        public IReadOnlyDictionary<string, ModuleFlag> ModuleFlags
         {
             get
             {
                 ValidateHandle( );
                 var handle = LLVMModuleGetModuleFlagsMetadata( ModuleHandle );
-                return new NamedMDNode( handle );
+                var namedNode = new NamedMDNode( handle );
+                return namedNode.Operands
+                                .Select( n => new ModuleFlag( n ) )
+                                .ToDictionary( f => f.Name );
             }
         }
 

--- a/src/Llvm.NET/DebugInfo/DebugType.cs
+++ b/src/Llvm.NET/DebugInfo/DebugType.cs
@@ -231,6 +231,7 @@ namespace Llvm.NET.DebugInfo
             NativeType = llvmType ?? throw new ArgumentNullException( nameof( llvmType ) );
         }
 
+        // TODO: Leverage a generic WriteOnce<T> of some sort to enforce intentions in code rather than "by convention"
         // this can't be an auto property as the setter needs Enforce Set Once semantics
         [SuppressMessage( "StyleCop.CSharp.NamingRules"
                         , "SA1310:Field names must not contain underscore"
@@ -239,6 +240,7 @@ namespace Llvm.NET.DebugInfo
         ]
         private TNative NativeType_;
 
+        // TODO: Leverage a generic WriteOnce<T> of some sort to enforce intentions in code rather than "by convention"
         // this can't be an auto property as the setter needs Enforce Set Once semantics
         [SuppressMessage( "StyleCop.CSharp.NamingRules"
                         , "SA1310:Field names must not contain underscore"

--- a/src/Llvm.NET/EnumerableExtensions.cs
+++ b/src/Llvm.NET/EnumerableExtensions.cs
@@ -2,7 +2,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // </copyright>
 
-#if NET47
+#if !NET_COREAPP
 using System;
 using System.Collections.Generic;
 

--- a/src/Llvm.NET/HandleInterningMap.cs
+++ b/src/Llvm.NET/HandleInterningMap.cs
@@ -10,9 +10,6 @@ using JetBrains.Annotations;
 // interface and common base implementation are a matched pair
 #pragma warning disable SA1649 // File name must match first type name
 
-// These are internal and intellisene can't seem to grasp it isn't supposed to compain about internal types
-#pragma warning disable SA1600 // Elements must be documented
-
 namespace Llvm.NET
 {
     internal interface IHandleInterning<THandle, TMappedType>

--- a/src/Llvm.NET/Instructions/FPToSI.cs
+++ b/src/Llvm.NET/Instructions/FPToSI.cs
@@ -6,7 +6,10 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
-    public class FPToSI : Cast
+    /// <summary>Instruction to convert a floating point value to a signed integer type</summary>
+    /// <seealso href="xref:llvm_langref#fptosi-to-instruction">LLVM fptosi .. to Instruction</seealso>
+    public class FPToSI
+        : Cast
     {
         internal FPToSI( LLVMValueRef valueRef )
             : base( valueRef )

--- a/src/Llvm.NET/Instructions/FPToUI.cs
+++ b/src/Llvm.NET/Instructions/FPToUI.cs
@@ -6,6 +6,8 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to convert a floating point value to an unsigned integer type</summary>
+    /// <seealso href="xref:llvm_langref#fptoui-to-instruction">LLVM fptoui .. to Instruction</seealso>
     public class FPToUI : Cast
     {
         internal FPToUI( LLVMValueRef valueRef )

--- a/src/Llvm.NET/Instructions/FPTrunc.cs
+++ b/src/Llvm.NET/Instructions/FPTrunc.cs
@@ -6,7 +6,10 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
-    public class FPTrunc : Cast
+    /// <summary>Instruction to truncate a floating point value to another flpating point type</summary>
+    /// <seealso href="xref:llvm_langref#fptruncto-to-instruction">LLVM fptruncto .. to Instruction</seealso>
+    public class FPTrunc
+        : Cast
     {
         internal FPTrunc( LLVMValueRef valueRef )
             : base( valueRef )

--- a/src/Llvm.NET/Instructions/Fence.cs
+++ b/src/Llvm.NET/Instructions/Fence.cs
@@ -6,6 +6,8 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Synchronization instruction to introduce "happens-before" edges between operations</summary>
+    /// <seealso href="xref:llvm_langref#fence-instruction">LLVM fence Instruction</seealso>
     public class Fence
         : Instruction
     {

--- a/src/Llvm.NET/Instructions/GetElementPtr.cs
+++ b/src/Llvm.NET/Instructions/GetElementPtr.cs
@@ -6,6 +6,8 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to compute the address of a sub element of an aggregate data type</summary>
+    /// <seealso href="xref:llvm_langref#getelementptr-instruction">LLVM getelementptr Instruction</seealso>
     public class GetElementPtr
         : Instruction
     {

--- a/src/Llvm.NET/Instructions/IndirectBranch.cs
+++ b/src/Llvm.NET/Instructions/IndirectBranch.cs
@@ -3,9 +3,13 @@
 // </copyright>
 
 using Llvm.NET.Native;
+using Llvm.NET.Values;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to performa an indirect branch to a block within the current function</summary>
+    /// <remarks>The address of the branch must come from a <see cref="BlockAddress"/> constant</remarks>
+    /// <seealso href="xref:llvm_langref#indirectbr-instruction">LLVM indirectbr Instruction</seealso>
     public class IndirectBranch
         : Terminator
     {

--- a/src/Llvm.NET/Instructions/InsertElement.cs
+++ b/src/Llvm.NET/Instructions/InsertElement.cs
@@ -6,6 +6,8 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to insert an element into a vector type</summary>
+    /// <seealso href="xref:llvm_langref#insertelement-instruction">LLVM insertelement Instruction</seealso>
     public class InsertElement
         : Instruction
     {

--- a/src/Llvm.NET/Instructions/InsertValue.cs
+++ b/src/Llvm.NET/Instructions/InsertValue.cs
@@ -6,6 +6,8 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to insert a value into a member field in an aggregate value</summary>
+    /// <seealso href="xref:llvm_langref#insertvalue-instruction">LLVM insertvalue Instruction</seealso>
     public class InsertValue
         : Instruction
     {

--- a/src/Llvm.NET/Instructions/InstructionExtensions.cs
+++ b/src/Llvm.NET/Instructions/InstructionExtensions.cs
@@ -28,8 +28,6 @@ namespace Llvm.NET.Instructions
             return self;
         }
 
-#pragma warning disable IDE0019 // Use Pattern matching - doesn't work for generics (Expected in C#7.X)
-
         /// <summary>Fluent style extension method to set the Volatile property of a <see cref="Load"/> or <see cref="Store"/> instruction</summary>
         /// <typeparam name="T">Type of the instruction (usually implicitly inferred from usage)</typeparam>
         /// <param name="self">Instruction to set the Volatile property for</param>
@@ -41,15 +39,13 @@ namespace Llvm.NET.Instructions
             if( self.IsMemoryAccess )
             {
                 // only load and store instructions have the volatile property
-                var loadInst = self as Load;
-                if( loadInst != null )
+                if( self is Load loadInst )
                 {
                     loadInst.IsVolatile = value;
                 }
                 else
                 {
-                    var storeinst = self as Store;
-                    if( storeinst != null )
+                    if( self is Store storeinst )
                     {
                         storeinst.IsVolatile = value;
                     }
@@ -59,5 +55,4 @@ namespace Llvm.NET.Instructions
             return self;
         }
     }
-#pragma warning restore IDE0019 // Use Pattern matching - doesn't work for generics (Expected in C#7.X)
 }

--- a/src/Llvm.NET/Instructions/IntCmp.cs
+++ b/src/Llvm.NET/Instructions/IntCmp.cs
@@ -6,6 +6,8 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to perform an integer compare</summary>
+    /// <seealso href="xref:llvm_langref#intcmp-instruction">LLVM intcmp Instruction</seealso>
     public class IntCmp
         : Cmp
     {

--- a/src/Llvm.NET/Instructions/IntToPointer.cs
+++ b/src/Llvm.NET/Instructions/IntToPointer.cs
@@ -6,6 +6,8 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to convert an integer to a pointer type</summary>
+    /// <seealso href="xref:llvm_langref#inttoptr-to-instruction">LLVM inttoptr .. to Instruction</seealso>
     public class IntToPointer
         : Cast
     {

--- a/src/Llvm.NET/Instructions/Intrinsic.cs
+++ b/src/Llvm.NET/Instructions/Intrinsic.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>base class for calls to LLVM intrinsic functions</summary>
     public class Intrinsic
         : CallInstruction
     {
@@ -16,9 +17,5 @@ namespace Llvm.NET.Instructions
 
         internal const string DoNothingName = "llvm.donothing";
         internal const string DebugTrapName = "llvm.debugtrap";
-
-        // TODO: move these out of here to follow pattern in MemCpy
-        internal const string MemMoveName = "llvm.memmove.p0i8.p0i8.i32";
-        internal const string MemSetName = "llvm.memset.p0i8.i32";
     }
 }

--- a/src/Llvm.NET/Instructions/Invoke.cs
+++ b/src/Llvm.NET/Instructions/Invoke.cs
@@ -12,14 +12,19 @@ using static Llvm.NET.Native.NativeMethods;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to invoke (call) a function with exception handling</summary>
+    /// <seealso href="xref:llvm_langref#i-invoke">LLVM invoke Instruction</seealso>
     public class Invoke
         : Terminator
         , IAttributeAccessor
     {
+        /// <summary>Gets the target function of the invocation</summary>
         public Function TargetFunction => FromHandle<Function>( LLVMGetCalledValue( ValueHandle ) );
 
+        /// <summary>Gets the attributes for this callsite</summary>
         public IAttributeDictionary Attributes { get; }
 
+        /// <inheritdoc/>
         public void AddAttributeAtIndex( FunctionAttributeIndex index, AttributeValue attrib )
         {
             attrib.VerifyValidOn( index, this );
@@ -27,11 +32,13 @@ namespace Llvm.NET.Instructions
             LLVMAddCallSiteAttribute( ValueHandle, ( LLVMAttributeIndex )index, attrib.NativeAttribute );
         }
 
+        /// <inheritdoc/>
         public uint GetAttributeCountAtIndex( FunctionAttributeIndex index )
         {
             return LLVMGetCallSiteAttributeCount( ValueHandle, ( LLVMAttributeIndex )index );
         }
 
+        /// <inheritdoc/>
         public IEnumerable<AttributeValue> GetAttributesAtIndex( FunctionAttributeIndex index )
         {
             uint count = GetAttributeCountAtIndex( index );
@@ -46,12 +53,14 @@ namespace Llvm.NET.Instructions
                    select AttributeValue.FromHandle( Context, attribRef );
         }
 
+        /// <inheritdoc/>
         public AttributeValue GetAttributeAtIndex( FunctionAttributeIndex index, AttributeKind kind )
         {
             var handle = LLVMGetCallSiteEnumAttribute( ValueHandle, ( LLVMAttributeIndex )index, kind.GetEnumAttributeId( ) );
             return AttributeValue.FromHandle( Context, handle );
         }
 
+        /// <inheritdoc/>
         public AttributeValue GetAttributeAtIndex( FunctionAttributeIndex index, string name )
         {
             if( string.IsNullOrWhiteSpace( name ) )
@@ -63,11 +72,13 @@ namespace Llvm.NET.Instructions
             return AttributeValue.FromHandle( Context, handle );
         }
 
+        /// <inheritdoc/>
         public void RemoveAttributeAtIndex( FunctionAttributeIndex index, AttributeKind kind )
         {
             LLVMRemoveCallSiteEnumAttribute( ValueHandle, ( LLVMAttributeIndex )index, kind.GetEnumAttributeId( ) );
         }
 
+        /// <inheritdoc/>
         public void RemoveAttributeAtIndex( FunctionAttributeIndex index, string name )
         {
             LLVMRemoveCallSiteStringAttribute( ValueHandle, ( LLVMAttributeIndex )index, name, ( uint )name.Length );

--- a/src/Llvm.NET/Instructions/LandingPad.cs
+++ b/src/Llvm.NET/Instructions/LandingPad.cs
@@ -10,9 +10,18 @@ using static Llvm.NET.Native.NativeMethods;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Marks a <see cref="BasicBlock"/> as a catch handler</summary>
+    /// <remarks>
+    /// Like the <see cref="CatchPad"/>, instruction this must be the first non-phi instruction
+    /// in the block.
+    /// </remarks>
+    /// <seealso href="xref:llvm_langref#i-landingpad">LLVM landing Instruction</seealso>
+    /// <seealso href="xref:llvm_exception_handling#exception-handling-in-llvm">Exception Handling in LLVM</seealso>
     public class LandingPad
         : Instruction
     {
+        /// <summary>Adds a clause to the <see cref="LandingPad"/></summary>
+        /// <param name="clause">A catch or filter clause for the LandingPad</param>
         public void AddClause(Value clause)
         {
             if( clause == null )
@@ -23,7 +32,26 @@ namespace Llvm.NET.Instructions
             LLVMAddClause( ValueHandle, clause.ValueHandle);
         }
 
-        public void SetCleanup( bool value ) => LLVMSetCleanup( ValueHandle, value );
+        /*
+        TODO: Implement clauses property
+        This basically requires OperandList.Cast<COnstant>.ToList(), but without the overhead of the
+        duplication and enumeration caused from running ToList(), see notes in UserOperandList
+
+        unsigned LLVMGetNumClauses(LLVMValueRef LandingPad) {
+          return unwrap<LandingPadInst>(LandingPad)->getNumClauses();
+        }
+
+        LLVMValueRef LLVMGetClause(LLVMValueRef LandingPad, unsigned Idx) {
+          return wrap(unwrap<LandingPadInst>(LandingPad)->getClause(Idx));
+        }
+        */
+
+        /// <summary>Gets or sets a value indicating whether this <see cref="LandingPad"/> is a cleanup pad</summary>
+        public bool IsCleanup
+        {
+            get => LLVMIsCleanup( ValueHandle );
+            set => LLVMSetCleanup( ValueHandle, value );
+        }
 
         internal LandingPad( LLVMValueRef valueRef )
             : base( valueRef )

--- a/src/Llvm.NET/Instructions/Load.cs
+++ b/src/Llvm.NET/Instructions/Load.cs
@@ -8,13 +8,16 @@ using static Llvm.NET.Native.NativeMethods;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to read from memory</summary>
+    /// <seealso href="xref:llvm_langref#load-instruction">LLVM load Instruction</seealso>
     public class Load
         : UnaryInstruction
     {
+        /// <summary>Gets or sets a value indicating whether this load is volatile</summary>
         public bool IsVolatile
         {
-            get { return LLVMGetVolatile( ValueHandle ); }
-            set { LLVMSetVolatile( ValueHandle, value ); }
+            get => LLVMGetVolatile( ValueHandle );
+            set => LLVMSetVolatile( ValueHandle, value );
         }
 
         internal Load( LLVMValueRef valueRef )

--- a/src/Llvm.NET/Instructions/MemCpy.cs
+++ b/src/Llvm.NET/Instructions/MemCpy.cs
@@ -8,6 +8,7 @@ using Llvm.NET.Types;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction for the LLVM intrinsic llvm.memcpy instruction</summary>
     public class MemCpy
         : MemIntrinsic
     {

--- a/src/Llvm.NET/Instructions/MemIntrinsic.cs
+++ b/src/Llvm.NET/Instructions/MemIntrinsic.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Base class for memory intrinsic instructions</summary>
     public class MemIntrinsic
         : Intrinsic
     {

--- a/src/Llvm.NET/Instructions/MemMove.cs
+++ b/src/Llvm.NET/Instructions/MemMove.cs
@@ -2,16 +2,27 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // </copyright>
 
+using System.Diagnostics;
 using Llvm.NET.Native;
+using Llvm.NET.Types;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Intrinsic call to target optimized memmove</summary>
     public class MemMove
         : MemIntrinsic
     {
         internal MemMove( LLVMValueRef valueRef )
             : base( valueRef )
         {
+        }
+
+        internal static string GetIntrinsicNameForArgs( IPointerType dst, IPointerType src, ITypeRef len )
+        {
+            Debug.Assert( dst != null && dst.ElementType.IsInteger && dst.ElementType.IntegerBitWidth > 0, "Invalid dst" );
+            Debug.Assert( src != null && src.ElementType.IsInteger && src.ElementType.IntegerBitWidth > 0, "Invalid src" );
+            Debug.Assert( len.IsInteger && len.IntegerBitWidth > 0, "Invalid len" );
+            return $"llvm.memmove.p{dst.AddressSpace}i{dst.ElementType.IntegerBitWidth}.p{src.AddressSpace}i{src.ElementType.IntegerBitWidth}.i{len.IntegerBitWidth}";
         }
     }
 }

--- a/src/Llvm.NET/Instructions/MemSet.cs
+++ b/src/Llvm.NET/Instructions/MemSet.cs
@@ -2,16 +2,26 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // </copyright>
 
+using System.Diagnostics;
 using Llvm.NET.Native;
+using Llvm.NET.Types;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction for the LLVM intrinsic memset function</summary>
     public class MemSet
         : MemIntrinsic
     {
         internal MemSet( LLVMValueRef valueRef )
             : base( valueRef )
         {
+        }
+
+        internal static string GetIntrinsicNameForArgs( IPointerType dst, ITypeRef src, ITypeRef len )
+        {
+            Debug.Assert( dst != null && dst.ElementType.IsInteger && dst.ElementType.IntegerBitWidth > 0, "Invalid dst" );
+            Debug.Assert( len.IsInteger && len.IntegerBitWidth > 0, "Invalid len" );
+            return $"llvm.memset.p{dst.AddressSpace}i{src.IntegerBitWidth}.i{len.IntegerBitWidth}";
         }
     }
 }

--- a/src/Llvm.NET/Instructions/PointerToInt.cs
+++ b/src/Llvm.NET/Instructions/PointerToInt.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to cast a pointer to an integer value</summary>
     public class PointerToInt
         : Cast
     {

--- a/src/Llvm.NET/Instructions/ResumeInstruction.cs
+++ b/src/Llvm.NET/Instructions/ResumeInstruction.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Resume instruction</summary>
     public class ResumeInstruction
         : Terminator
     {

--- a/src/Llvm.NET/Instructions/ReturnInstruction.cs
+++ b/src/Llvm.NET/Instructions/ReturnInstruction.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Return instruction</summary>
     public class ReturnInstruction
         : Terminator
     {

--- a/src/Llvm.NET/Instructions/SIToFP.cs
+++ b/src/Llvm.NET/Instructions/SIToFP.cs
@@ -6,7 +6,9 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
-    public class SIToFP : Cast
+    /// <summary>Instruction for converting a signed integer value into a floating point value</summary>
+    public class SIToFP
+        : Cast
     {
         internal SIToFP( LLVMValueRef valueRef )
             : base( valueRef )

--- a/src/Llvm.NET/Instructions/Select.cs
+++ b/src/Llvm.NET/Instructions/Select.cs
@@ -6,7 +6,9 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
-    public class Select : Instruction
+    /// <summary>Select instruction</summary>
+    public class Select
+        : Instruction
     {
         internal Select( LLVMValueRef valueRef )
             : base( valueRef )

--- a/src/Llvm.NET/Instructions/ShuffleVector.cs
+++ b/src/Llvm.NET/Instructions/ShuffleVector.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to shuffle the elements of a vector</summary>
     public class ShuffleVector
         : Instruction
     {

--- a/src/Llvm.NET/Instructions/SignExtend.cs
+++ b/src/Llvm.NET/Instructions/SignExtend.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Sign extension instruction</summary>
     public class SignExtend
         : Cast
     {

--- a/src/Llvm.NET/Instructions/Store.cs
+++ b/src/Llvm.NET/Instructions/Store.cs
@@ -8,13 +8,15 @@ using static Llvm.NET.Native.NativeMethods;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to store a value to memory</summary>
     public class Store
         : Instruction
     {
+        /// <summary>Gets or sets a value indicating whether the store is volatile</summary>
         public bool IsVolatile
         {
-            get { return LLVMGetVolatile( ValueHandle ); }
-            set { LLVMSetVolatile( ValueHandle, value ); }
+            get => LLVMGetVolatile( ValueHandle );
+            set => LLVMSetVolatile( ValueHandle, value );
         }
 
         internal Store( LLVMValueRef valueRef )

--- a/src/Llvm.NET/Instructions/Switch.cs
+++ b/src/Llvm.NET/Instructions/Switch.cs
@@ -9,11 +9,12 @@ using static Llvm.NET.Native.NativeMethods;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Switch instruction</summary>
     public class Switch
         : Terminator
     {
         /// <summary>Gets the default <see cref="BasicBlock"/> for the switch</summary>
-        public BasicBlock Default => BasicBlock.FromHandle( NativeMethods.LLVMGetSwitchDefaultDest( ValueHandle ) );
+        public BasicBlock Default => BasicBlock.FromHandle( LLVMGetSwitchDefaultDest( ValueHandle ) );
 
         /// <summary>Adds a new case to the <see cref="Switch"/> instruction</summary>
         /// <param name="onVal">Value for the case to match</param>

--- a/src/Llvm.NET/Instructions/Terminator.cs
+++ b/src/Llvm.NET/Instructions/Terminator.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Base class for all terminator instructions</summary>
     public class Terminator
         : Instruction
     {

--- a/src/Llvm.NET/Instructions/Trunc.cs
+++ b/src/Llvm.NET/Instructions/Trunc.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Integer truncate instruction</summary>
     public class Trunc
         : Cast
     {

--- a/src/Llvm.NET/Instructions/UIToFP.cs
+++ b/src/Llvm.NET/Instructions/UIToFP.cs
@@ -6,7 +6,9 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
-    public class UIToFP : Cast
+    /// <summary>Instruction to cast an unsigned integer to a float</summary>
+    public class UIToFP
+        : Cast
     {
         internal UIToFP( LLVMValueRef valueRef )
             : base( valueRef )

--- a/src/Llvm.NET/Instructions/UnaryInstruction.cs
+++ b/src/Llvm.NET/Instructions/UnaryInstruction.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Base class for unary operator instructions</summary>
     public class UnaryInstruction
         : Instruction
     {

--- a/src/Llvm.NET/Instructions/Unreachable.cs
+++ b/src/Llvm.NET/Instructions/Unreachable.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to indicate an unreachable location</summary>
     public class Unreachable
         : Terminator
     {

--- a/src/Llvm.NET/Instructions/UserOp1.cs
+++ b/src/Llvm.NET/Instructions/UserOp1.cs
@@ -6,7 +6,9 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
-    public class UserOp1 : Instruction
+    /// <summary>Custom operator that can be used in LLVM transform passes but should be removed before target instruction selection</summary>
+    public class UserOp1
+        : Instruction
     {
         internal UserOp1( LLVMValueRef valueRef )
             : base( valueRef )

--- a/src/Llvm.NET/Instructions/UserOp2.cs
+++ b/src/Llvm.NET/Instructions/UserOp2.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Custom operator that can be used in LLVM transform passes but should be removed before target instruction selection</summary>
     public class UserOp2 : Instruction
     {
         internal UserOp2( LLVMValueRef valueRef )

--- a/src/Llvm.NET/Instructions/VAArg.cs
+++ b/src/Llvm.NET/Instructions/VAArg.cs
@@ -6,7 +6,9 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
-    public class VaArg : UnaryInstruction
+    /// <summary>Instruction to load an argument of a specified type from a ariadic argument list</summary>
+    public class VaArg
+        : UnaryInstruction
     {
         internal VaArg( LLVMValueRef valueRef )
             : base( valueRef )

--- a/src/Llvm.NET/Instructions/ZeroExtend.cs
+++ b/src/Llvm.NET/Instructions/ZeroExtend.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Instructions
 {
+    /// <summary>Instruction to zero extend a value</summary>
     public class ZeroExtend
         : Cast
     {

--- a/src/Llvm.NET/JIT/OrcJit.cs
+++ b/src/Llvm.NET/JIT/OrcJit.cs
@@ -9,6 +9,9 @@ using Llvm.NET.Native;
 using static Llvm.NET.JIT.OrcJit;
 using static Llvm.NET.Native.NativeMethods;
 
+// siable comment warnings as this is all pretty experimental at this point
+#pragma warning disable SA1600,SA1101
+
 namespace Llvm.NET.JIT
 {
     /// <summary>LLVM On Request Compilation (ORC) Just-In-Time (JIT) Engine</summary>

--- a/src/Llvm.NET/Metadata/LlvmMetadata.cs
+++ b/src/Llvm.NET/Metadata/LlvmMetadata.cs
@@ -15,11 +15,6 @@ namespace Llvm.NET
     /// is changed in the .NET bindings to avoid the conflict.</remarks>
     public abstract class LlvmMetadata
     {
-        /*TODO:
-        MetadataKind Kind { get; }
-
-        */
-
         /// <summary>Replace all uses of this descriptor with another</summary>
         /// <param name="other">New descriptor to replace this one with</param>
         public virtual void ReplaceAllUsesWith( LlvmMetadata other )

--- a/src/Llvm.NET/Metadata/ModuleFlag.cs
+++ b/src/Llvm.NET/Metadata/ModuleFlag.cs
@@ -1,0 +1,62 @@
+﻿// <copyright file="ModuleFlag.cs" company=".NET Foundation">
+// Copyright (c) .NET Foundation. All rights reserved.
+// </copyright>
+
+using System;
+using Llvm.NET.Values;
+using Ubiquity.ArgValidators;
+
+namespace Llvm.NET.Metadata
+{
+    /// <summary>Module Flags Tuple for a module</summary>
+    public class ModuleFlag
+    {
+        /// <summary>Initializes a new instance of the <see cref="ModuleFlag"/> class.</summary>
+        /// <param name="behavior">Behavior for the flag</param>
+        /// <param name="name">Name of the flag</param>
+        /// <param name="metadata">Metadata for the flag</param>
+        public ModuleFlag( ModuleFlagBehavior behavior, string name, LlvmMetadata metadata )
+        {
+            Behavior = behavior;
+            Name = name;
+            Metadata = metadata;
+        }
+
+        /// <summary>Gets the <see cref="ModuleFlagBehavior"/> options for this module flag</summary>
+        public ModuleFlagBehavior Behavior { get; }
+
+        /// <summary>Gets the name of flag</summary>
+        public string Name { get; }
+
+        /// <summary>Gets the Metadata for this flag</summary>
+        public LlvmMetadata Metadata { get; }
+
+        internal ModuleFlag( MDNode node )
+        {
+            node.ValidateNotNull( nameof( node ) );
+            if( node.Operands.Count != 3 )
+            {
+                throw new ArgumentException( "Expected node with 3 operands", nameof( node ) );
+            }
+
+            if( !(node.Operands[0].Metadata is ConstantAsMetadata behavior))
+            {
+                throw new ArgumentException( "Expected ConstantAsMetadata for first operand", nameof( node ) );
+            }
+
+            if( !(behavior.Constant is ConstantInt behaviorConst ) )
+            {
+                throw new ArgumentException( "Expected ConstantInt wrapped in first operand", nameof( node ) );
+            }
+
+            if( !(node.Operands[1].Metadata is MDString nameMd ) )
+            {
+                throw new ArgumentException( "Expected MDString as second operand", nameof( node ) );
+            }
+
+            Behavior = ( ModuleFlagBehavior )( behaviorConst.ZeroExtendedValue );
+            Name = nameMd.ToString( );
+            Metadata = node.Operands[ 2 ].Metadata;
+        }
+    }
+}

--- a/src/Llvm.NET/Metadata/NamedMDNode.cs
+++ b/src/Llvm.NET/Metadata/NamedMDNode.cs
@@ -2,8 +2,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Llvm.NET.Metadata;
 using Llvm.NET.Native;
 
 using static Llvm.NET.Native.NativeMethods;
@@ -11,11 +14,14 @@ using static Llvm.NET.Native.NativeMethods;
 namespace Llvm.NET
 {
     /// <summary>Wraps an LLVM NamedMDNode</summary>
-    /// <remarks>Despite its name a NamedMDNode is not itself an MDNode.</remarks>
+    /// <remarks>Despite its name a NamedMDNode is not itself an MDNode. It is owned directly by a
+    /// a <see cref="BitcodeModule"/> and contains a list of <see cref="MDNode"/> operands.</remarks>
     public class NamedMDNode
     {
+        /// <summary>Gets the name of the node</summary>
+        public string Name => LLVMNamedMDNodeGetName( NativeHandle );
+
         /* TODO:
-        public string Name { get; }
         public void AddOperand(MDNode node) {...}
         */
 
@@ -32,6 +38,19 @@ namespace Llvm.NET
         }
 
         private LLVMNamedMDNodeRef NativeHandle;
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
+        [return: MarshalAs( UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof( StringMarshaler ) )]
+        private static extern string /*char const**/ LLVMNamedMDNodeGetName( LLVMNamedMDNodeRef namedMDNode );
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
+        private static extern UInt32 LLVMNamedMDNodeGetNumOperands( LLVMNamedMDNodeRef namedMDNode );
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
+        private static extern /*MDNode*/ LLVMMetadataRef LLVMNamedMDNodeGetOperand( LLVMNamedMDNodeRef namedMDNode, UInt32 index );
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
+        private static extern LLVMModuleRef LLVMNamedMDNodeGetParentModule( LLVMNamedMDNodeRef namedMDNode );
 
         // internal iterator for Metadata operands
         private class OperandIterator

--- a/src/Llvm.NET/Native/CustomGenerated.cs
+++ b/src/Llvm.NET/Native/CustomGenerated.cs
@@ -408,15 +408,6 @@ namespace Llvm.NET.Native
         internal static extern LLVMNamedMDNodeRef LLVMModuleGetModuleFlagsMetadata( LLVMModuleRef module );
 
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern UInt32 LLVMNamedMDNodeGetNumOperands( LLVMNamedMDNodeRef namedMDNode );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern /*MDNode*/ LLVMMetadataRef LLVMNamedMDNodeGetOperand( LLVMNamedMDNodeRef namedMDNode, UInt32 index );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMModuleRef LLVMNamedMDNodeGetParentModule( LLVMNamedMDNodeRef namedMDNode );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
         internal static extern LLVMValueRef LLVMGetOrInsertFunction( LLVMModuleRef module, [MarshalAs( UnmanagedType.LPStr )] string @name, LLVMTypeRef functionType );
 
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]

--- a/src/Llvm.NET/Native/StringMarshaler.cs
+++ b/src/Llvm.NET/Native/StringMarshaler.cs
@@ -11,8 +11,13 @@ namespace Llvm.NET.Native
 {
     // Performs string marshalling for various forms of strings used in LLVM interop
     // use with:
+    //   // const char* owned by native LLVM, and never disposed by managed callers (just copy to managed string)
     //   [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(StringMarshaler))]
+    //
+    //   // const char* allocated in native LLVM, released by managed caller via LLVMDisposeMessage
     //   [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(StringMarshaler), MarshalCookie="DisposeMessage")]
+    //
+    //   //  const char* allocated in native LLVM, released by managed caller via LLVMDisposeMangledSymbol
     //   [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(StringMarshaler), MarshalCookie="MangledSymbol")]
     [SuppressMessage( "Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Instantiated via CustomMarshaling" )]
     internal class StringMarshaler

--- a/src/Llvm.NET/Target.cs
+++ b/src/Llvm.NET/Target.cs
@@ -37,6 +37,26 @@ namespace Llvm.NET
         /// <param name="relocationMode">Relocation mode for generated code</param>
         /// <param name="codeModel"><see cref="CodeModel"/> to use for generated code</param>
         /// <returns><see cref="TargetMachine"/> based on the specified parameters</returns>
+        public TargetMachine CreateTargetMachine( Triple triple
+                                                , string cpu = null
+                                                , string features = null
+                                                , CodeGenOpt optLevel = CodeGenOpt.Default
+                                                , Reloc relocationMode = Reloc.Default
+                                                , CodeModel codeModel = CodeModel.Default
+                                                )
+        {
+            LLVMTargetMachineRef targetMachineHandle = InternalCreateTargetMachine( this, triple, cpu, features, optLevel, relocationMode, codeModel );
+            return new TargetMachine( targetMachineHandle );
+        }
+
+        /// <summary>Creates a <see cref="TargetMachine"/> for the target and specified parameters</summary>
+        /// <param name="triple">Target triple for this machine (e.g. -mtriple)</param>
+        /// <param name="cpu">CPU for this machine (e.g. -mcpu)</param>
+        /// <param name="features">Features for this machine (e.g. -mattr...)</param>
+        /// <param name="optLevel">Optimization level</param>
+        /// <param name="relocationMode">Relocation mode for generated code</param>
+        /// <param name="codeModel"><see cref="CodeModel"/> to use for generated code</param>
+        /// <returns><see cref="TargetMachine"/> based on the specified parameters</returns>
         public TargetMachine CreateTargetMachine( string triple
                                                 , string cpu = null
                                                 , string features = null
@@ -45,19 +65,7 @@ namespace Llvm.NET
                                                 , CodeModel codeModel = CodeModel.Default
                                                 )
         {
-            triple.ValidateNotNullOrWhiteSpace( nameof( triple ) );
-            optLevel.ValidateDefined( nameof( optLevel ) );
-            relocationMode.ValidateDefined( nameof( relocationMode ) );
-            codeModel.ValidateDefined( nameof( codeModel ) );
-
-            var targetMachineHandle = LLVMCreateTargetMachine( TargetHandle
-                                                             , triple
-                                                             , cpu ?? string.Empty
-                                                             , features ?? string.Empty
-                                                             , ( LLVMCodeGenOptLevel )optLevel
-                                                             , ( LLVMRelocMode )relocationMode
-                                                             , ( LLVMCodeModel )codeModel
-                                                             );
+            LLVMTargetMachineRef targetMachineHandle = InternalCreateTargetMachine( this, triple, cpu, features, optLevel, relocationMode, codeModel );
             return new TargetMachine( targetMachineHandle );
         }
 
@@ -103,6 +111,24 @@ namespace Llvm.NET
         }
 
         internal LLVMTargetRef TargetHandle { get; }
+
+        internal static LLVMTargetMachineRef InternalCreateTargetMachine( Target target, string triple, string cpu, string features, CodeGenOpt optLevel, Reloc relocationMode, CodeModel codeModel )
+        {
+            triple.ValidateNotNullOrWhiteSpace( nameof( triple ) );
+            optLevel.ValidateDefined( nameof( optLevel ) );
+            relocationMode.ValidateDefined( nameof( relocationMode ) );
+            codeModel.ValidateDefined( nameof( codeModel ) );
+
+            var targetMachineHandle = LLVMCreateTargetMachine( target.TargetHandle
+                                                             , triple
+                                                             , cpu ?? string.Empty
+                                                             , features ?? string.Empty
+                                                             , ( LLVMCodeGenOptLevel )optLevel
+                                                             , ( LLVMRelocMode )relocationMode
+                                                             , ( LLVMCodeModel )codeModel
+                                                             );
+            return targetMachineHandle;
+        }
 
         internal static Target FromHandle( LLVMTargetRef targetHandle )
         {

--- a/src/Llvm.NET/TargetMachine.cs
+++ b/src/Llvm.NET/TargetMachine.cs
@@ -13,9 +13,24 @@ namespace Llvm.NET
 {
     /// <summary>Target specific code generation information</summary>
     public sealed class TargetMachine
-        : DisposableObject
     {
-        public override bool IsDisposed => ( TargetMachineHandle is null ) || TargetMachineHandle.IsClosed || TargetMachineHandle.IsInvalid;
+        /// <summary>Initializes a new instance of the <see cref="TargetMachine"/> class.</summary>
+        /// <param name="triple">Triple for the target machine</param>
+        /// <param name="cpu">CPU options for the machine</param>
+        /// <param name="features">CPU features for the machine</param>
+        /// <param name="optLevel">General optimization level for machine code generation</param>
+        /// <param name="relocationMode">Relocation mode for machine code generation</param>
+        /// <param name="codeModel">Code model for machine code generation</param>
+        public TargetMachine( Triple triple
+                            , string cpu = null
+                            , string features = null
+                            , CodeGenOpt optLevel = CodeGenOpt.Default
+                            , Reloc relocationMode = Reloc.Default
+                            , CodeModel codeModel = CodeModel.Default
+                            )
+            : this( Target.InternalCreateTargetMachine( Target.FromTriple(triple), triple, cpu, features, optLevel, relocationMode, codeModel ) )
+        {
+        }
 
         /// <summary>Gets the target that owns this <see cref="TargetMachine"/></summary>
         public Target Target => Target.FromHandle( LLVMGetTargetMachineTarget( TargetMachineHandle ) );
@@ -131,14 +146,6 @@ namespace Llvm.NET
             TargetMachineHandle = targetMachineHandle;
         }
 
-        internal LLVMTargetMachineRef TargetMachineHandle { get; private set; }
-
-        protected override void InternalDispose( bool disposing )
-        {
-            if( disposing )
-            {
-                TargetMachineHandle.Dispose( );
-            }
-        }
+        internal LLVMTargetMachineRef TargetMachineHandle { get; }
     }
 }

--- a/src/Llvm.NET/Transforms/PassManager.cs
+++ b/src/Llvm.NET/Transforms/PassManager.cs
@@ -2,37 +2,18 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // </copyright>
 
-using System;
 using Llvm.NET.Native;
 
 namespace Llvm.NET.Transforms
 {
     /// <summary>Common base class for pass managers</summary>
     public class PassManager
-        : IDisposable
     {
-        /// <inheritdoc/>
-        public void Dispose( )
-        {
-            Dispose( true );
-        }
-
         internal PassManager( LLVMPassManagerRef handle )
         {
             Handle = handle;
         }
 
         internal LLVMPassManagerRef Handle { get; }
-
-        protected virtual void Dispose( bool disposing )
-        {
-            if( disposing )
-            {
-                if( !Handle.IsClosed )
-                {
-                    Handle.Close( );
-                }
-            }
-        }
     }
 }

--- a/src/Llvm.NET/Types/ITypeRef.cs
+++ b/src/Llvm.NET/Types/ITypeRef.cs
@@ -79,9 +79,11 @@ namespace Llvm.NET.Types
         IPointerType CreatePointerType( uint addressSpace );
     }
 
+    /// <summary>Internal interface for getting access to the raw type handle internally</summary>
+    /// <remarks>This is usually implemented as an explicit interface implementation so that it isn't exposed publicly</remarks>
     internal interface ITypeHandleOwner
     {
-        // Gets the LibLLVM handle for the type
+        /// <summary>Gets the LibLLVM handle for the type</summary>
         LLVMTypeRef TypeHandle { get; }
     }
 

--- a/src/Llvm.NET/Values/AttributeKindExtensions.cs
+++ b/src/Llvm.NET/Values/AttributeKindExtensions.cs
@@ -17,7 +17,7 @@ namespace Llvm.NET.Values
     /// <summary>Enumeration for the known LLVM attributes</summary>
     /// <remarks>
     /// <para>It is important to note that the integer values of this enum do NOT necessarily
-    /// correlate to the attribute IDs. LLVM has moved away from using an enum Flags model
+    /// correlate to the LLVM attribute IDs. LLVM has moved away from using an enum Flags model
     /// as the number of attributes reached the limit of available bits. Thus, the enum was
     /// dropped. Instead, strings are used to identify attributes. However, for maximum
     /// compatibility and ease of use for this library the enum is retained and the provided

--- a/src/Llvm.NET/Values/ConstantAggregateZero.cs
+++ b/src/Llvm.NET/Values/ConstantAggregateZero.cs
@@ -6,6 +6,7 @@ using Llvm.NET.Native;
 
 namespace Llvm.NET.Values
 {
+    /// <summary>Constant aggregate of value 0</summary>
     public class ConstantAggregateZero
         : ConstantData
     {

--- a/src/Llvm.NET/Values/ConstantInt.cs
+++ b/src/Llvm.NET/Values/ConstantInt.cs
@@ -5,6 +5,8 @@
 using System;
 using Llvm.NET.Native;
 
+using static Llvm.NET.Native.NativeMethods;
+
 namespace Llvm.NET.Values
 {
     /// <summary>Represents an arbitrary bit width integer constant in LLVM</summary>
@@ -16,11 +18,18 @@ namespace Llvm.NET.Values
     public sealed class ConstantInt
         : ConstantData
     {
+        /// <summary>Gets the number of bits in this integer constant</summary>
+        public uint BitWidth => NativeType.IntegerBitWidth;
+
         /// <summary>Gets the value of the constant zero extended to a 64 bit value</summary>
-        public UInt64 ZeroExtendedValue => NativeMethods.LLVMConstIntGetZExtValue( ValueHandle );
+        /// <exception cref="InvalidOperationException">If <see cref="BitWidth"/> is greater than 64 bits</exception>
+        public UInt64 ZeroExtendedValue
+            => BitWidth <= 64 ? LLVMConstIntGetZExtValue( ValueHandle ) : throw new InvalidOperationException("Arbitrary precision integer exceeds size of System.UInt64 integer");
 
         /// <summary>Gets the value of the constant sign extended to a 64 bit value</summary>
-        public Int64 SignExtendedValue => NativeMethods.LLVMConstIntGetSExtValue( ValueHandle );
+        /// <exception cref="InvalidOperationException">If <see cref="BitWidth"/> is greater than 64 bits</exception>
+        public Int64 SignExtendedValue
+            => BitWidth <= 64 ? LLVMConstIntGetSExtValue( ValueHandle ) : throw new InvalidOperationException( "Arbitrary precision integer exceeds size of System.Int64 integer" );
 
         internal ConstantInt( LLVMValueRef valueRef )
             : base( valueRef )

--- a/src/Llvm.NET/Values/Function.cs
+++ b/src/Llvm.NET/Values/Function.cs
@@ -99,6 +99,7 @@ namespace Llvm.NET.Values
             set => LLVMSetGC( ValueHandle, value );
         }
 
+        /// <summary>Gets the attributes for this function</summary>
         public IAttributeDictionary Attributes { get; }
 
         /// <summary>Verifies the function is valid and all blocks properly terminated</summary>

--- a/src/Llvm.NET/Values/UserOperandList.cs
+++ b/src/Llvm.NET/Values/UserOperandList.cs
@@ -12,7 +12,8 @@ using static Llvm.NET.Native.NativeMethods;
 
 /* TODO: Consider an interface that allows updating elements without growing the list */
 /* TODO: Consider a generic implementation of this as it is mosly a duplicate of the Metadata operand list support
-         (core difference is the GetOperand() and GetNumOperands calls)
+         (core difference is the GetOperand() and GetNumOperands calls). This would also be re-usable for
+         the clauses of a landingpad instruction and other type specific operand variants.
 */
 
 namespace Llvm.NET.Values

--- a/src/Llvm.NETTests/ContextTests.cs
+++ b/src/Llvm.NETTests/ContextTests.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 // warning SA1500: Braces for multi-line statements must not share line
 #pragma warning disable SA1500
+
 namespace Llvm.NET.Tests
 {
     [TestClass]
@@ -141,8 +142,8 @@ namespace Llvm.NET.Tests
         [TestMethod]
         public void CreateFunctionTypeTest( )
         {
+            var targetMachine = TargetTests.GetTargetMachine( );
             using( var context = new Context( ) )
-            using( var targetMachine = TargetTests.GetTargetMachine( ) )
             {
                 var module = new BitcodeModule( context, "test.bc", SourceLanguage.CSharp, "test.cs", "unittests" );
                 Assert.IsNotNull( module );
@@ -191,8 +192,8 @@ namespace Llvm.NET.Tests
         [TestMethod]
         public void VerifyCreateFunctionTypeWithSameSigIsSameInstanceTest( )
         {
+            var targetMachine = TargetTests.GetTargetMachine( );
             using( var context = new Context( ) )
-            using( var targetMachine = TargetTests.GetTargetMachine( ) )
             {
                 var module = new BitcodeModule( context, "test.bc", SourceLanguage.CSharp, "test.cs", "unittests" );
                 Assert.IsNotNull( module );

--- a/src/Llvm.NETTests/DebugInfo/DebugUnionTypeTests.cs
+++ b/src/Llvm.NETTests/DebugInfo/DebugUnionTypeTests.cs
@@ -4,7 +4,9 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+// warning SA1500: Braces for multi-line statements must not share line
 #pragma warning disable SA1500
+
 namespace Llvm.NET.DebugInfo.Tests
 {
     // TODO: Standard arg checks and error handling in general
@@ -87,10 +89,9 @@ namespace Llvm.NET.DebugInfo.Tests
         [TestMethod]
         public void DebugUnionTypeTest2( )
         {
-            const string testTriple = "thumbv7m-none--eabi";
-            var target = Target.FromTriple( testTriple );
+            var testTriple = new Triple( "thumbv7m-none--eabi" );
+            var targetMachine = new TargetMachine( testTriple );
             using( var ctx = new Context( ) )
-            using( var targetMachine = target.CreateTargetMachine( testTriple ) )
             using( var module = new BitcodeModule( ctx, "testModule" ) { Layout= targetMachine.TargetData } )
             {
                 const string nativeUnionName = "union.testUnion";

--- a/src/Llvm.NETTests/MDNodeTests.cs
+++ b/src/Llvm.NETTests/MDNodeTests.cs
@@ -25,9 +25,9 @@ namespace Llvm.NET.Tests
         [TestMethod]
         public void OperandsAreAccessibleTest()
         {
+            var targetMachine = TargetTests.GetTargetMachine( );
             using( var ctx = new Context( ) )
             using( var module = new BitcodeModule( ctx, "test.bc", SourceLanguage.CSharp, "test.cs", "unittests" ) )
-            using( var targetMachine = TargetTests.GetTargetMachine( ) )
             {
                 module.Layout = targetMachine.TargetData;
                 var intType = new DebugBasicType( module.Context.Int32Type, module, "int", DiTypeKind.Signed );

--- a/src/Llvm.NETTests/ModuleTests.cs
+++ b/src/Llvm.NETTests/ModuleTests.cs
@@ -407,9 +407,43 @@ namespace Llvm.NET.Tests
                 module.AddModuleFlag( ModuleFlagBehavior.Error, "min_enum_size", 4 );
                 module.AddVersionIdentMetadata( "unit-tests 1.0" );
 
-                // currently no exposed means to get module level flags...
-                // so at this point as long as adding the flags doesn't throw an exception
-                // assume things are OK.
+                Assert.AreEqual( 4, module.ModuleFlags.Count );
+                Assert.IsTrue( module.ModuleFlags.ContainsKey( BitcodeModule.DwarfVersionValue ) );
+                Assert.IsTrue( module.ModuleFlags.ContainsKey( BitcodeModule.DebugVersionValue ) );
+                Assert.IsTrue( module.ModuleFlags.ContainsKey( "wchar_size" ) );
+                Assert.IsTrue( module.ModuleFlags.ContainsKey( "min_enum_size" ) );
+
+                var dwarfVerFlag = module.ModuleFlags[ BitcodeModule.DwarfVersionValue ];
+                Assert.AreEqual( ModuleFlagBehavior.Warning, dwarfVerFlag.Behavior );
+                Assert.AreEqual( BitcodeModule.DwarfVersionValue, dwarfVerFlag.Name );
+                Assert.IsInstanceOfType( dwarfVerFlag.Metadata, typeof( ConstantAsMetadata ) );
+                var dwarfVerConst = ( ( ConstantAsMetadata )dwarfVerFlag.Metadata ).Constant;
+                Assert.IsInstanceOfType( dwarfVerConst, typeof( ConstantInt ) );
+                Assert.AreEqual( 4UL, ( ( ConstantInt )dwarfVerConst ).ZeroExtendedValue );
+
+                var debugVerFlag = module.ModuleFlags[ BitcodeModule.DebugVersionValue ];
+                Assert.AreEqual( ModuleFlagBehavior.Warning, debugVerFlag.Behavior );
+                Assert.AreEqual( BitcodeModule.DebugVersionValue, debugVerFlag.Name );
+                Assert.IsInstanceOfType( debugVerFlag.Metadata, typeof( ConstantAsMetadata ) );
+                var debugVerConst = ( ( ConstantAsMetadata )debugVerFlag.Metadata ).Constant;
+                Assert.IsInstanceOfType( debugVerConst, typeof( ConstantInt ) );
+                Assert.AreEqual( BitcodeModule.DebugMetadataVersion, ( ( ConstantInt )debugVerConst ).ZeroExtendedValue );
+
+                var wcharSizeFlag = module.ModuleFlags[ "wchar_size" ];
+                Assert.AreEqual( ModuleFlagBehavior.Error, wcharSizeFlag.Behavior );
+                Assert.AreEqual( "wchar_size", wcharSizeFlag.Name );
+                Assert.IsInstanceOfType( wcharSizeFlag.Metadata, typeof( ConstantAsMetadata ) );
+                var wcharSizeConst = ( ( ConstantAsMetadata )wcharSizeFlag.Metadata ).Constant;
+                Assert.IsInstanceOfType( wcharSizeConst, typeof( ConstantInt ) );
+                Assert.AreEqual( 4UL, ( ( ConstantInt )wcharSizeConst ).ZeroExtendedValue );
+
+                var minEnumSizeFlag = module.ModuleFlags[ "wchar_size" ];
+                Assert.AreEqual( ModuleFlagBehavior.Error, minEnumSizeFlag.Behavior );
+                Assert.AreEqual( "wchar_size", minEnumSizeFlag.Name );
+                Assert.IsInstanceOfType( minEnumSizeFlag.Metadata, typeof( ConstantAsMetadata ) );
+                var minEnumSizeConst = ( ( ConstantAsMetadata )minEnumSizeFlag.Metadata ).Constant;
+                Assert.IsInstanceOfType( minEnumSizeConst, typeof( ConstantInt ) );
+                Assert.AreEqual( 4UL, ( ( ConstantInt )minEnumSizeConst ).ZeroExtendedValue );
             }
         }
 


### PR DESCRIPTION
## Breaking Changes

1. TargetMachine is no longer IDisposable. Now that the native handle is a proper safehandle, there isn't any need to perform any determinisitc finalization/cleanup. Long term goal is to minimize the use of IDisposable as much as possible as it makes things more difficult to use.
1. BitCodeModule.ModuleFlags is now a IReadOnlyDictionary<string,ModuleFlag> (ModuleFag is a new type). This greatly simplifies accessing the flags data from a module.

## Additional changes
More docs updates.
