### PR TITLE
Completed internal conversion of all handle interning caches to a common pattern

### DIFF
--- a/Samples/CodeGenWithDebugInfo/Program.cs
+++ b/Samples/CodeGenWithDebugInfo/Program.cs
@@ -71,7 +71,7 @@ namespace TestDebugInfo
 
                 // <CreatingModule>
                 using( var context = new Context( ) )
-                using( var module = new BitcodeModule( context, moduleName ) )
+                using( var module = context.CreateBitcodeModule( moduleName ) )
                 {
                     module.SourceFileName = Path.GetFileName( srcPath );
                     module.TargetTriple = TargetDetails.TargetMachine.Triple;

--- a/Samples/Kaleidoscope/Chapter3/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter3/CodeGenerator.cs
@@ -23,7 +23,7 @@ namespace Kaleidoscope
         public CodeGenerator( LanguageLevel level )
         {
             Context = new Context( );
-            Module = new BitcodeModule( Context, "Kaleidoscope" );
+            Module = Context.CreateBitcodeModule( "Kaleidoscope" );
             InstructionBuilder = new InstructionBuilder( Context );
             NamedValues = new Dictionary<string, Value>( );
             ParserStack = new ReplParserStack( level );

--- a/Samples/Kaleidoscope/Chapter4/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter4/CodeGenerator.cs
@@ -167,7 +167,7 @@ namespace Kaleidoscope
 
         private void InitializeModuleAndPassManager( )
         {
-            Module = new BitcodeModule( Context );
+            Module = Context.CreateBitcodeModule( );
             FunctionPassManager = new FunctionPassManager( Module );
             FunctionPassManager.AddInstructionCombiningPass( )
                                .AddReassociatePass( )

--- a/Samples/Kaleidoscope/Chapter5/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter5/CodeGenerator.cs
@@ -339,7 +339,7 @@ namespace Kaleidoscope
 
         private void InitializeModuleAndPassManager( )
         {
-            Module = new BitcodeModule( Context, "Kaleidoscope" );
+            Module = Context.CreateBitcodeModule( "Kaleidoscope" );
             FunctionPassManager = new FunctionPassManager( Module );
             FunctionPassManager.AddInstructionCombiningPass( )
                                .AddReassociatePass( )

--- a/Samples/Kaleidoscope/Chapter6/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter6/CodeGenerator.cs
@@ -395,7 +395,7 @@ namespace Kaleidoscope
 
         private void InitializeModuleAndPassManager( )
         {
-            Module = new BitcodeModule( Context, "Kaleidoscope" );
+            Module = Context.CreateBitcodeModule( "Kaleidoscope" );
             FunctionPassManager = new FunctionPassManager( Module );
             FunctionPassManager.AddInstructionCombiningPass( )
                                .AddReassociatePass( )

--- a/Samples/Kaleidoscope/Chapter7/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter7/CodeGenerator.cs
@@ -453,7 +453,7 @@ namespace Kaleidoscope
 
         private void InitializeModuleAndPassManager( )
         {
-            Module = new BitcodeModule( Context, "Kaleidoscope" );
+            Module = Context.CreateBitcodeModule( "Kaleidoscope" );
             FunctionPassManager = new FunctionPassManager( Module );
             FunctionPassManager.AddPromoteMemoryToRegisterPass()
                                .AddInstructionCombiningPass( )

--- a/Samples/Kaleidoscope/Chapter8/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter8/CodeGenerator.cs
@@ -443,7 +443,7 @@ namespace Kaleidoscope
 
         private void InitializeModuleAndPassManager( )
         {
-            Module = new BitcodeModule( Context, "Kaleidoscope" );
+            Module = Context.CreateBitcodeModule( "Kaleidoscope" );
         }
 
         private Function GetFunction( string name )

--- a/Samples/Kaleidoscope/Chapter9/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter9/CodeGenerator.cs
@@ -33,11 +33,9 @@ namespace Kaleidoscope
             NamedValues = new Dictionary<string, Alloca>( );
             FunctionPrototypes = new PrototypeCollection( );
             ParserStack = new ReplParserStack( level );
-            Module = new BitcodeModule( Context, "Kaleidoscope", SourceLanguage.C, "fib.ks", "Kaleidoscope Compiler" )
-            {
-                TargetTriple = machine.Triple,
-                Layout = machine.TargetData
-            };
+            Module = Context.CreateBitcodeModule( "Kaleidoscope", SourceLanguage.C, "fib.ks", "Kaleidoscope Compiler" );
+            Module.TargetTriple = machine.Triple;
+            Module.Layout = machine.TargetData;
             DoubleType = new DebugBasicType( Context.DoubleType, Module, "double", DiTypeKind.Float );
         }
 

--- a/src/Llvm.NET.sln
+++ b/src/Llvm.NET.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27128.1
+VisualStudioVersion = 15.0.27130.2003
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Llvm.NET", "Llvm.NET\Llvm.NET.csproj", "{0162C8CE-6641-4922-8664-F8A44356FBF7}"
 EndProject

--- a/src/Llvm.NET/IBitcodeModuleFactory.cs
+++ b/src/Llvm.NET/IBitcodeModuleFactory.cs
@@ -1,0 +1,47 @@
+﻿// <copyright file="IBitcodeModuleFactory.cs" company=".NET Foundation">
+// Copyright (c) .NET Foundation. All rights reserved.
+// </copyright>
+
+using System;
+using Llvm.NET.DebugInfo;
+
+namespace Llvm.NET
+{
+    /// <summary>Interface for a <see cref="BitcodeModule"/> factory</summary>
+    /// <remarks>
+    /// Modules are owned by the context and thus not created, freestanding.
+    /// This interface provides factory methods for constructing modules. It
+    /// is implemented by the <see cref="Context"/> and also internally by
+    /// the handle caches that ultimately call the inderlying LLVM module
+    /// creation APIs.
+    /// </remarks>
+    public interface IBitcodeModuleFactory
+    {
+        /// <summary>Creates a new instance of the <see cref="BitcodeModule"/> class in this context</summary>
+        /// <returns><see cref="BitcodeModule"/></returns>
+        BitcodeModule CreateBitcodeModule( );
+
+        /// <summary>Creates a new instance of the <see cref="BitcodeModule"/> class in a given context</summary>
+        /// <param name="moduleId">Module's ID</param>
+        /// <returns><see cref="BitcodeModule"/></returns>
+        BitcodeModule CreateBitcodeModule( string moduleId );
+
+        /// <summary>Initializes a new instance of the <see cref="BitcodeModule"/> class with a root <see cref="DICompileUnit"/> to contain debugging information</summary>
+        /// <param name="moduleId">Module name</param>
+        /// <param name="language">Language to store in the debugging information</param>
+        /// <param name="srcFilePath">path of source file to set for the compilation unit</param>
+        /// <param name="producer">Name of the application producing this module</param>
+        /// <param name="optimized">Flag to indicate if the module is optimized</param>
+        /// <param name="compilationFlags">Additional flags (use <see cref="String.Empty"/> if none are needed)</param>
+        /// <param name="runtimeVersion">Runtime version if any (use 0 if the runtime version has no meaning)</param>
+        /// <returns><see cref="BitcodeModule"/></returns>
+        BitcodeModule CreateBitcodeModule( string moduleId
+                                         , SourceLanguage language
+                                         , string srcFilePath
+                                         , string producer
+                                         , bool optimized = false
+                                         , string compilationFlags = ""
+                                         , uint runtimeVersion = 0
+                                         );
+    }
+}

--- a/src/Llvm.NET/JIT/LegacyExecutionEngine.cs
+++ b/src/Llvm.NET/JIT/LegacyExecutionEngine.cs
@@ -189,11 +189,23 @@ namespace Llvm.NET.JIT
             EngineHandle = handle;
         }
 
-        internal static IHandleInterning<LLVMExecutionEngineRef, LegacyExecutionEngine> CreateInterningFactory( )
+        internal class InterningFactory
+            : HandleInterningMap<LLVMExecutionEngineRef, LegacyExecutionEngine>
         {
-            return new HandleInterningMap<LLVMExecutionEngineRef, LegacyExecutionEngine>( ( h, c ) => new LegacyExecutionEngine( h )
-                                                                                        , ( ee ) => LLVMDisposeExecutionEngine( ee.EngineHandle )
-                                                                                        );
+            internal InterningFactory( Context context )
+                : base( context )
+            {
+            }
+
+            private protected override LegacyExecutionEngine ItemFactory( LLVMExecutionEngineRef handle )
+            {
+                return new LegacyExecutionEngine( handle );
+            }
+
+            private protected override void DisposeItem( LegacyExecutionEngine item )
+            {
+                LLVMDisposeExecutionEngine( item.EngineHandle );
+            }
         }
 
         private void CreateEngine( BitcodeModule module )

--- a/src/Llvm.NET/MemoryBuffer.cs
+++ b/src/Llvm.NET/MemoryBuffer.cs
@@ -81,7 +81,7 @@ namespace Llvm.NET
         private static extern LLVMStatus LLVMCreateMemoryBufferWithSTDIN( out LLVMMemoryBufferRef @OutMemBuf, out IntPtr @OutMessage );
 
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
-        private static extern LLVMMemoryBufferRef LLVMCreateMemoryBufferWithMemoryRange( [ MarshalAs( UnmanagedType.LPStr )] string @InputData
+        private static extern LLVMMemoryBufferRef LLVMCreateMemoryBufferWithMemoryRange( [MarshalAs( UnmanagedType.LPStr )] string @InputData
                                                                                        , size_t @InputDataLength
                                                                                        , [MarshalAs( UnmanagedType.LPStr )] string @BufferName
                                                                                        , [MarshalAs( UnmanagedType.Bool )]bool @RequiresNullTerminator

--- a/src/Llvm.NET/Metadata/LlvmMetadata.cs
+++ b/src/Llvm.NET/Metadata/LlvmMetadata.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Llvm.NET.DebugInfo;
 using Llvm.NET.Native;
 
@@ -54,7 +53,165 @@ namespace Llvm.NET
                 return null;
             }
 
-            return ( T )context.GetNodeFor( handle, StaticFactory );
+            return ( T )context.GetNodeFor( handle );
+        }
+
+        internal class InterningFactory
+            : HandleInterningMap<LLVMMetadataRef, LlvmMetadata>
+        {
+            internal InterningFactory( Context context )
+                : base( context )
+            {
+            }
+
+            /// <summary>Enumeration to define debug information metadata nodes</summary>
+            private enum MetadataKind : uint
+            {
+                MDString,                     // HANDLE_METADATA_LEAF(MDString)
+                                              // ValueAsMetadata,            // HANDLE_METADATA_BRANCH(ValueAsMetadata)
+                ConstantAsMetadata,           // HANDLE_METADATA_LEAF(ConstantAsMetadata)
+                LocalAsMetadata,              // HANDLE_METADATA_LEAF(LocalAsMetadata)
+                DistinctMDOperandPlaceholder, // HANDLE_METADATA_LEAF(DistinctMDOperandPlaceholder)
+                                              // MDNode,                     // HANDLE_MDNODE_BRANCH(MDNode)
+                MDTuple,                      // HANDLE_MDNODE_LEAF_UNIQUABLE(MDTuple)
+                DILocation,                   // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILocation)
+                DIExpression,                 // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIExpression)
+                DIGlobalVariableExpression,   // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIGlobalVariableExpression)
+                                              // DINode,                     // HANDLE_SPECIALIZED_MDNODE_BRANCH(DINode)
+                GenericDINode,                // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(GenericDINode)
+                DISubrange,                   // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DISubrange)
+                DIEnumerator,                 // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIEnumerator)
+                                              // DIScope,                    // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIScope)
+                                              // DIType,                     // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIType)
+                DIBasicType,                  // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIBasicType)
+                DIDerivedType,                // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIDerivedType)
+                DICompositeType,              // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DICompositeType)
+                DISubroutineType,             // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DISubroutineType)
+                DIFile,                       // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIFile)
+                DICompileUnit,                // HANDLE_SPECIALIZED_MDNODE_LEAF(DICompileUnit)
+                                              // DILocalScope,               // HANDLE_SPECIALIZED_MDNODE_BRANCH(DILocalScope)
+                DISubprogram,                 // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DISubprogram)
+                                              // DILexicalBlockBase,         // HANDLE_SPECIALIZED_MDNODE_BRANCH(DILexicalBlockBase)
+                DILexicalBlock,               // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILexicalBlock)
+                DILexicalBlockFile,           // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILexicalBlockFile)
+                DINamespace,                  // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DINamespace)
+                DIModule,                     // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIModule)
+                                              // DITemplateParameter,        // HANDLE_SPECIALIZED_MDNODE_BRANCH(DITemplateParameter)
+                DITemplateTypeParameter,      // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DITemplateTypeParameter)
+                DITemplateValueParameter,     // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DITemplateValueParameter)
+                                              // DIVariable,                 // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIVariable)
+                DIGlobalVariable,             // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIGlobalVariable)
+                DILocalVariable,              // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILocalVariable)
+                DIObjCProperty,               // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIObjCProperty)
+                DIImportedEntity,             // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIImportedEntity)
+                                              // DIMacroNode,                // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIMacroNode)
+                DIMacro,                      // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIMacro)
+                DIMacroFile,                  // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIMacroFile)
+            }
+
+            private protected override LlvmMetadata ItemFactory( LLVMMetadataRef handle )
+            {
+                // use the native kind value to determine the managed type
+                // that should wrap this particular handle
+                var kind = ( MetadataKind )NativeMethods.LLVMGetMetadataID( handle );
+                switch( kind )
+                {
+                case MetadataKind.MDString:
+                    return new MDString( handle );
+
+                case MetadataKind.ConstantAsMetadata:
+                    return new ConstantAsMetadata( handle );
+
+                case MetadataKind.LocalAsMetadata:
+                    return new LocalAsMetadata( handle );
+
+                case MetadataKind.DistinctMDOperandPlaceholder:
+                    throw new NotSupportedException( ); // return new DistinctMDOperandPlaceHodler( handle );
+
+                case MetadataKind.MDTuple:
+                    return new MDTuple( handle );
+
+                case MetadataKind.DILocation:
+                    return new DILocation( handle );
+
+                case MetadataKind.DIExpression:
+                    return new DIExpression( handle );
+
+                case MetadataKind.DIGlobalVariableExpression:
+                    return new DIGlobalVariableExpression( handle );
+
+                case MetadataKind.GenericDINode:
+                    return new GenericDINode( handle );
+
+                case MetadataKind.DISubrange:
+                    return new DISubRange( handle );
+
+                case MetadataKind.DIEnumerator:
+                    return new DIEnumerator( handle );
+
+                case MetadataKind.DIBasicType:
+                    return new DIBasicType( handle );
+
+                case MetadataKind.DIDerivedType:
+                    return new DIDerivedType( handle );
+
+                case MetadataKind.DICompositeType:
+                    return new DICompositeType( handle );
+
+                case MetadataKind.DISubroutineType:
+                    return new DISubroutineType( handle );
+
+                case MetadataKind.DIFile:
+                    return new DIFile( handle );
+
+                case MetadataKind.DICompileUnit:
+                    return new DICompileUnit( handle );
+
+                case MetadataKind.DISubprogram:
+                    return new DISubProgram( handle );
+
+                case MetadataKind.DILexicalBlock:
+                    return new DILexicalBlock( handle );
+
+                case MetadataKind.DILexicalBlockFile:
+                    return new DILexicalBlockFile( handle );
+
+                case MetadataKind.DINamespace:
+                    return new DINamespace( handle );
+
+                case MetadataKind.DIModule:
+                    return new DIModule( handle );
+
+                case MetadataKind.DITemplateTypeParameter:
+                    return new DITemplateTypeParameter( handle );
+
+                case MetadataKind.DITemplateValueParameter:
+                    return new DITemplateValueParameter( handle );
+
+                case MetadataKind.DIGlobalVariable:
+                    return new DIGlobalVariable( handle );
+
+                case MetadataKind.DILocalVariable:
+                    return new DILocalVariable( handle );
+
+                case MetadataKind.DIObjCProperty:
+                    return new DIObjCProperty( handle );
+
+                case MetadataKind.DIImportedEntity:
+                    return new DIImportedEntity( handle );
+
+                case MetadataKind.DIMacro:
+                    return new DIMacro( handle );
+
+                case MetadataKind.DIMacroFile:
+                    return new DIMacroFile( handle );
+
+                default:
+#pragma warning disable RECS0083 // Intentional trigger to catch changes in underlying LLVM libs
+                    throw new NotImplementedException( );
+#pragma warning restore RECS0083
+                }
+            }
         }
 
         private protected LlvmMetadata( LLVMMetadataRef handle )
@@ -65,157 +222,6 @@ namespace Llvm.NET
             }
 
             MetadataHandle = handle;
-        }
-
-        /// <summary>Enumeration to define debug information metadata nodes</summary>
-        private enum MetadataKind : uint
-        {
-            MDString,                     // HANDLE_METADATA_LEAF(MDString)
-            // ValueAsMetadata,            // HANDLE_METADATA_BRANCH(ValueAsMetadata)
-            ConstantAsMetadata,           // HANDLE_METADATA_LEAF(ConstantAsMetadata)
-            LocalAsMetadata,              // HANDLE_METADATA_LEAF(LocalAsMetadata)
-            DistinctMDOperandPlaceholder, // HANDLE_METADATA_LEAF(DistinctMDOperandPlaceholder)
-            // MDNode,                     // HANDLE_MDNODE_BRANCH(MDNode)
-            MDTuple,                      // HANDLE_MDNODE_LEAF_UNIQUABLE(MDTuple)
-            DILocation,                   // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILocation)
-            DIExpression,                 // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIExpression)
-            DIGlobalVariableExpression,   // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIGlobalVariableExpression)
-            // DINode,                     // HANDLE_SPECIALIZED_MDNODE_BRANCH(DINode)
-            GenericDINode,                // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(GenericDINode)
-            DISubrange,                   // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DISubrange)
-            DIEnumerator,                 // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIEnumerator)
-            // DIScope,                    // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIScope)
-            // DIType,                     // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIType)
-            DIBasicType,                  // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIBasicType)
-            DIDerivedType,                // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIDerivedType)
-            DICompositeType,              // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DICompositeType)
-            DISubroutineType,             // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DISubroutineType)
-            DIFile,                       // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIFile)
-            DICompileUnit,                // HANDLE_SPECIALIZED_MDNODE_LEAF(DICompileUnit)
-            // DILocalScope,               // HANDLE_SPECIALIZED_MDNODE_BRANCH(DILocalScope)
-            DISubprogram,                 // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DISubprogram)
-            // DILexicalBlockBase,         // HANDLE_SPECIALIZED_MDNODE_BRANCH(DILexicalBlockBase)
-            DILexicalBlock,               // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILexicalBlock)
-            DILexicalBlockFile,           // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILexicalBlockFile)
-            DINamespace,                  // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DINamespace)
-            DIModule,                     // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIModule)
-            // DITemplateParameter,        // HANDLE_SPECIALIZED_MDNODE_BRANCH(DITemplateParameter)
-            DITemplateTypeParameter,      // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DITemplateTypeParameter)
-            DITemplateValueParameter,     // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DITemplateValueParameter)
-            // DIVariable,                 // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIVariable)
-            DIGlobalVariable,             // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIGlobalVariable)
-            DILocalVariable,              // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILocalVariable)
-            DIObjCProperty,               // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIObjCProperty)
-            DIImportedEntity,             // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIImportedEntity)
-            // DIMacroNode,                // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIMacroNode)
-            DIMacro,                      // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIMacro)
-            DIMacroFile,                  // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIMacroFile)
-        }
-
-        [SuppressMessage( "Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "Static factory method" )]
-        [SuppressMessage( "Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "Static factory method" )]
-        private static LlvmMetadata StaticFactory( LLVMMetadataRef handle )
-        {
-            // use the native kind value to determine the managed type
-            // that should wrap this particular handle
-            var kind = ( MetadataKind )NativeMethods.LLVMGetMetadataID( handle );
-            switch( kind )
-            {
-            case MetadataKind.MDString:
-                return new MDString( handle );
-
-            case MetadataKind.ConstantAsMetadata:
-                return new ConstantAsMetadata( handle );
-
-            case MetadataKind.LocalAsMetadata:
-                return new LocalAsMetadata( handle );
-
-            case MetadataKind.DistinctMDOperandPlaceholder:
-                throw new NotSupportedException( ); // return new DistinctMDOperandPlaceHodler( handle );
-
-            case MetadataKind.MDTuple:
-                return new MDTuple( handle );
-
-            case MetadataKind.DILocation:
-                return new DILocation( handle );
-
-            case MetadataKind.DIExpression:
-                return new DIExpression( handle );
-
-            case MetadataKind.DIGlobalVariableExpression:
-                return new DIGlobalVariableExpression( handle );
-
-            case MetadataKind.GenericDINode:
-                return new GenericDINode( handle );
-
-            case MetadataKind.DISubrange:
-                return new DISubRange( handle );
-
-            case MetadataKind.DIEnumerator:
-                return new DIEnumerator( handle );
-
-            case MetadataKind.DIBasicType:
-                return new DIBasicType( handle );
-
-            case MetadataKind.DIDerivedType:
-                return new DIDerivedType( handle );
-
-            case MetadataKind.DICompositeType:
-                return new DICompositeType( handle );
-
-            case MetadataKind.DISubroutineType:
-                return new DISubroutineType( handle );
-
-            case MetadataKind.DIFile:
-                return new DIFile( handle );
-
-            case MetadataKind.DICompileUnit:
-                return new DICompileUnit( handle );
-
-            case MetadataKind.DISubprogram:
-                return new DISubProgram( handle );
-
-            case MetadataKind.DILexicalBlock:
-                return new DILexicalBlock( handle );
-
-            case MetadataKind.DILexicalBlockFile:
-                return new DILexicalBlockFile( handle );
-
-            case MetadataKind.DINamespace:
-                return new DINamespace( handle );
-
-            case MetadataKind.DIModule:
-                return new DIModule( handle );
-
-            case MetadataKind.DITemplateTypeParameter:
-                return new DITemplateTypeParameter( handle );
-
-            case MetadataKind.DITemplateValueParameter:
-                return new DITemplateValueParameter( handle );
-
-            case MetadataKind.DIGlobalVariable:
-                return new DIGlobalVariable( handle );
-
-            case MetadataKind.DILocalVariable:
-                return new DILocalVariable( handle );
-
-            case MetadataKind.DIObjCProperty:
-                return new DIObjCProperty( handle );
-
-            case MetadataKind.DIImportedEntity:
-                return new DIImportedEntity( handle );
-
-            case MetadataKind.DIMacro:
-                return new DIMacro( handle );
-
-            case MetadataKind.DIMacroFile:
-                return new DIMacroFile( handle );
-
-            default:
-#pragma warning disable RECS0083 // Intentional trigger to catch changes in underlying LLVM libs
-                throw new NotImplementedException( );
-#pragma warning restore RECS0083
-            }
         }
     }
 }

--- a/src/Llvm.NET/Native/ContextCache.cs
+++ b/src/Llvm.NET/Native/ContextCache.cs
@@ -28,6 +28,23 @@ namespace Llvm.NET.Native
             return context;
         }
 
+        internal static Context GetContextFor( LLVMContextRef contextRef )
+        {
+            if( contextRef == default )
+            {
+                return null;
+            }
+
+            if( TryGetValue( contextRef, out Context retVal ) )
+            {
+                return retVal;
+            }
+
+            // Context constructor will add itself to this cache
+            // ad remove itself on Dispose/finalize
+            return new Context( contextRef );
+        }
+
         private static IDictionary<LLVMContextRef, Context> CreateInstance()
         {
             return new ConcurrentDictionary<LLVMContextRef, Context>( EqualityComparer<LLVMContextRef>.Default );

--- a/src/Llvm.NET/Native/Handles/LLVMContextRef.cs
+++ b/src/Llvm.NET/Native/Handles/LLVMContextRef.cs
@@ -10,22 +10,6 @@ namespace Llvm.NET.Native
     internal class LLVMContextRef
         : LlvmObjectRef
     {
-        // FIXME: Move this out of here to the context as it is a layering violation
-        public static explicit operator Context( LLVMContextRef contextRef )
-        {
-            if( contextRef == default )
-            {
-                return null;
-            }
-
-            if( ContextCache.TryGetValue( contextRef, out Context retVal ) )
-            {
-                return retVal;
-            }
-
-            return new Context( contextRef );
-        }
-
         internal LLVMContextRef( IntPtr handle, bool owner )
             : base( owner )
         {

--- a/src/Llvm.NET/Native/Handles/LLVMMetadataRef.cs
+++ b/src/Llvm.NET/Native/Handles/LLVMMetadataRef.cs
@@ -34,7 +34,7 @@ namespace Llvm.NET.Native
 
                 var hContext = LLVMGetNodeContext( this );
                 Debug.Assert( hContext != default, "Should not get a null pointer from LLVM" );
-                return ( Context )hContext;
+                return ContextCache.GetContextFor( hContext );
             }
         }
 

--- a/src/Llvm.NET/Native/Handles/LLVMModuleRef.cs
+++ b/src/Llvm.NET/Native/Handles/LLVMModuleRef.cs
@@ -4,9 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-
-using static Llvm.NET.Native.NativeMethods;
 
 namespace Llvm.NET.Native
 {
@@ -23,21 +20,6 @@ namespace Llvm.NET.Native
             => EqualityComparer<LLVMModuleRef>.Default.Equals( lhs, rhs );
 
         public static bool operator !=( LLVMModuleRef lhs, LLVMModuleRef rhs ) => !( lhs == rhs );
-
-        public Context Context
-        {
-            get
-            {
-                if( Handle.IsNull( ) )
-                {
-                    return null;
-                }
-
-                var hContext = LLVMGetModuleContext( this );
-                Debug.Assert( hContext != default, "Should not get a null pointer from LLVM" );
-                return ( Context )hContext;
-            }
-        }
 
         internal LLVMModuleRef( IntPtr pointer )
         {

--- a/src/Llvm.NET/Native/Handles/LLVMTypeRef.cs
+++ b/src/Llvm.NET/Native/Handles/LLVMTypeRef.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace Llvm.NET.Native
 {
@@ -25,28 +23,10 @@ namespace Llvm.NET.Native
 
         public static bool operator !=( LLVMTypeRef lhs, LLVMTypeRef rhs ) => !( lhs == rhs );
 
-        public Context Context
-        {
-            get
-            {
-                if( Handle.IsNull( ) )
-                {
-                    return null;
-                }
-
-                var hContext = LLVMGetTypeContext( this );
-                Debug.Assert( hContext != default, "Should not get a null pointer from LLVM" );
-                return ( Context )hContext;
-            }
-        }
-
         internal LLVMTypeRef( IntPtr pointer )
         {
             Handle = pointer;
         }
-
-        [DllImport( NativeMethods.LibraryPath, CallingConvention = CallingConvention.Cdecl )]
-        private static extern LLVMContextAlias LLVMGetTypeContext( LLVMTypeRef @Ty );
 
         private readonly IntPtr Handle;
     }

--- a/src/Llvm.NET/Native/Handles/LLVMValueRef.cs
+++ b/src/Llvm.NET/Native/Handles/LLVMValueRef.cs
@@ -4,9 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-
-using static Llvm.NET.Native.NativeMethods;
 
 namespace Llvm.NET.Native
 {
@@ -23,22 +20,6 @@ namespace Llvm.NET.Native
             => EqualityComparer<LLVMValueRef>.Default.Equals( lhs, rhs );
 
         public static bool operator !=( LLVMValueRef lhs, LLVMValueRef rhs ) => !( lhs == rhs );
-
-        // FIXME: Move this out of here to the Value as it is a layering violation
-        public Context Context
-        {
-            get
-            {
-                if( Handle.IsNull() )
-                {
-                    return null;
-                }
-
-                var hType = LLVMTypeOf( this );
-                Debug.Assert( hType != default, "Should not get a null pointer from LLVM" );
-                return hType.Context;
-            }
-        }
 
         internal LLVMValueRef( IntPtr pointer )
         {

--- a/src/Llvm.NET/Values/AttributeValue.cs
+++ b/src/Llvm.NET/Values/AttributeValue.cs
@@ -170,10 +170,24 @@ namespace Llvm.NET.Values
 
         internal static AttributeValue FromHandle( Context context, LLVMAttributeRef handle)
         {
-            return context.GetAttributeFor( handle, (c,h)=>new AttributeValue(c, h) );
+            return context.GetAttributeFor( handle );
         }
 
         internal LLVMAttributeRef NativeAttribute { get; }
+
+        internal class InterningFactory
+            : HandleInterningMap<LLVMAttributeRef, AttributeValue>
+        {
+            internal InterningFactory( Context context)
+                : base( context )
+            {
+            }
+
+            private protected override AttributeValue ItemFactory( LLVMAttributeRef handle )
+            {
+                return new AttributeValue( Context, handle );
+            }
+        }
 
         private AttributeValue( Context context, LLVMAttributeRef nativeValue )
         {

--- a/src/Llvm.NETTests/ContextTests.cs
+++ b/src/Llvm.NETTests/ContextTests.cs
@@ -145,7 +145,7 @@ namespace Llvm.NET.Tests
             var targetMachine = TargetTests.GetTargetMachine( );
             using( var context = new Context( ) )
             {
-                var module = new BitcodeModule( context, "test.bc", SourceLanguage.CSharp, "test.cs", "unittests" );
+                var module = context.CreateBitcodeModule( "test.bc", SourceLanguage.CSharp, "test.cs", "unittests" );
                 Assert.IsNotNull( module );
                 module.Layout = targetMachine.TargetData;
 
@@ -195,7 +195,7 @@ namespace Llvm.NET.Tests
             var targetMachine = TargetTests.GetTargetMachine( );
             using( var context = new Context( ) )
             {
-                var module = new BitcodeModule( context, "test.bc", SourceLanguage.CSharp, "test.cs", "unittests" );
+                var module = context.CreateBitcodeModule( "test.bc", SourceLanguage.CSharp, "test.cs", "unittests" );
                 Assert.IsNotNull( module );
                 module.Layout = targetMachine.TargetData;
 

--- a/src/Llvm.NETTests/DebugInfo/DebugUnionTypeTests.cs
+++ b/src/Llvm.NETTests/DebugInfo/DebugUnionTypeTests.cs
@@ -20,7 +20,7 @@ namespace Llvm.NET.DebugInfo.Tests
         public void DebugUnionTypeTest( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context ) )
+            using( var module = context.CreateBitcodeModule( ) )
             {
                 const string nativeUnionName = "union.testUnion";
                 const string unionSymbolName = "testUnion";
@@ -93,11 +93,12 @@ namespace Llvm.NET.DebugInfo.Tests
             var testTriple = new Triple( "thumbv7m-none--eabi" );
             var targetMachine = new TargetMachine( testTriple );
             using( var ctx = new Context( ) )
-            using( var module = new BitcodeModule( ctx, "testModule" ) { Layout= targetMachine.TargetData } )
+            using( var module = ctx.CreateBitcodeModule( "testModule" ) )
             {
                 const string nativeUnionName = "union.testUnion";
                 const string unionSymbolName = "testUnion";
 
+                module.Layout = targetMachine.TargetData;
                 var diFile = module.DIBuilder.CreateFile( "test.c" );
                 var diCompileUnit = module.DIBuilder.CreateCompileUnit( SourceLanguage.C, "test.c", "unit-test", false, string.Empty, 0 );
 

--- a/src/Llvm.NETTests/MDNodeTests.cs
+++ b/src/Llvm.NETTests/MDNodeTests.cs
@@ -27,7 +27,7 @@ namespace Llvm.NET.Tests
         {
             var targetMachine = TargetTests.GetTargetMachine( );
             using( var ctx = new Context( ) )
-            using( var module = new BitcodeModule( ctx, "test.bc", SourceLanguage.CSharp, "test.cs", "unittests" ) )
+            using( var module = ctx.CreateBitcodeModule( "test.bc", SourceLanguage.CSharp, "test.cs", "unittests" ) )
             {
                 module.Layout = targetMachine.TargetData;
                 var intType = new DebugBasicType( module.Context.Int32Type, module, "int", DiTypeKind.Signed );

--- a/src/Llvm.NETTests/ModuleTests.cs
+++ b/src/Llvm.NETTests/ModuleTests.cs
@@ -36,7 +36,7 @@ namespace Llvm.NET.Tests
         public void DefaultConstructorTest( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context ) )
+            using( var module = context.CreateBitcodeModule( ) )
             {
                 Assert.AreSame( string.Empty, module.Name );
                 Assert.AreSame( string.Empty, module.SourceFileName );
@@ -64,7 +64,7 @@ namespace Llvm.NET.Tests
         public void ConstructorTestWithName( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context, TestModuleName ) )
+            using( var module = context.CreateBitcodeModule( TestModuleName ) )
             {
                 Assert.AreEqual( TestModuleName, module.Name );
                 Assert.AreEqual( TestModuleName, module.SourceFileName );
@@ -92,7 +92,7 @@ namespace Llvm.NET.Tests
         public void ConstructorTestWithNameAndCompileUnit( )
         {
             using( var ctx = new Context( ) )
-            using( var module = new BitcodeModule( ctx, TestModuleName, DebugInfo.SourceLanguage.C99, "test.c", "unitTest", false, string.Empty, 0 ) )
+            using( var module = ctx.CreateBitcodeModule( TestModuleName, DebugInfo.SourceLanguage.C99, "test.c", "unitTest", false, string.Empty, 0 ) )
             {
                 Assert.AreEqual( TestModuleName, module.Name );
                 Assert.AreEqual( "test.c", module.SourceFileName );
@@ -118,7 +118,7 @@ namespace Llvm.NET.Tests
         public void DisposeTest( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context, TestModuleName ) )
+            using( var module = context.CreateBitcodeModule( TestModuleName ) )
             {
             }
         }
@@ -128,8 +128,8 @@ namespace Llvm.NET.Tests
         {
             // verifies linked modules can be disposed
             using( var ctx = new Context( ) )
-            using( var module = new BitcodeModule( ctx, TestModuleName ) )
-            using( var otherModule = new BitcodeModule( ctx, "Other" ) )
+            using( var module = ctx.CreateBitcodeModule( TestModuleName ) )
+            using( var otherModule = ctx.CreateBitcodeModule( "Other" ) )
             {
                 module.Link( otherModule );
                 Assert.IsTrue( otherModule.IsDisposed );
@@ -141,7 +141,7 @@ namespace Llvm.NET.Tests
         public void MultiContextLinkTest( )
         {
             using( var context = new Context( ) )
-            using( var mergedMod = new BitcodeModule( context ) )
+            using( var mergedMod = context.CreateBitcodeModule( ) )
             using( var contextM1 = new Context( ))
             using( var m1 = CreateSimpleModule( contextM1, "module1" ) )
             using( var contextM2 = new Context( ) )
@@ -173,7 +173,7 @@ namespace Llvm.NET.Tests
         public void MultiContextCloneLinkTest( )
         {
             using( var context = new Context( ) )
-            using( var mergedMod = new BitcodeModule( context ) )
+            using( var mergedMod = context.CreateBitcodeModule( ) )
             using( var contextM1 = new Context( ) )
             using( var m1 = CreateSimpleModule( contextM1, "module1" ) )
             using( var contextM2 = new Context( ) )
@@ -199,7 +199,7 @@ namespace Llvm.NET.Tests
         public void VerifyValidModuleTest( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context, TestModuleName ) )
+            using( var module = context.CreateBitcodeModule( TestModuleName ) )
             {
                 Function testFunc = CreateSimpleVoidNopTestFunction( module, "foo" );
 
@@ -215,7 +215,7 @@ namespace Llvm.NET.Tests
         public void VerifyInvalidModuleTest( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context, TestModuleName ) )
+            using( var module = context.CreateBitcodeModule( TestModuleName ) )
             {
                 Function testFunc = CreateInvalidFunction( module, "badfunc" );
 
@@ -235,7 +235,7 @@ namespace Llvm.NET.Tests
         public void AddFunctionGetFunctionTest( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context, TestModuleName ) )
+            using( var module = context.CreateBitcodeModule( TestModuleName ) )
             {
                 Function testFunc = CreateSimpleVoidNopTestFunction( module, "foo" );
 
@@ -257,7 +257,7 @@ namespace Llvm.NET.Tests
             try
             {
                 using( var context = new Context( ) )
-                using( var module = new BitcodeModule( context, TestModuleName ) )
+                using( var module = context.CreateBitcodeModule( TestModuleName ) )
                 {
                     Function testFunc = CreateSimpleVoidNopTestFunction( module, "foo" );
                     module.WriteToFile( path );
@@ -286,7 +286,7 @@ namespace Llvm.NET.Tests
         public void AsStringTest( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context, TestModuleName ) )
+            using( var module = context.CreateBitcodeModule( TestModuleName ) )
             {
                 Function testFunc = CreateSimpleVoidNopTestFunction( module, "foo" );
 
@@ -303,7 +303,7 @@ namespace Llvm.NET.Tests
         public void AddAliasGetAliasTest( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context, TestModuleName ) )
+            using( var module = context.CreateBitcodeModule( TestModuleName ) )
             {
                 Function testFunc = CreateSimpleVoidNopTestFunction( module, "_test" );
 
@@ -328,7 +328,7 @@ namespace Llvm.NET.Tests
         public void AddGlobalTest( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context, TestModuleName ) )
+            using( var module = context.CreateBitcodeModule( TestModuleName ) )
             {
                 module.AddGlobal( module.Context.Int32Type, "TestInt" );
                 GlobalVariable globalVar = module.GetNamedGlobal( "TestInt" );
@@ -341,7 +341,7 @@ namespace Llvm.NET.Tests
         public void AddGlobalTest1( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context, TestModuleName ) )
+            using( var module = context.CreateBitcodeModule( TestModuleName ) )
             {
                 // unnamed global
                 module.AddGlobal( module.Context.Int32Type, true, Linkage.WeakODR, module.Context.CreateConstant( 0x12345678 ) );
@@ -362,7 +362,7 @@ namespace Llvm.NET.Tests
         public void AddGlobalTest2( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context, TestModuleName ) )
+            using( var module = context.CreateBitcodeModule( TestModuleName ) )
             {
                 module.AddGlobal( module.Context.Int32Type, true, Linkage.WeakODR, module.Context.CreateConstant( 0x12345678 ), "TestInt" );
                 GlobalVariable globalVar = module.GetNamedGlobal( "TestInt" );
@@ -381,7 +381,7 @@ namespace Llvm.NET.Tests
         public void GetTypeByNameTest( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context, TestModuleName ) )
+            using( var module = context.CreateBitcodeModule( TestModuleName ) )
             {
                 // while GetTypeByName is exposed on the module it isn't really specific to the module
                 // That is, the type belongs to the context and GetTypeByName() is just a convenience
@@ -398,7 +398,7 @@ namespace Llvm.NET.Tests
         public void AddModuleFlagTest( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context, TestModuleName ) )
+            using( var module = context.CreateBitcodeModule( TestModuleName ) )
             {
                 module.AddModuleFlag( ModuleFlagBehavior.Warning, BitcodeModule.DwarfVersionValue, 4 );
                 module.AddModuleFlag( ModuleFlagBehavior.Warning, BitcodeModule.DebugVersionValue, BitcodeModule.DebugMetadataVersion );
@@ -468,7 +468,7 @@ namespace Llvm.NET.Tests
         public void ComdatDataTest( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context, TestModuleName ) )
+            using( var module = context.CreateBitcodeModule( TestModuleName ) )
             {
                 const string comdatName = "testcomdat";
                 const string globalName = "globalwithcomdat";
@@ -503,7 +503,7 @@ namespace Llvm.NET.Tests
         public void ComdatFunctionTest( )
         {
             using( var context = new Context( ) )
-            using( var module = new BitcodeModule( context, TestModuleName ) )
+            using( var module = context.CreateBitcodeModule( TestModuleName ) )
             {
                 const string comdatName = "testcomdat";
                 const string globalName = "globalwithcomdat";
@@ -538,7 +538,7 @@ namespace Llvm.NET.Tests
 
         private BitcodeModule CreateSimpleModule( Context ctx, string name )
         {
-            var retVal = new BitcodeModule( ctx, name );
+            var retVal = ctx.CreateBitcodeModule( name );
             CreateSimpleVoidNopTestFunction( retVal, name );
             return retVal;
         }


### PR DESCRIPTION
## Breaking Changes
BitcodeModule is no longer a "newable" type. Creating modules now requires calling factory methods on the context. This is a small but necessary change to clean up internal complexity and clarify the actual ownership via a factory method.