### PR TITLE
New module members and refactorings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,7 +69,7 @@
                 <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
                 <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
             </ItemGroup>
-            <ItemGroup>
+            <ItemGroup Condition="'$(NoCommonAnalyzers)'!='true'">
                 <None Include="$(MSBuildThisFileDirectory)Ubiquity.NET.ruleset" Link="Ubiquity.NET.ruleset" />
             </ItemGroup>
         </When>

--- a/docfx/articles/InternalDetails/marshal-LLVMBool.md
+++ b/docfx/articles/InternalDetails/marshal-LLVMBool.md
@@ -1,0 +1,36 @@
+# Marshaling LLVMBool
+
+LLVMBool is a typdef in the LLVM-C API that is both simple and problematic. In it's
+simplest sense an LLVMBool is a representation of a bi-modal value. However, the
+problematic part is that the semantics for the value are different depending on any
+given API. That is, in some cases LLVMBool != 0 is a failure case, and others it is
+a success! The confusion stems from LLVMBool serving a dual role:
+  1) A real boolean true/false
+  2) A status code where 0 == success and non-zero indicates an error
+
+This duality is confusing and can lead to subtle errors in usage of APIs if translated
+directly into language projections. This makes hands-off automatic generation of P/Invoke
+calls to LLVM either imposible or error prone. Thus, Llvm.NET uses manually updated P/Invoke
+calls that were initially auto generated to get things started but not maintined via any
+generation tools. In the case of LLVMBool Llvm.NET uses distinct types for the different 
+semantics and declares the interop signatures with the form appropriate to the function
+being called. The two types are LLVMStatus and standard `System.Boolean` or `bool` in C#
+
+## LLVMStatus
+This is a status value where 0 == Success and non-zero is a failure or false status.
+LLVMStatus is used whenever the 0 == success semantics apply to the API. For example:
+
+```C#
+[DllImport( LibraryPath, EntryPoint = "LLVMWriteBitcodeToFD", CallingConvention = CallingConvention.Cdecl )]
+internal static extern LLVMStatus LLVMWriteBitcodeToFD( LLVMModuleRef @M, int @FD, int @ShouldClose, int @Unbuffered );
+```
+
+## LLVMBool
+This is the traditioanl boolean value where 0==false and non-zero is true and uses the
+standard boolean marshaling support for System.Boolean
+```C#
+[DllImport( LibraryPath, EntryPoint = "LLVMTypeIsSized", CallingConvention = CallingConvention.Cdecl )]
+[return: MarshalAs( UnmanagedType.Bool )]
+internal static extern bool LLVMTypeIsSized( LLVMTypeRef @Ty );
+```
+

--- a/docfx/articles/InternalDetails/marshal-string.md
+++ b/docfx/articles/InternalDetails/marshal-string.md
@@ -1,0 +1,27 @@
+# Marshaling strings in LLVM.NET
+LLVM provides strings in several forms and this leads to complexities for
+P/Invoke signatures as sometimes the strings require some form of release
+and in other cases, they do not. Standard .NET marshaling of strings makes
+some assumptions with regard to strings as a return type that make the LLVM
+APIs difficult. (e.g. in some LLVM APIs the returned string must be released
+via LLVMDisposeMessage() or some other call, while in other cases it is just
+a pointer to an internal const string that does not need any release.)
+
+To resolve these issues and make the requirements explicitly clear and consistent
+Llvm.NET uses custom marshaling of the strings to mark the exact behavior directly
+on the P/Invoke signature so it is both clear and easy to use for the upper layers
+(it's just a `System.String`)
+
+The current forms of string marshalling are:
+
+```C#
+// const char* owned by native LLVM, and never disposed by managed callers (just copy to managed string)
+[MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(StringMarshaler))]
+
+// const char* allocated in native LLVM, released by managed caller via LLVMDisposeMessage
+[MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(StringMarshaler), MarshalCookie="DisposeMessage")]
+
+// const char* allocated in native LLVM, released by managed caller via LLVMDisposeMangledSymbol
+[MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(StringMarshaler), MarshalCookie="MangledSymbol")]
+
+```

--- a/docfx/articles/InternalDetails/toc.md
+++ b/docfx/articles/InternalDetails/toc.md
@@ -1,2 +1,4 @@
 # [LLVM Handles](llvm-handles.md)
 # [Interning Handles](handleref-interning.md)
+# [Marshaling Strings](marshal-string.md)
+# [Marshaling LLVMBool](marshal-LLVMBool.md)

--- a/src/LibLLVM/ContextBindings.cpp
+++ b/src/LibLLVM/ContextBindings.cpp
@@ -1,0 +1,25 @@
+#include "ContextBindings.h"
+#include <llvm\IR\LLVMContext.h>
+
+using namespace llvm;
+
+extern "C"
+{
+    LLVMBool LLVMContextGetIsODRUniquingDebugTypes( LLVMContextRef context )
+    {
+        return unwrap( context )->isODRUniquingDebugTypes( );
+    }
+
+    void LLVMContextSetIsODRUniquingDebugTypes( LLVMContextRef context, LLVMBool state )
+    {
+        auto pContext = unwrap( context );
+        if ( state )
+        {
+            pContext->enableDebugTypeODRUniquing( );
+        }
+        else
+        {
+            pContext->disableDebugTypeODRUniquing( );
+        }
+    }
+}

--- a/src/LibLLVM/ContextBindings.h
+++ b/src/LibLLVM/ContextBindings.h
@@ -1,0 +1,17 @@
+#ifndef _CONTEXT_BINDINGS_H_
+#define _CONTEXT_BINDINGS_H_
+
+#include "llvm-c/Core.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    LLVMBool LLVMContextGetIsODRUniquingDebugTypes( LLVMContextRef context );
+    void LLVMContextSetIsODRUniquingDebugTypes( LLVMContextRef context, LLVMBool state );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/LibLLVM/EXPORTS.DEF
+++ b/src/LibLLVM/EXPORTS.DEF
@@ -31,6 +31,14 @@ LLVMComdatGetName
 LLVMGlobalObjectGetComdat
 LLVMGlobalObjectSetComdat
 
+LLVMModuleGetFirstGlobalAlias
+LLVMModuleGetNextGlobalAlias
+LLVMModuleGetFirstNamedMD
+LLVMModuleGetNextNamedMD
+
+LLVMContextGetIsODRUniquingDebugTypes
+LLVMContextSetIsODRUniquingDebugTypes
+
 LLVMCreatePassRegistry
 LLVMPassRegistryDispose
 LLVMAddModuleFlag

--- a/src/LibLLVM/LibLLVM.vcxproj
+++ b/src/LibLLVM/LibLLVM.vcxproj
@@ -178,6 +178,7 @@
   <ItemGroup>
     <ClCompile Include="AnalysisBindings.cpp" />
     <ClCompile Include="AttributeBindings.cpp" />
+    <ClCompile Include="ContextBindings.cpp" />
     <ClCompile Include="DIBuilderBindings.cpp" />
     <ClCompile Include="DITypeBindings.cpp" />
     <ClCompile Include="InlinedExports.cpp" />
@@ -190,6 +191,7 @@
   <ItemGroup>
     <ClInclude Include="AnalysisBindings.h" />
     <ClInclude Include="AttributeBindings.h" />
+    <ClInclude Include="ContextBindings.h" />
     <ClInclude Include="DIBuilderBindings.h" />
     <ClInclude Include="DITypeBindings.h" />
     <ClInclude Include="InlinedExports.h" />

--- a/src/LibLLVM/LibLLVM.vcxproj.filters
+++ b/src/LibLLVM/LibLLVM.vcxproj.filters
@@ -61,6 +61,9 @@
     <ClCompile Include="AttributeBindings.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ContextBindings.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DIBuilderBindings.h">
@@ -100,6 +103,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="AttributeBindings.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ContextBindings.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/LibLLVM/ModuleBindings.cpp
+++ b/src/LibLLVM/ModuleBindings.cpp
@@ -163,4 +163,44 @@ extern "C"
         Comdat const& comdat = *unwrap( comdatRef );
         return LLVMCreateMessage( comdat.getName( ).str( ).c_str( ) );
     }
+
+    LLVMValueRef LLVMModuleGetFirstGlobalAlias( LLVMModuleRef M )
+    {
+        Module *Mod = unwrap( M );
+        Module::alias_iterator I = Mod->alias_begin( );
+        if ( I == Mod->alias_end( ) )
+            return nullptr;
+
+        return wrap( &*I );
+    }
+
+    LLVMValueRef LLVMModuleGetNextGlobalAlias( LLVMValueRef valueRef )
+    {
+        GlobalAlias *pGA = unwrap<GlobalAlias>( valueRef );
+        Module::alias_iterator I( pGA );
+        if ( ++I == pGA->getParent( )->alias_end( ) )
+            return nullptr;
+
+        return wrap( &*I );
+    }
+
+    LLVMNamedMDNodeRef LLVMModuleGetFirstNamedMD( LLVMModuleRef M )
+    {
+        Module *Mod = unwrap( M );
+        Module::named_metadata_iterator I = Mod->named_metadata_begin( );
+        if ( I == Mod->named_metadata_end( ) )
+            return nullptr;
+
+        return wrap( &*I );
+    }
+
+    LLVMNamedMDNodeRef LLVMModuleGetNextNamedMD( LLVMNamedMDNodeRef /*NamedMDNode*/ valueRef )
+    {
+        NamedMDNode *pMD = unwrap( valueRef );
+        Module::named_metadata_iterator I( pMD );
+        if ( ++I == pMD->getParent( )->named_metadata_end( ) )
+            return nullptr;
+
+        return wrap( &*I );
+    }
 }

--- a/src/LibLLVM/ModuleBindings.h
+++ b/src/LibLLVM/ModuleBindings.h
@@ -81,6 +81,11 @@ extern "C" {
     void LLVMComdatSetKind( LLVMComdatRef comdatRef, LLVMComdatSelectionKind kind );
     char const* LLVMComdatGetName( LLVMComdatRef comdatRef );
 
+    // Alias enumeration
+    LLVMValueRef LLVMModuleGetFirstGlobalAlias( LLVMModuleRef M );
+    LLVMValueRef LLVMModuleGetNextGlobalAlias( LLVMValueRef /*GlobalAlias*/ valueRef );
+    LLVMNamedMDNodeRef LLVMModuleGetFirstNamedMD( LLVMModuleRef M );
+    LLVMNamedMDNodeRef LLVMModuleGetNextNamedMD( LLVMNamedMDNodeRef valueRef );
 #ifdef __cplusplus
 }
 

--- a/src/Llvm.NET.sln
+++ b/src/Llvm.NET.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2003
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Llvm.NET", "Llvm.NET\Llvm.NET.csproj", "{0162C8CE-6641-4922-8664-F8A44356FBF7}"
 EndProject
@@ -72,6 +72,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "InternalDetails", "Internal
 		..\docfx\articles\InternalDetails\handleref-interning.md = ..\docfx\articles\InternalDetails\handleref-interning.md
 		..\docfx\articles\InternalDetails\index.md = ..\docfx\articles\InternalDetails\index.md
 		..\docfx\articles\InternalDetails\llvm-handles.md = ..\docfx\articles\InternalDetails\llvm-handles.md
+		..\docfx\articles\InternalDetails\marshal-LLVMBool.md = ..\docfx\articles\InternalDetails\marshal-LLVMBool.md
+		..\docfx\articles\InternalDetails\marshal-string.md = ..\docfx\articles\InternalDetails\marshal-string.md
 		..\docfx\articles\InternalDetails\toc.md = ..\docfx\articles\InternalDetails\toc.md
 	EndProjectSection
 EndProject

--- a/src/Llvm.NET/DebugInfo/DebugType.cs
+++ b/src/Llvm.NET/DebugInfo/DebugType.cs
@@ -110,16 +110,11 @@ namespace Llvm.NET.DebugInfo
         /// <exception cref="InvalidOperationException">The native type was already set</exception>
         public TNative NativeType
         {
-            get => NativeType_;
+            get => NativeType_.ValueOrDefault;
 
             protected set
             {
-                if( NativeType_ != null )
-                {
-                    throw new InvalidOperationException( "Once the native type is set it cannot be changed" );
-                }
-
-                NativeType_ = value;
+                NativeType_.Value = value;
             }
         }
 
@@ -230,20 +225,20 @@ namespace Llvm.NET.DebugInfo
 
         internal DebugType( TNative llvmType )
         {
-            NativeType = llvmType ?? throw new ArgumentNullException( nameof( llvmType ) );
+            NativeType_.Value = llvmType ?? throw new ArgumentNullException( nameof( llvmType ) );
         }
 
-        // TODO: Leverage a generic WriteOnce<T> of some sort to enforce intentions in code rather than "by convention"
-        // this can't be an auto property as the setter needs Enforce Set Once semantics
+        // This can't be an auto property as the setter needs Enforce Set Once semantics
         [SuppressMessage( "StyleCop.CSharp.NamingRules"
                         , "SA1310:Field names must not contain underscore"
                         , Justification = "Trailing _ indicates value MUST NOT be written to directly, even internally"
                         )
         ]
-        private TNative NativeType_;
+        private readonly WriteOnce<TNative> NativeType_ = new WriteOnce<TNative>();
 
-        // TODO: Leverage a generic WriteOnce<T> of some sort to enforce intentions in code rather than "by convention"
-        // this can't be an auto property as the setter needs Enforce Set Once semantics
+        // This can't be an auto property as the setter needs Enforce Set Once semantics
+        // NOTE: WriteOnce isn't really viable here as this has a special case to allow replacing
+        // a temporary type.
         [SuppressMessage( "StyleCop.CSharp.NamingRules"
                         , "SA1310:Field names must not contain underscore"
                         , Justification = "Trailing _ indicates value MUST NOT be written to directly, even internally"

--- a/src/Llvm.NET/IBitcodeModuleFactory.cs
+++ b/src/Llvm.NET/IBitcodeModuleFactory.cs
@@ -12,7 +12,7 @@ namespace Llvm.NET
     /// Modules are owned by the context and thus not created, freestanding.
     /// This interface provides factory methods for constructing modules. It
     /// is implemented by the <see cref="Context"/> and also internally by
-    /// the handle caches that ultimately call the inderlying LLVM module
+    /// the handle caches that ultimately call the underlying LLVM module
     /// creation APIs.
     /// </remarks>
     public interface IBitcodeModuleFactory

--- a/src/Llvm.NET/MemoryBuffer.cs
+++ b/src/Llvm.NET/MemoryBuffer.cs
@@ -20,11 +20,12 @@ namespace Llvm.NET
         public MemoryBuffer( string path )
         {
             path.ValidateNotNullOrWhiteSpace( nameof( path ) );
-
-            if( LLVMCreateMemoryBufferWithContentsOfFile( path, out BufferHandle_, out string msg ).Failed )
+            if( LLVMCreateMemoryBufferWithContentsOfFile( path, out LLVMMemoryBufferRef handle, out string msg ).Failed )
             {
                 throw new InternalCodeGeneratorException( msg );
             }
+
+            BufferHandle_.Value = handle;
         }
 
         /// <summary>Gets the size of the buffer</summary>
@@ -55,12 +56,11 @@ namespace Llvm.NET
         {
             bufferHandle.ValidateNotDefault( nameof( bufferHandle ) );
 
-            BufferHandle_ = bufferHandle;
+            BufferHandle_.Value = bufferHandle;
         }
 
         internal LLVMMemoryBufferRef BufferHandle => BufferHandle_;
 
-        // TODO: Consider some form of WriteOnce<T> to enforce semantics and not rely on a coment
         // keep as a private field so this is usable as an out parameter in constructor
         // do not write to it directly, treat it as readonly.
         [SuppressMessage( "StyleCop.CSharp.NamingRules"
@@ -68,7 +68,7 @@ namespace Llvm.NET
                         , Justification = "Trailing _ indicates should not be written to directly even internally"
                         )
         ]
-        private LLVMMemoryBufferRef BufferHandle_;
+        private readonly WriteOnce<LLVMMemoryBufferRef> BufferHandle_ = new WriteOnce<LLVMMemoryBufferRef>();
 
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
         private static extern LLVMStatus LLVMCreateMemoryBufferWithContentsOfFile( [MarshalAs( UnmanagedType.LPStr )] string @Path

--- a/src/Llvm.NET/Metadata/OperandBundleNames.cs
+++ b/src/Llvm.NET/Metadata/OperandBundleNames.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="OperandBundleNames.cs" company=".NET Foundation">
+// Copyright (c) .NET Foundation. All rights reserved.
+// </copyright>
+
+namespace Llvm.NET
+{
+    /// <summary>Static class to hold constant strings for well known operand bundle tag names</summary>
+    public static class OperandBundleNames
+    {
+        /// <summary>Name of the well-known deopt operand bundle</summary>
+        public const string DeOpt = "deopt";
+
+        /// <summary>Name of the well-known funclet operand bundle</summary>
+        public const string Funclet = "funclet";
+
+        /// <summary>Name of the well-known gc-transition operand bundle</summary>
+        public const string GcTransition = "gc-transition";
+    }
+}

--- a/src/Llvm.NET/Native/CustomGenerated.cs
+++ b/src/Llvm.NET/Native/CustomGenerated.cs
@@ -486,9 +486,6 @@ namespace Llvm.NET.Native
         internal static extern LLVMValueRef LLVMGetGlobalAlias( LLVMModuleRef module, [MarshalAs( UnmanagedType.LPStr )] string name );
 
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
-        internal static extern LLVMValueRef LLVMGetAliasee( LLVMValueRef Val );
-
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
         internal static extern void LLVMMDNodeResolveCycles( LLVMMetadataRef M );
 
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]

--- a/src/Llvm.NET/Native/Generated.cs
+++ b/src/Llvm.NET/Native/Generated.cs
@@ -617,9 +617,6 @@ namespace Llvm.NET.Native
         [DllImport( LibraryPath, EntryPoint = "LLVMContextSetYieldCallback", CallingConvention = CallingConvention.Cdecl )]
         internal static extern void LLVMContextSetYieldCallback( LLVMContextRef @C, LLVMYieldCallback @Callback, IntPtr @OpaqueHandle );
 
-        [DllImport( LibraryPath, EntryPoint = "LLVMGetMDKindIDInContext", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
-        internal static extern uint LLVMGetMDKindIDInContext( LLVMContextRef @C, [MarshalAs( UnmanagedType.LPStr )] string @Name, uint @SLen );
-
         [DllImport( LibraryPath, EntryPoint = "LLVMParseIRInContext", CallingConvention = CallingConvention.Cdecl )]
         internal static extern LLVMStatus LLVMParseIRInContext( LLVMContextRef @ContextRef, LLVMMemoryBufferRef @MemBuf, out LLVMModuleRef @OutM, out IntPtr @OutMessage );
         #endregion
@@ -685,11 +682,8 @@ namespace Llvm.NET.Native
         [DllImport( LibraryPath, EntryPoint = "LLVMGetDataLayoutStr", CallingConvention = CallingConvention.Cdecl )]
         internal static extern IntPtr LLVMGetDataLayoutStr( LLVMModuleRef @M );
 
-        [DllImport( LibraryPath, EntryPoint = "LLVMGetDataLayout", CallingConvention = CallingConvention.Cdecl )]
-        internal static extern IntPtr LLVMGetDataLayout( LLVMModuleRef @M );
-
         [DllImport( LibraryPath, EntryPoint = "LLVMSetDataLayout", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ThrowOnUnmappableChar = true, BestFitMapping = false )]
-        internal static extern void LLVMSetDataLayout( LLVMModuleRef @M, [MarshalAs( UnmanagedType.LPStr )] string @DataLayoutStr );
+        internal static extern void LLVMSetDataLayoutStr( LLVMModuleRef @M, [MarshalAs( UnmanagedType.LPStr )] string @DataLayoutStr );
 
         [DllImport( LibraryPath, EntryPoint = "LLVMGetTarget", CallingConvention = CallingConvention.Cdecl )]
         [return: MarshalAs( UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof( StringMarshaler ) )]

--- a/src/Llvm.NET/Native/ValueKind.cs
+++ b/src/Llvm.NET/Native/ValueKind.cs
@@ -14,7 +14,7 @@ namespace Llvm.NET.Native
 
         Function = LLVMValueKind.LLVMFunctionValueKind,              // This is an instance of Function
         GlobalAlias = LLVMValueKind.LLVMGlobalAliasValueKind,           // This is an instance of GlobalAlias
-        GlobalIFunc = LLVMValueKind.LLVMGlobalIFuncValueKind,           // ???
+        GlobalIFunc = LLVMValueKind.LLVMGlobalIFuncValueKind,           // Global Indirect Function (derived from GlobalIndirectSymbol)
         GlobalVariable = LLVMValueKind.LLVMGlobalVariableValueKind,        // This is an instance of GlobalVariable
         BlockAddress = LLVMValueKind.LLVMBlockAddressValueKind,          // This is an instance of BlockAddress
         ConstantExpr = LLVMValueKind.LLVMConstantExprValueKind,          // This is an instance of ConstantExpr

--- a/src/Llvm.NET/Types/TypeRef.cs
+++ b/src/Llvm.NET/Types/TypeRef.cs
@@ -83,14 +83,7 @@ namespace Llvm.NET.Types
         }
 
         /// <inheritdoc/>
-        public bool IsPointerPointer
-        {
-            get
-            {
-                var ptrType = this as IPointerType;
-                return ptrType != null && ptrType.ElementType.Kind == TypeKind.Pointer;
-            }
-        }
+        public bool IsPointerPointer => (this is IPointerType ptrType) && ptrType.ElementType.Kind == TypeKind.Pointer;
 
         /// <inheritdoc/>
         public Context Context => GetContextFor( TypeRefHandle );

--- a/src/Llvm.NET/Values/GlobalAlias.cs
+++ b/src/Llvm.NET/Values/GlobalAlias.cs
@@ -8,26 +8,13 @@ namespace Llvm.NET.Values
 {
     /// <summary>LLVM Global Alias for a function or global value</summary>
     public class GlobalAlias
-        : GlobalValue
+        : GlobalIndirectSymbol
     {
-        /// <summary>Gets the aliasee that this Alias refers to</summary>
+        /// <summary>Gets or sets the aliasee that this Alias refers to</summary>
         public Constant Aliasee
         {
-            get
-            {
-                if( ValueHandle == default )
-                {
-                    return null;
-                }
-
-                var handle = NativeMethods.LLVMGetAliasee( ValueHandle );
-                if( handle == default )
-                {
-                    return null;
-                }
-
-                return FromHandle<Constant>( handle );
-            }
+            get => IndirectSymbol;
+            set => IndirectSymbol = value;
         }
 
         internal GlobalAlias( LLVMValueRef valueRef )

--- a/src/Llvm.NET/Values/GlobalIFunc.cs
+++ b/src/Llvm.NET/Values/GlobalIFunc.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="GlobalIFunc.cs" company=".NET Foundation">
+// Copyright (c) .NET Foundation. All rights reserved.
+// </copyright>
+
+using Llvm.NET.Native;
+
+namespace Llvm.NET.Values
+{
+    /// <summary>Global Indirect Function</summary>
+    /// <remarks>
+    /// represents a single indirect function in the IR. Indirect function uses
+    /// ELF symbol type extension to mark that the address of a declaration should
+    /// be resolved at runtime by calling a resolver function.
+    /// </remarks>
+    public class GlobalIFunc
+        : GlobalIndirectSymbol
+    {
+        /// <summary>Gets or sets the ifunc resolver</summary>
+        public Constant Resolver
+        {
+            get => IndirectSymbol;
+            set => IndirectSymbol = value;
+        }
+
+        internal GlobalIFunc( LLVMValueRef handle )
+            : base( handle )
+        {
+        }
+    }
+}

--- a/src/Llvm.NET/Values/GlobalIndirectSymbol.cs
+++ b/src/Llvm.NET/Values/GlobalIndirectSymbol.cs
@@ -1,0 +1,25 @@
+﻿// <copyright file="GlobalIndirectSymbol.cs" company=".NET Foundation">
+// Copyright (c) .NET Foundation. All rights reserved.
+// </copyright>
+
+using Llvm.NET.Native;
+
+namespace Llvm.NET.Values
+{
+    /// <summary>Global Indirect Symbol</summary>
+    public class GlobalIndirectSymbol
+        : GlobalValue
+    {
+        /// <summary>Gets or sets the symbol this inderctly references</summary>
+        public Constant IndirectSymbol
+        {
+            get => GetOperand<Constant>( 0 );
+            set => Operands[ 0 ] = value;
+        }
+
+        internal GlobalIndirectSymbol( LLVMValueRef handle )
+            : base( handle )
+        {
+        }
+    }
+}

--- a/src/Llvm.NET/Values/GlobalObject.cs
+++ b/src/Llvm.NET/Values/GlobalObject.cs
@@ -56,14 +56,11 @@ namespace Llvm.NET.Values
         }
 
         /* TODO: Add GlobalObject metadata accessors
-        public MDNode GetMetadata(unsigned kindID) {...}
-        public MDNode GetMetadata(string kind) {...}
+        public IEnumerable<MDNode> GetMetadata() {...}
 
-        public MDNode GetMetadata(unsigned kindID, IEnumerable<MDNode> nodes) {...}
-        public MDNode GetMetadata(string kind, IEnumerable<MDNode> nodes) {...}
 
-        public MDNode SetMetadata(unsigned kindID, MDNode node) {...}
-        public MDNode SetMetadata(string kind, MDNode node) {...}
+        public void SetMetadata(unsigned kindID, MDNode node) {...}
+        public void SetMetadata(string kind, MDNode node) {...}
         */
         internal GlobalObject( LLVMValueRef valueRef )
             : base( valueRef )

--- a/src/Llvm.NET/Values/Value.cs
+++ b/src/Llvm.NET/Values/Value.cs
@@ -171,6 +171,9 @@ namespace Llvm.NET.Values
                 case ValueKind.GlobalVariable:
                     return new GlobalVariable( handle );
 
+                case ValueKind.GlobalIFunc:
+                    return new GlobalIFunc( handle );
+
                 case ValueKind.UndefValue:
                     return new UndefValue( handle );
 
@@ -374,6 +377,7 @@ namespace Llvm.NET.Values
                 case ValueKind.CatchSwitch:
                     return new Instructions.CatchSwitch( handle );
 
+                // Default to constant, Instruction or generic base Value
                 default:
                     if( kind >= ValueKind.ConstantFirstVal && kind <= ValueKind.ConstantLastVal )
                     {

--- a/src/Llvm.NET/WriteOnce.cs
+++ b/src/Llvm.NET/WriteOnce.cs
@@ -1,0 +1,78 @@
+﻿// <copyright file="WriteOnce.cs" company=".NET Foundation">
+// Copyright (c) .NET Foundation. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace Llvm.NET
+{
+    /// <summary>Wrapper class to provide Write-Once semenatics to a value</summary>
+    /// <typeparam name="T">TYpe of value to store</typeparam>
+    /// <remarks>
+    /// This provides write once semantics for fields that may require initialization
+    /// outside the context of a constructor, but once set should never be set again.
+    /// Allowing a sort of lazy <see langword="readonly"/>.
+    /// </remarks>
+    [System.Diagnostics.DebuggerDisplay( "{ValueOrDefault}" )]
+    internal sealed class WriteOnce<T>
+    {
+        /// <inheritdoc/>
+        public override string ToString( )
+        {
+            return HasValue ? Convert.ToString( ActualValue ) : string.Empty;
+        }
+
+        /// <summary>Gets or sets the value for this instance</summary>
+        /// <exception cref="InvalidOperationException">Getting the value when no value is set</exception>
+        /// <exception cref="InvalidOperationException">Setting the value when a value is already set</exception>
+        public T Value
+        {
+            get
+            {
+                if( !HasValue )
+                {
+                    throw new InvalidOperationException( "Value not set" );
+                }
+
+                return ActualValue;
+            }
+
+            set
+            {
+                if( HasValue )
+                {
+                    throw new InvalidOperationException( "Value already set" );
+                }
+
+                ActualValue = value;
+                HasValue = true;
+            }
+        }
+
+        /// <summary>Initializer</summary>
+        /// <param name="value">value to initialize</param>
+        public delegate void Initializer( out T value );
+
+        /// <summary>Initializes the value via a delegate using an out parameter</summary>
+        /// <param name="initializer">delegate to initialize the value from</param>
+        /// <returns>This instance for fluent style use</returns>
+        public WriteOnce<T> InitializeWith( Initializer initializer )
+        {
+            initializer( out ActualValue );
+            HasValue = true;
+            return this;
+        }
+
+        /// <summary>Gets a value indicating whether the <see cref="Value"/> was set or not</summary>
+        public bool HasValue { get; private set; }
+
+        /// <summary>Gets the current value or the default value for <typeparamref name="T"/> if not yet set</summary>
+        public T ValueOrDefault => ActualValue;
+
+        /// <summary>Convenieance implicit cast as a wrapper around the <see cref="Value"/> parameter</summary>
+        /// <param name="value"> <see cref="WriteOnce{T}"/> instance to extract a value from</param>
+        public static implicit operator T( WriteOnce<T> value ) => value.Value;
+
+        private T ActualValue;
+    }
+}

--- a/src/Llvm.NETTests/Llvm.NETTests.csproj
+++ b/src/Llvm.NETTests/Llvm.NETTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-      <TargetFramework>net47</TargetFramework>
+      <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(BuildRootDir)src\Llvm.NET\Llvm.NET.csproj">


### PR DESCRIPTION
* Removed redundant arg validator now that ValidateNotDefault is in nuget pkg
* Added GlobalIndirectSymbol
* Added GlobalIfunc
* Added WriteOnce<T> class and applied to several places
* Added Module.GetMDKind()
* Added Module.Aliases
* Added Module.NamedMetadata
* Added docs on internal marshal support for LLVMBool and strings
* Added Context bindings to support ODR unique debug types
* removed obsoleted P/Invoke APIs
* Changed typ of values enumerated from BitCodeModule.Globals to reflect actual underlying type as GlobalVariable. This non-breaking as it is a more derived type and makes it easier to get at the additional info from the GlobalVariable type.
* Minor refactorings and corrections