### PR TITLE
Remove extraneous IDisposable types for global handles

### DIFF
--- a/src/Llvm.NET/BitcodeModule.cs
+++ b/src/Llvm.NET/BitcodeModule.cs
@@ -798,12 +798,10 @@ namespace Llvm.NET
                 return Clone( );
             }
 
-            using( var buffer = WriteToBuffer( ) )
-            {
-                var retVal = LoadFrom( buffer, targetContext );
-                Debug.Assert( retVal.Context == targetContext, "Expected to get a module bound to the specified context" );
-                return retVal;
-            }
+            var buffer = WriteToBuffer( );
+            var retVal = LoadFrom( buffer, targetContext );
+            Debug.Assert( retVal.Context == targetContext, "Expected to get a module bound to the specified context" );
+            return retVal;
         }
 
         /// <inheritdoc/>
@@ -828,10 +826,8 @@ namespace Llvm.NET
                 throw new FileNotFoundException( "Specified bit-code file does not exist", path );
             }
 
-            using( var buffer = new MemoryBuffer( path ) )
-            {
-                return LoadFrom( buffer, context );
-            }
+            var buffer = new MemoryBuffer( path );
+            return LoadFrom( buffer, context );
         }
 
         /// <summary>Load bit code from a memory buffer</summary>

--- a/src/Llvm.NET/DebugInfo/DebugInfoBuilder.cs
+++ b/src/Llvm.NET/DebugInfo/DebugInfoBuilder.cs
@@ -19,8 +19,6 @@ using static Llvm.NET.Native.NativeMethods;
 
 namespace Llvm.NET.DebugInfo
 {
-    // TODO: Remove IDisposable once LLVMDIBuilderRef is based on LlvmObject
-
     /// <summary>DebugInfoBuilder is a factory class for creating DebugInformation for an LLVM
     /// <see cref="BitcodeModule"/></summary>
     /// <remarks>
@@ -31,7 +29,6 @@ namespace Llvm.NET.DebugInfo
     /// </remarks>
     /// <seealso href="xref:llvm_sourceleveldebugging">LLVM Source Level Debugging</seealso>
     public sealed class DebugInfoBuilder
-        : IDisposable
     {
         /// <summary>Gets the module that owns this builder</summary>
         public BitcodeModule OwningModule { get; }
@@ -1305,16 +1302,6 @@ namespace Llvm.NET.DebugInfo
             return MDNode.FromHandle<DICompositeType>( handle );
         }
 
-        /// <inheritdoc/>
-        public void Dispose( )
-        {
-            if( BuilderHandle == default )
-            {
-                LLVMDIBuilderDestroy( BuilderHandle );
-                BuilderHandle = default;
-            }
-        }
-
         internal DebugInfoBuilder( BitcodeModule owningModule )
             : this( owningModule, true )
         {
@@ -1326,10 +1313,7 @@ namespace Llvm.NET.DebugInfo
         // allowUnresolved == false
         private DebugInfoBuilder( BitcodeModule owningModule, bool allowUnresolved )
         {
-            if( owningModule == null )
-            {
-                throw new ArgumentNullException( nameof( owningModule ) );
-            }
+            owningModule.ValidateNotNull( nameof( owningModule ) );
 
             BuilderHandle = LLVMNewDIBuilder( owningModule.ModuleHandle, allowUnresolved );
             OwningModule = owningModule;
@@ -1347,9 +1331,6 @@ namespace Llvm.NET.DebugInfo
         #region LibLLVM P/Invoke APIs
         [DllImport( LibraryPath, CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
         private static extern LLVMDIBuilderRef LLVMNewDIBuilder( LLVMModuleRef @m, [MarshalAs( UnmanagedType.Bool )]bool allowUnresolved );
-
-        [DllImport( LibraryPath, CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        private static extern void LLVMDIBuilderDestroy( LLVMDIBuilderRef @d );
 
         [DllImport( LibraryPath, CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
         private static extern void LLVMDIBuilderFinalize( LLVMDIBuilderRef @d );

--- a/src/Llvm.NET/JIT/GenericValue.cs
+++ b/src/Llvm.NET/JIT/GenericValue.cs
@@ -13,7 +13,6 @@ namespace Llvm.NET.JIT
 {
     /// <summary>LLVM JIT discriminated union for a generic primitive value</summary>
     public sealed class GenericValue
-        : IDisposable
     {
         /// <summary>Initializes a new instance of the <see cref="GenericValue"/> class with an integer value</summary>
         /// <param name="t">LLVM type describing the integer bit width</param>
@@ -62,12 +61,6 @@ namespace Llvm.NET.JIT
         /// <param name="ctx">Context to use for the LLVM double type definition</param>
         /// <returns>Floating point value</returns>
         public double ToDouble( Context ctx ) => LLVMGenericValueToFloat( ctx.DoubleType.GetTypeRef( ), Handle );
-
-        /// <inheritdoc/>
-        public void Dispose( )
-        {
-            Handle.Dispose( );
-        }
 
         private readonly LLVMGenericValueRef Handle;
     }

--- a/src/Llvm.NET/MemoryBuffer.cs
+++ b/src/Llvm.NET/MemoryBuffer.cs
@@ -15,7 +15,6 @@ namespace Llvm.NET
 {
     /// <summary>LLVM MemoryBuffer</summary>
     public sealed class MemoryBuffer
-        : IDisposable
     {
         /// <summary>Initializes a new instance of the <see cref="MemoryBuffer"/> class from a file</summary>
         /// <param name="path">Path of the file to load</param>
@@ -43,16 +42,6 @@ namespace Llvm.NET
             }
         }
 
-        /// <inheritdoc/>
-        public void Dispose( )
-        {
-            if( BufferHandle == default )
-            {
-                LLVMDisposeMemoryBuffer( BufferHandle );
-                BufferHandle_ = default;
-            }
-        }
-
         /// <summary>Gets an array of bytes from the buffer</summary>
         /// <returns>Array of bytes copied from the buffer</returns>
         public byte[] ToArray()
@@ -72,6 +61,7 @@ namespace Llvm.NET
 
         internal LLVMMemoryBufferRef BufferHandle => BufferHandle_;
 
+        // TODO: Consider some form of WriteOnce<T> to enforce semantics and not rely on a coment
         // keep as a private field so this is usable as an out parameter in constructor
         // do not write to it directly, treat it as readonly.
         [SuppressMessage( "StyleCop.CSharp.NamingRules"
@@ -80,5 +70,33 @@ namespace Llvm.NET
                         )
         ]
         private LLVMMemoryBufferRef BufferHandle_;
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
+        private static extern LLVMStatus LLVMCreateMemoryBufferWithContentsOfFile( [MarshalAs( UnmanagedType.LPStr )] string @Path
+                                                                                 , out LLVMMemoryBufferRef @OutMemBuf
+                                                                                 , [MarshalAs( UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof( StringMarshaler ), MarshalCookie = "DisposeMessage" )]out string @OutMessage
+                                                                                 );
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl )]
+        private static extern LLVMStatus LLVMCreateMemoryBufferWithSTDIN( out LLVMMemoryBufferRef @OutMemBuf, out IntPtr @OutMessage );
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
+        private static extern LLVMMemoryBufferRef LLVMCreateMemoryBufferWithMemoryRange( [ MarshalAs( UnmanagedType.LPStr )] string @InputData
+                                                                                       , size_t @InputDataLength
+                                                                                       , [MarshalAs( UnmanagedType.LPStr )] string @BufferName
+                                                                                       , [MarshalAs( UnmanagedType.Bool )]bool @RequiresNullTerminator
+                                                                                       );
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
+        private static extern LLVMMemoryBufferRef LLVMCreateMemoryBufferWithMemoryRangeCopy( [MarshalAs( UnmanagedType.LPStr )] string @InputData
+                                                                                           , size_t @InputDataLength
+                                                                                           , [MarshalAs( UnmanagedType.LPStr )] string @BufferName
+                                                                                           );
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl )]
+        private static extern IntPtr LLVMGetBufferStart( LLVMMemoryBufferRef @MemBuf );
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl )]
+        private static extern size_t LLVMGetBufferSize( LLVMMemoryBufferRef @MemBuf );
     }
 }

--- a/src/Llvm.NET/Native/Generated.cs
+++ b/src/Llvm.NET/Native/Generated.cs
@@ -2311,29 +2311,6 @@ namespace Llvm.NET.Native
         internal static extern LLVMValueRef LLVMBuildAtomicCmpXchg( LLVMBuilderRef @B, LLVMValueRef @Ptr, LLVMValueRef @Cmp, LLVMValueRef @New, LLVMAtomicOrdering @SuccessOrdering, LLVMAtomicOrdering @FailureOrdering, [MarshalAs( UnmanagedType.Bool )]bool @SingleThread );
         #endregion
 
-        #region Memory Buffer
-        [DllImport( LibraryPath, EntryPoint = "LLVMCreateMemoryBufferWithContentsOfFile", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
-        internal static extern LLVMStatus LLVMCreateMemoryBufferWithContentsOfFile( [MarshalAs( UnmanagedType.LPStr )] string @Path, out LLVMMemoryBufferRef @OutMemBuf, [MarshalAs( UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof( StringMarshaler ), MarshalCookie = "DisposeMessage" )]out string @OutMessage );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMCreateMemoryBufferWithSTDIN", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern LLVMStatus LLVMCreateMemoryBufferWithSTDIN( out LLVMMemoryBufferRef @OutMemBuf, out IntPtr @OutMessage );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMCreateMemoryBufferWithMemoryRange", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
-        internal static extern LLVMMemoryBufferRef LLVMCreateMemoryBufferWithMemoryRange( [MarshalAs( UnmanagedType.LPStr )] string @InputData, size_t @InputDataLength, [MarshalAs( UnmanagedType.LPStr )] string @BufferName, [MarshalAs( UnmanagedType.Bool )]bool @RequiresNullTerminator );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMCreateMemoryBufferWithMemoryRangeCopy", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
-        internal static extern LLVMMemoryBufferRef LLVMCreateMemoryBufferWithMemoryRangeCopy( [MarshalAs( UnmanagedType.LPStr )] string @InputData, size_t @InputDataLength, [MarshalAs( UnmanagedType.LPStr )] string @BufferName );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMGetBufferStart", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern IntPtr LLVMGetBufferStart( LLVMMemoryBufferRef @MemBuf );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMGetBufferSize", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern size_t LLVMGetBufferSize( LLVMMemoryBufferRef @MemBuf );
-
-        [DllImport( LibraryPath, EntryPoint = "LLVMDisposeMemoryBuffer", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern void LLVMDisposeMemoryBuffer( LLVMMemoryBufferRef @MemBuf );
-        #endregion
-
         #region Pass Manager
         [DllImport( LibraryPath, EntryPoint = "LLVMGetGlobalPassRegistry", CallingConvention = CallingConvention.Cdecl )]
         internal static extern LLVMPassRegistryRef LLVMGetGlobalPassRegistry( );

--- a/src/Llvm.NET/Native/Handles/LLVMDIBuilderRef.cs
+++ b/src/Llvm.NET/Native/Handles/LLVMDIBuilderRef.cs
@@ -3,30 +3,35 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Security;
+
+using static Llvm.NET.Native.NativeMethods;
 
 namespace Llvm.NET.Native
 {
-    // TODO: Convert to using LlvmObject so that DebugInfoBuilder doesn't need to be disposable
-    internal struct LLVMDIBuilderRef
-        : IEquatable<LLVMDIBuilderRef>
+    [SecurityCritical]
+    internal class LLVMDIBuilderRef
+        : LlvmObjectRef
     {
-        public override int GetHashCode( ) => Handle.GetHashCode( );
-
-        public override bool Equals( object obj ) => !( obj is null ) && ( obj is LLVMDIBuilderRef r ) && r.Handle == Handle;
-
-        public bool Equals( LLVMDIBuilderRef other ) => Handle == other.Handle;
-
-        public static bool operator ==( LLVMDIBuilderRef lhs, LLVMDIBuilderRef rhs )
-            => EqualityComparer<LLVMDIBuilderRef>.Default.Equals( lhs, rhs );
-
-        public static bool operator !=( LLVMDIBuilderRef lhs, LLVMDIBuilderRef rhs ) => !( lhs == rhs );
-
-        internal LLVMDIBuilderRef( IntPtr pointer )
+        public LLVMDIBuilderRef( IntPtr handle, bool owner)
+            : base( owner )
         {
-            Handle = pointer;
+            SetHandle( handle );
         }
 
-        private readonly IntPtr Handle;
+        protected override bool ReleaseHandle( )
+        {
+            LLVMDIBuilderDestroy( handle );
+            return true;
+        }
+
+        private LLVMDIBuilderRef()
+            : base( true )
+        {
+        }
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl )]
+        private static extern void LLVMDIBuilderDestroy( IntPtr d );
     }
 }

--- a/src/Llvm.NET/Native/Handles/LLVMMemoryBufferRef.cs
+++ b/src/Llvm.NET/Native/Handles/LLVMMemoryBufferRef.cs
@@ -1,33 +1,38 @@
-﻿// <copyright file="Generated.cs" company=".NET Foundation">
+﻿// <copyright file="LLVMMemoryBufferRef.cs" company=".NET Foundation">
 // Copyright (c) .NET Foundation. All rights reserved.
 // </copyright>
 
 using System;
-using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Security;
+
+using static Llvm.NET.Native.NativeMethods;
 
 namespace Llvm.NET.Native
 {
-     // TODO: replace with LlvmObject impl so that MemoryBuffer can remove the IDisposable interface and function like any other
-     // garbage collected type in .NET
-     internal struct LLVMMemoryBufferRef
-        : IEquatable<LLVMMemoryBufferRef>
+    [SecurityCritical]
+    internal class LLVMMemoryBufferRef
+        : LlvmObjectRef
     {
-        public override int GetHashCode( ) => Handle.GetHashCode( );
-
-        public override bool Equals( object obj ) => !( obj is null ) && ( obj is LLVMMemoryBufferRef r ) && r.Handle == Handle;
-
-        public bool Equals( LLVMMemoryBufferRef other ) => Handle == other.Handle;
-
-        public static bool operator ==( LLVMMemoryBufferRef lhs, LLVMMemoryBufferRef rhs )
-            => EqualityComparer<LLVMMemoryBufferRef>.Default.Equals( lhs, rhs );
-
-        public static bool operator !=( LLVMMemoryBufferRef lhs, LLVMMemoryBufferRef rhs ) => !( lhs == rhs );
-
-        internal LLVMMemoryBufferRef( IntPtr pointer )
+        public LLVMMemoryBufferRef( IntPtr handle, bool owner )
+            : base( owner )
         {
-            Handle = pointer;
+            SetHandle( handle );
         }
 
-        private readonly IntPtr Handle;
+        [SecurityCritical]
+        protected override bool ReleaseHandle( )
+        {
+            LLVMDisposeMemoryBuffer( handle );
+            return true;
+        }
+
+        private LLVMMemoryBufferRef( )
+            : base( true )
+        {
+        }
+
+        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl )]
+        private static extern void LLVMDisposeMemoryBuffer( IntPtr handle );
     }
 }


### PR DESCRIPTION
Converted global handles for MemoryBuffer and DIBuilder and GenericValue to use LlvmObject to remove need for IDisposable