### PR TITLE
Added more docs on Kaleidoscope

### DIFF
--- a/Samples/Kaleidoscope/Chapter2/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter2/CodeGenerator.cs
@@ -14,6 +14,11 @@ using static Kaleidoscope.Grammar.KaleidoscopeParser;
 namespace Kaleidoscope
 {
     /// <summary>Static extension methods to perform LLVM IR Code generation from the Kaledoscope AST</summary>
+    /// <remarks>
+    /// This doesn't actually generate any code. The only thing it does is to record any user defined operators
+    /// in the <see cref="DynamicRuntimeState"/> so that subsequent parsing takes the operator precednece into
+    /// account. (If the language didn't support user defined precedence this would not be needed at all)
+    /// </remarks>
     internal sealed class CodeGenerator
         : KaleidoscopeBaseVisitor<int>
         , IDisposable
@@ -30,6 +35,11 @@ namespace Kaleidoscope
 
         public int Generate( Parser parser, IParseTree tree, DiagnosticRepresentations additionalDiagnostics )
         {
+            if( parser.NumberOfSyntaxErrors > 0 )
+            {
+                return 0;
+            }
+
             return Visit( tree );
         }
 

--- a/Samples/Kaleidoscope/Chapter2/Program.cs
+++ b/Samples/Kaleidoscope/Chapter2/Program.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using Antlr4.Runtime.Tree;
 using Kaleidoscope.Grammar;
 using Kaleidoscope.Runtime;
 
@@ -27,7 +26,11 @@ namespace Kaleidoscope
             {
                 Console.WriteLine( "LLVM Kaleidoscope Syntax Viewer - {0}", parser.LanguageLevel );
 
-                var replLoop = new ReplLoop<int>( generator, parser, DiagnosticRepresentations.Xml | DiagnosticRepresentations.Dgml );
+                // generate hopefully helpful representations of parse trees
+                var replLoop = new ReplLoop<int>( generator
+                                                , parser
+                                                , DiagnosticRepresentations.Xml | DiagnosticRepresentations.Dgml | DiagnosticRepresentations.BlockDiag
+                                                );
                 replLoop.ReadyStateChanged += ( s, e ) => Console.Write( e.PartialParse ? ">" : "Ready>" );
                 replLoop.GeneratedResultAvailable += OnGeneratedResultAvailable;
 
@@ -37,11 +40,10 @@ namespace Kaleidoscope
 
         private static void OnGeneratedResultAvailable( object sender, GeneratedResultAvailableArgs<int> e )
         {
-            var docListener = new XDocumentListener( e.Recognizer );
-            ParseTreeWalker.Default.Walk( docListener, e.ParseTree );
-            Console.WriteLine( "Parsed:" );
-            docListener.Document.Save( Console.Out );
-            Console.WriteLine( );
+            if( e.Recognizer.NumberOfSyntaxErrors == 0 )
+            {
+                Console.WriteLine( "Parsed {0}", e.ParseTree.GetType( ).Name );
+            }
         }
     }
 }

--- a/Samples/Kaleidoscope/Chapter3/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter3/CodeGenerator.cs
@@ -16,6 +16,8 @@ using Llvm.NET.Values;
 
 using static Kaleidoscope.Grammar.KaleidoscopeParser;
 
+#pragma warning disable SA1512, SA1513, SA1515 // single line comments used to tag regions for extraction into docs
+
 namespace Kaleidoscope
 {
     /// <summary>Static extension methods to perform LLVM IR Code generation from the Kaledoscope AST</summary>
@@ -24,6 +26,7 @@ namespace Kaleidoscope
         , IDisposable
         , IKaleidoscopeCodeGenerator<Value>
     {
+        // <Initialization>
         public CodeGenerator( DynamicRuntimeState globalState )
         {
             RuntimeState = globalState;
@@ -32,6 +35,7 @@ namespace Kaleidoscope
             InstructionBuilder = new InstructionBuilder( Context );
             NamedValues = new Dictionary<string, Value>( );
         }
+        // </Initialization>
 
         public void Dispose( )
         {
@@ -219,11 +223,13 @@ namespace Kaleidoscope
             return function;
         }
 
+        // <PrivateMembers>
         private readonly DynamicRuntimeState RuntimeState;
         private static int AnonNameIndex;
         private readonly Context Context;
         private BitcodeModule Module;
         private readonly InstructionBuilder InstructionBuilder;
         private readonly IDictionary<string, Value> NamedValues;
+        // </PrivateMembers>
     }
 }

--- a/Samples/Kaleidoscope/Kaleidoscope.Parser/AntlrUtilities.cs
+++ b/Samples/Kaleidoscope/Kaleidoscope.Parser/AntlrUtilities.cs
@@ -20,6 +20,11 @@ namespace Kaleidoscope.Grammar
         /// <returns>Character based interval covered by the context</returns>
         public static Interval GetCharInterval( this ParserRuleContext ruleContext )
         {
+            if( ruleContext.start.Type == Recognizer<IToken, Antlr4.Runtime.Atn.ParserATNSimulator>.Eof )
+            {
+                return Interval.Invalid;
+            }
+
             int startChar = ruleContext.Start.StartIndex;
             int endChar = ruleContext.Stop.StopIndex - 1;
             return Interval.Of( Min( startChar, endChar ), Max( startChar, endChar ) );

--- a/Samples/Kaleidoscope/Kaleidoscope.Parser/BlockDiagGenerator.cs
+++ b/Samples/Kaleidoscope/Kaleidoscope.Parser/BlockDiagGenerator.cs
@@ -1,0 +1,68 @@
+﻿// <copyright file="BlockDiagGenerator.cs" company=".NET Foundation">
+// Copyright (c) .NET Foundation. All rights reserved.
+// </copyright>
+
+#if NET47
+using System.CodeDom.Compiler;
+using System.IO;
+
+namespace Kaleidoscope.Grammar
+{
+    /// <summary>Extension class to generate a blockdiag file from a DGML graph</summary>
+    /// <remarks>
+    /// <para>This isn't a generator in the same sense that the <see cref="DgmlGenerator"/> and
+    /// <see cref="XDocumentListener"/> are. Rather it is an extension class that allows
+    /// generating a blockdiag diagram, from the directed graph created by the DgmlGenerator.
+    /// The resulting ".diag" file is convertible to SVG form for documentation.</para>
+    /// <para>
+    /// The generated diagrams include a numbered element for binary operator expressions
+    /// to indicate the precedence value that is diyamically evaluated for the expression.
+    /// This is particularly useful for debugging custom operator precedence problems.
+    /// </para>
+    /// </remarks>
+    /// <seealso href="http://blockdiag.com"/>
+    public static class BlockDiagGenerator
+    {
+        public static void WriteBlockDiag( this DgmlGenerator generator, string file )
+        {
+            using( var strmWriter = new StreamWriter( File.Open( file, FileMode.Create, FileAccess.ReadWrite, FileShare.None ) ) )
+            using( var writer = new IndentedTextWriter( strmWriter, "    " ) )
+            {
+                writer.WriteLine( "blockdiag" );
+                writer.WriteLine( '{' );
+                ++writer.Indent;
+                writer.WriteLine( "default_shape = roundedbox" );
+                writer.WriteLine( "orientation = portrait" );
+
+                writer.WriteLineNoTabs( string.Empty );
+                writer.WriteLine( "// Nodes" );
+                foreach( var node in generator.Graph.Nodes )
+                {
+                    writer.Write( "N{0} [label= \"{1}\"", node.Id, node.Label );
+                    if( node.Properties.TryGetValue("Precedence", out object precedence))
+                    {
+                        writer.Write( ", numbered = {0}", precedence );
+                    }
+
+                    if( node.Category == "Terminal")
+                    {
+                        writer.Write( ", shape = circle" );
+                    }
+
+                    writer.WriteLine("];");
+                }
+
+                writer.WriteLineNoTabs( string.Empty );
+                writer.WriteLine( "// Edges" );
+                foreach( var link in generator.Graph.Links )
+                {
+                    writer.WriteLine( "N{0} -> N{1}", link.Source, link.Target );
+                }
+
+                --writer.Indent;
+                writer.WriteLine( '}' );
+            }
+        }
+    }
+}
+#endif

--- a/Samples/Kaleidoscope/Kaleidoscope.Parser/DgmlGenerator.cs
+++ b/Samples/Kaleidoscope/Kaleidoscope.Parser/DgmlGenerator.cs
@@ -14,7 +14,7 @@ namespace Kaleidoscope.Grammar
 {
     /// <summary>Parse tree listener to generate a DGML Graph of the parsed syntax</summary>
     /// <remarks>
-    /// This is similar to ther <see cref="XDocumentListener"/> but allows writing to a
+    /// This is similar to the <see cref="XDocumentListener"/> but allows writing to a
     /// DGML file for visualizing in VisualStudio or any available DGML viewer.
     /// </remarks>
     public class DgmlGenerator
@@ -49,8 +49,7 @@ namespace Kaleidoscope.Grammar
 
         public override void EnterExpression( [NotNull] ExpressionContext context )
         {
-            base.EnterExpression( context );
-            ActiveNode.Properties.Add( "ChildCount", context.ChildCount );
+            ActiveNode.Properties.Add( "Precedence", context._p );
         }
 
         public override void VisitTerminal( [NotNull] ITerminalNode node )
@@ -114,6 +113,8 @@ namespace Kaleidoscope.Grammar
             Graph.WriteToFile( path );
         }
 
+        internal DirectedGraph Graph { get; } = new DirectedGraph( );
+
         private Node ActiveNode => NodeStack.Peek();
 
         private Node Pop( )
@@ -130,7 +131,6 @@ namespace Kaleidoscope.Grammar
         private const string ContextTypeNameSuffix = "Context";
 
         private KaleidoscopeParser Recognizer;
-        private DirectedGraph Graph = new DirectedGraph();
         private Stack<Node> NodeStack = new Stack<Node>();
     }
 }

--- a/Samples/Kaleidoscope/Kaleidoscope.Parser/Kaleidoscope.g4
+++ b/Samples/Kaleidoscope/Kaleidoscope.Parser/Kaleidoscope.g4
@@ -6,8 +6,6 @@
 //
 grammar Kaleidoscope;
 
-// <Lexer>
-
 // Lexer Rules -------
 fragment NonZeroDecimalDigit_: [1-9];
 fragment DecimalDigit_: [0-9];
@@ -50,7 +48,6 @@ NOTEQUAL: '!=';
 PLUSPLUS: '++';
 MINUSMINUS: '--';
 
-// <FeatureControlledKeywords>
 IF:     {FeatureControlFlow}? 'if';
 THEN:   {FeatureControlFlow}? 'then';
 ELSE:   {FeatureControlFlow}? 'else';
@@ -59,16 +56,13 @@ IN:     {FeatureControlFlow}? 'in';
 VAR:    {FeatureMutableVars}? 'var';
 UNARY:  {FeatureUserOperators}? 'unary';
 BINARY: {FeatureUserOperators}? 'binary';
-// </FeatureControlledKeywords>
 
 LineComment: '#' ~[\r\n]* EndOfLine_ -> skip;
 WhiteSpace: [ \t\r\n\f]+ -> skip;
 
 Identifier: [a-zA-Z][a-zA-Z0-9]*;
 Number: Digits_ ('.' DecimalDigit_+)?;
-// </Lexer>
 
-// <Parser>
 // Parser rules ------
 
 // built-in operator symbols
@@ -109,13 +103,47 @@ unaryop
     | SLASH
     | LEFTANGLE
     | CARET
-    | userdefinedop
+    | EXCLAMATION
+    | PERCENT
+    | AMPERSAND
+    | PERIOD
+    | COLON
+    | RIGHTANGLE
+    | QMARK
+    | ATSIGN
+    | BACKSLASH
+    | UNDERSCORE
+    | VBAR
+    | EQUALEQUAL
+    | NOTEQUAL
+    | PLUSPLUS
+    | MINUSMINUS
     ;
 
 // All binary operators
 binaryop
-    : builtinop
-    | userdefinedop
+    : ASSIGN
+    | ASTERISK
+    | PLUS
+    | MINUS
+    | SLASH
+    | LEFTANGLE
+    | CARET
+    | EXCLAMATION
+    | PERCENT
+    | AMPERSAND
+    | PERIOD
+    | COLON
+    | RIGHTANGLE
+    | QMARK
+    | ATSIGN
+    | BACKSLASH
+    | UNDERSCORE
+    | VBAR
+    | EQUALEQUAL
+    | NOTEQUAL
+    | PLUSPLUS
+    | MINUSMINUS
     ;
 
 // pull the initializer out to a distinct rule so it is easier to get at
@@ -133,7 +161,8 @@ primaryExpression
     | FOR initializer COMMA expression[0] (COMMA expression[0])? IN expression[0] # ForExpression
     | {IsPrefixOp()}? unaryop expression[0]                                       # UnaryOpExpression
     | Identifier                                                                  # VariableExpression
-    | Number                                                                      # ConstExpression;
+    | Number                                                                      # ConstExpression
+    ;
 
 // Need to make precedence handling explicit in the code behind
 // since precedence is potentially user defined at runtime.
@@ -155,4 +184,3 @@ repl
     | expression[0]               # TopLevelExpression
     | SEMICOLON                   # TopLevelSemicolon
     ;
-// </Parser>

--- a/Samples/Kaleidoscope/Kaleidoscope.Parser/XDocumentListener.cs
+++ b/Samples/Kaleidoscope/Kaleidoscope.Parser/XDocumentListener.cs
@@ -15,7 +15,7 @@ namespace Kaleidoscope.Grammar
     {
         public XDocumentListener( IRecognizer recognizer )
         {
-            Document = new XDocument( );
+            Document = new XDocument( ) { Declaration = new XDeclaration( "1.0", "utf-8", "yes" ) };
             Push( new XElement( "Kaleidoscope" ) );
             Recognizer = recognizer;
         }

--- a/Samples/Kaleidoscope/Kaleidoscope.Runtime/GeneratedResultAvailableArgs.cs
+++ b/Samples/Kaleidoscope/Kaleidoscope.Runtime/GeneratedResultAvailableArgs.cs
@@ -11,7 +11,7 @@ namespace Kaleidoscope.Runtime
     public class GeneratedResultAvailableArgs<TResult>
         : EventArgs
     {
-        public GeneratedResultAvailableArgs( TResult result, IRecognizer recognizer, IParseTree parseTree )
+        public GeneratedResultAvailableArgs( TResult result, Parser recognizer, IParseTree parseTree )
         {
             Result = result;
             ParseTree = parseTree;
@@ -22,6 +22,6 @@ namespace Kaleidoscope.Runtime
 
         public IParseTree ParseTree { get; }
 
-        public IRecognizer Recognizer { get; }
+        public Parser Recognizer { get; }
     }
 }

--- a/Samples/Kaleidoscope/Kaleidoscope.Runtime/IKaleidoscopeCodeGenerator.cs
+++ b/Samples/Kaleidoscope/Kaleidoscope.Runtime/IKaleidoscopeCodeGenerator.cs
@@ -21,6 +21,9 @@ namespace Kaleidoscope.Runtime
         /// <summary>Generate a DGML representation of the parse tree</summary>
         Dgml,
 
+        /// <summary>Generates a BlockDiag representation of the parse tree</summary>
+        BlockDiag,
+
         /// <summary>Generate a textual representation of the Lllvm IR</summary>
         LlvmIR,
 

--- a/Samples/Kaleidoscope/Kaleidoscope.Runtime/ReplLoop.cs
+++ b/Samples/Kaleidoscope/Kaleidoscope.Runtime/ReplLoop.cs
@@ -12,17 +12,17 @@ namespace Kaleidoscope.Runtime
     public class ReplLoop<TResult>
     {
         public ReplLoop( IKaleidoscopeCodeGenerator<TResult> generator, LanguageLevel languageLevel )
-            : this( generator, new ReplParserStack( languageLevel ), DiagnosticRepresentations.None, Console.In, Console.Out )
+            : this( generator, new ReplParserStack( languageLevel ), DiagnosticRepresentations.None, Console.In )
         {
         }
 
         public ReplLoop( IKaleidoscopeCodeGenerator<TResult> generator, IKaleidoscopeParser parser )
-            : this( generator, parser, DiagnosticRepresentations.None, Console.In, Console.Out )
+            : this( generator, parser, DiagnosticRepresentations.None, Console.In )
         {
         }
 
         public ReplLoop( IKaleidoscopeCodeGenerator<TResult> generator, IKaleidoscopeParser parser, DiagnosticRepresentations additionalDiagnostics )
-            : this( generator, parser, additionalDiagnostics, Console.In, Console.Out )
+            : this( generator, parser, additionalDiagnostics, Console.In)
         {
         }
 
@@ -30,13 +30,11 @@ namespace Kaleidoscope.Runtime
                        , IKaleidoscopeParser parser
                        , DiagnosticRepresentations additionalDiagnostics
                        , TextReader inputReader
-                       , TextWriter outputWriter
                        )
         {
             Parser = parser;
             Generator = generator;
             Input = inputReader;
-            Output = outputWriter;
             AdditionalDiagnostics = additionalDiagnostics;
         }
 
@@ -98,6 +96,5 @@ namespace Kaleidoscope.Runtime
         private readonly IKaleidoscopeParser Parser;
         private readonly IKaleidoscopeCodeGenerator<TResult> Generator;
         private readonly TextReader Input;
-        private readonly TextWriter Output;
     }
 }

--- a/Samples/Kaleidoscope/Kaleidoscope.Runtime/ReplParserStack.cs
+++ b/Samples/Kaleidoscope/Kaleidoscope.Runtime/ReplParserStack.cs
@@ -97,11 +97,21 @@ namespace Kaleidoscope.Runtime
                     docListener.Document.Save("ParseTree.xml");
                 }
 #if NET47
-                if( aditionalDiagnostics.HasFlag( DiagnosticRepresentations.Dgml ) )
+                if( aditionalDiagnostics.HasFlag( DiagnosticRepresentations.Dgml ) || aditionalDiagnostics.HasFlag( DiagnosticRepresentations.BlockDiag ) )
                 {
+                    // both forms share the same initial DirectedGraph model as the formats are pretty similar
                     var dgmlGenerator = new DgmlGenerator( Parser );
                     ParseTreeWalker.Default.Walk( dgmlGenerator, parseTree );
-                    dgmlGenerator.WriteDgmlGraph( "ParseTree.dgml" );
+
+                    if( aditionalDiagnostics.HasFlag( DiagnosticRepresentations.Dgml ) )
+                    {
+                        dgmlGenerator.WriteDgmlGraph( "ParseTree.dgml" );
+                    }
+
+                    if( aditionalDiagnostics.HasFlag( DiagnosticRepresentations.BlockDiag ) )
+                    {
+                        dgmlGenerator.WriteBlockDiag( "ParseTree.diag" );
+                    }
                 }
 #endif
                 return (parseTree, Parser);

--- a/docfx/articles/Samples/Kaleidoscope-Parsetree-examples.md
+++ b/docfx/articles/Samples/Kaleidoscope-Parsetree-examples.md
@@ -1,0 +1,82 @@
+# Parse Tree Examples
+
+## Simple Expressions (Chapters 3,4)
+
+### Basic operators
+
+`1 + 2 * 3 - 4 / 5 ^ 6;`
+
+![Parse Tree](parsetree-simpleexp-1.svg)
+
+>[!NOTE]
+>The small circle in the upper left corner of the Expression nodes is the precedence value at
+>the entry to the rule. ANTLR uses a precendence climbing algorithm so this number indicates
+>the precedence for the expression in relation to others.
+
+>[!NOTE]
+>The parse tree for the expression has 5 children that are in evaluation order. That is,
+>evaluation of the expression starts at the left most child and proceeds across to the right
+>most child. Since, all binary operations include an operator symbol the evaluation would
+>consume the children (other than the first one) as an operator and right hand side pair.
+>this is used in the code generation when processing expression nodes.
+
+### If-Else control flow
+Given the following definition of a recursive function to compute
+fibonacci numbers
+```Kaleidoscope
+def fib(x)
+  if (x < 3) then
+    1
+  else
+    fib(x-1)+fib(x-2);
+```
+
+The parse tree looks like this:
+
+![Parse Tree](parsetree-if-else.svg)
+
+### For loop
+Given the following kaleidoscope function definition:
+``` Kaleidoscope
+extern putchard(char);
+def printstar(n)
+  for i = 1, i < n, 1.0 in
+    putchard(42)  # ascii 42 = '*'
+```
+The parse tree looks like this:
+
+![Parse Tree](parsetree-for-loop.svg)
+
+### User defined operators
+
+Given the following operator definitions:
+
+```Kaleidoscope
+# Logical unary not.
+def unary!(v)
+  if v then
+    0
+  else
+    1;
+
+# Define > with the same precedence as <.
+def binary> 10 (LHS RHS)
+  RHS < LHS;
+
+# Binary "logical or", (note that it does not "short circuit")
+def binary| 5 (LHS RHS)
+  if LHS then
+    1
+  else if RHS then
+    1
+  else
+    0;
+
+# Define = with slightly lower precedence than relationals.
+def binary== 9 (LHS RHS)
+  !(LHS < RHS | LHS > RHS);
+```
+
+The epression `2 == 3 | 5 < 4 | !1;` generates the following parse tree
+
+![Parse Tree](parsetree-userops.svg)

--- a/docfx/articles/Samples/Kaleidoscope-ch2.md
+++ b/docfx/articles/Samples/Kaleidoscope-ch2.md
@@ -1,6 +1,405 @@
 # Implementing the parser
 The Lllvm.NET version of Kaleidoscope leverages ANTLR4 to parse the langague into a parse tree.
-The code generration walks the tree to generate the actual LLVM IR. 
+The chapter 2 sample doesn't actually generate any code. Instead it focuses on the general structure
+of the samples and parsing of the language. The sample for this chapter enables all language features
+to allow exploring the language and how it is parsed to help better understand the rest of the chapters
+better. It is hoped that users of this library find this helpful as understanding the language grammar
+from reading the LVM tutorials and source was a difficult task since it isn't formally defined in one
+place. (There are some EBNF like comments in the code but it is spread around without much real discussion
+of the lanbguage the tutorials guide you to implement)
 
-## Sub Section
-...
+
+## Formal Grammar
+### Lexer symbols
+
+The Kaleidoscope lexer consists of several tokens and is defined in the Kaleidoscope.g4 grammar file
+
+```antlr
+// Lexer Rules -------
+fragment NonZeroDecimalDigit_: [1-9];
+fragment DecimalDigit_: [0-9];
+fragment Digits_: '0' | [1-9][0-9]*;
+fragment EndOfFile_: '\u0000' | '\u001A';
+fragment EndOfLine_
+    : ('\r' '\n')
+    | ('\r' |'\n' | '\u2028' | '\u2029')
+    | EndOfFile_
+    ;
+
+LPAREN: '(';
+RPAREN: ')';
+COMMA: ',';
+SEMICOLON: ';';
+DEF: 'def';
+EXTERN: 'extern';
+
+ASSIGN:'=';
+ASTERISK: '*';
+PLUS: '+';
+MINUS:'-';
+LEFTANGLE: '<';
+SLASH: '/';
+
+EXCLAMATION: '!';
+PERCENT: '%';
+AMPERSAND:'&';
+PERIOD:'.';
+COLON: ':';
+RIGHTANGLE: '>';
+QMARK: '?';
+ATSIGN: '@';
+BACKSLASH: '\\';
+CARET: '^';
+UNDERSCORE: '_';
+VBAR: '|';
+EQUALEQUAL: '==';
+NOTEQUAL: '!=';
+PLUSPLUS: '++';
+MINUSMINUS: '--';
+
+IF:     {FeatureControlFlow}? 'if';
+THEN:   {FeatureControlFlow}? 'then';
+ELSE:   {FeatureControlFlow}? 'else';
+FOR:    {FeatureControlFlow}? 'for';
+IN:     {FeatureControlFlow}? 'in';
+VAR:    {FeatureMutableVars}? 'var';
+UNARY:  {FeatureUserOperators}? 'unary';
+BINARY: {FeatureUserOperators}? 'binary';
+
+LineComment: '#' ~[\r\n]* EndOfLine_ -> skip;
+WhiteSpace: [ \t\r\n\f]+ -> skip;
+
+Identifier: [a-zA-Z][a-zA-Z0-9]*;
+Number: Digits_ ('.' DecimalDigit_+)?;
+```
+
+This includes basic numeric patterns as well as Identifiers and the symbols allowed for operators and keywords
+for the language. Subsequent chapters will introduce the meaning and use of each of these.
+
+#### Language Feature Defined Keywords
+Chapters 5-7 each introduce new language features that introduce new keywords into the language. In order to
+maintain a single grammar for all chapters the lexer uses a technique of ANTLR4 called semantic predicates.
+These are basically boolean expressions that determine if a given rule should be applied. These are applied
+to the rules for the feature specific keywords. Thus, at runtime, if a given feature is disabled then the
+keyword is not recognized.
+
+```antlr
+IF:     {FeatureControlFlow}? 'if';
+THEN:   {FeatureControlFlow}? 'then';
+ELSE:   {FeatureControlFlow}? 'else';
+FOR:    {FeatureControlFlow}? 'for';
+IN:     {FeatureControlFlow}? 'in';
+VAR:    {FeatureMutableVars}? 'var';
+UNARY:  {FeatureUserOperators}? 'unary';
+BINARY: {FeatureUserOperators}? 'binary';
+```
+
+>[!NOTE]
+>There are some important distinctions in the Llvm.NET implementation of Kaleidoscope, in the operators allowed for
+>User defined operators. The official LLVM version allows definining an operator '=', (in chapter 6). However,
+>in Chapter 7, when Mutable variables are introduced the '=' is reserved by the language for assignment. Thus,
+>any code written for chapter 6 with a user defined '=' operator would not work in later versions. Thus, the
+>Llvm.NET version reserves the '=' in all versions, but allows the '==' operator. (It also adds the '++' and '--'
+>tokens as user operators [The official LLVM implementation only allows a single character as the operator lexeme])
+>
+> Additionally the Llvm.NET implementation adds the built-in '^' operator for exponentiation.
+
+### Parser
+
+The parser, like the lexer, uses Semantic Predicates, that allows for dynamic adaptation of the grammar
+and parser to handle variations or versions of the language. The Sample code uses that to selectively enable
+language features as the chapters progress, without needing to change the grammar or generated parser code.
+The parser code provides a simple means of expressing the language support level. Semantic predicates play
+a vital role in supporting user defined operators with user defined precedence.
+
+#### Parser grammar
+A full tutorial on ANTLR is beyond the scope of this article but the basics should be familiar
+enough to anyone acquainted with EBNF form to make enough sense out of it. Don't worry too much
+about the details at this point as subsequent chapters will cover salient points as new features
+are enabled.
+
+##### Operators
+In order to support the parser detecting attemtps to overload builtin operators and to handle the fact that some
+operators don't make any sense for unary operators (e.g. you can't create a user defined unary '=' operator. technically
+you could implement that but it would make for some confusing code. If you really like hard to read and comprehend code
+there are [other languages](https://en.wikipedia.org/wiki/Brainfuck) better suited to that end 8^) )
+
+To manage detection of appropriate operator tokens the grammar uses a set of parser rules that group the operator
+tokens by their allowed kinds. This allows subsequent rules to simply refer to the kind of operator expected and
+not worry about the actual tokens involved. It also allows the parser to detect syntax and useage errors like
+trying to create a user defined '+' operator.
+
+```antlr
+// built-in operator symbols
+builtinop
+    : ASSIGN
+    | ASTERISK
+    | PLUS
+    | MINUS
+    | SLASH
+    | LEFTANGLE
+    | CARET
+    ;
+
+// Allowed user defined binary symbols
+userdefinedop
+    : EXCLAMATION
+    | PERCENT
+    | AMPERSAND
+    | PERIOD
+    | COLON
+    | RIGHTANGLE
+    | QMARK
+    | ATSIGN
+    | BACKSLASH
+    | UNDERSCORE
+    | VBAR
+    | EQUALEQUAL
+    | NOTEQUAL
+    | PLUSPLUS
+    | MINUSMINUS
+    ;
+
+// unary ops can re-use built-in binop symbols (Except ASSIGN)
+unaryop
+    : ASTERISK
+    | PLUS
+    | MINUS
+    | SLASH
+    | LEFTANGLE
+    | CARET
+    | EXCLAMATION
+    | PERCENT
+    | AMPERSAND
+    | PERIOD
+    | COLON
+    | RIGHTANGLE
+    | QMARK
+    | ATSIGN
+    | BACKSLASH
+    | UNDERSCORE
+    | VBAR
+    | EQUALEQUAL
+    | NOTEQUAL
+    | PLUSPLUS
+    | MINUSMINUS
+    ;
+
+// All binary operators
+binaryop
+    : ASSIGN
+    | ASTERISK
+    | PLUS
+    | MINUS
+    | SLASH
+    | LEFTANGLE
+    | CARET
+    | EXCLAMATION
+    | PERCENT
+    | AMPERSAND
+    | PERIOD
+    | COLON
+    | RIGHTANGLE
+    | QMARK
+    | ATSIGN
+    | BACKSLASH
+    | UNDERSCORE
+    | VBAR
+    | EQUALEQUAL
+    | NOTEQUAL
+    | PLUSPLUS
+    | MINUSMINUS
+    ;
+```
+
+##### Initializers
+Initializers are a useful re-useable rule to handle a common sequence in the language in multiple different contexts.
+(sort of like a function in most programming languages, in fact, ANTLR rules are implemented in the generated parser
+as methods). 
+
+```antlr
+// pull the initializer out to a distinct rule so it is easier to get at
+// the list of initializers when walking the parse tree
+initializer
+    : Identifier (ASSIGN expression[0])?
+    ;
+
+```
+
+##### Primary Expressions (Atoms)
+There are a number of primary expressions (also known as 'Atoms') that are not left recursive in their definition.
+These are split out to a distinct rule to aid in the support of left recursion and the need for user defined operator
+precedence.
+
+```antlr
+// Non Left recursive expressions (a.k.a. atoms)
+primaryExpression
+    : LPAREN expression[0] RPAREN                                                 # ParenExpression
+    | Identifier LPAREN (expression[0] (COMMA expression[0])*)? RPAREN            # FunctionCallExpression
+    | VAR initializer (COMMA initializer)* IN expression[0]                       # VarInExpression
+    | IF expression[0] THEN expression[0] ELSE expression[0]                      # ConditionalExpression
+    | FOR initializer COMMA expression[0] (COMMA expression[0])? IN expression[0] # ForExpression
+    | {IsPrefixOp()}? unaryop expression[0]                                       # UnaryOpExpression
+    | Identifier                                                                  # VariableExpression
+    | Number                                                                      # ConstExpression
+    ;
+```
+
+Let's look at each of these in turn to get a better understanding of the language.
+
+###### ParenExpression
+```antlr
+LPAREN expression[0] RPAREN
+```
+This is a simple rule for sub-expressions within parenthesis for example: `(1+2)/3` the parenthesis groups the
+addition so that it occurs before the division since, normally the precedence of division is higher. The parse
+tree for that expression looks like this:
+
+![Parse Tree](parsetree-paren-expr.svg)
+
+###### FunctionCallExpression
+```antlr
+Identifier LPAREN (expression[0] (COMMA expression[0])*)? RPAREN
+```
+This rule covers a function call which can have 0 or more comma delimited arguments. The parse tree
+for the call `foo(1, 2, 3);` is:
+
+![Parse Tree](parsetree-func-call.svg)
+
+###### Other expressions
+The other expressions are either simple tokens like `Identifier` and `Number` or more complex expressions that are
+covered in detail in later chapters.
+
+#### Parse Tree
+The Llvm.NET implementation of Kaleidoscope doesn't use an AST per se. Instead it use the parse tree generated
+by ANTLR with the addition of C# partial classes. ANTLR will generate a parser based on the grammar description
+input file. This generated parser (and lexer) includes a context type for each rule of the grammar. The C# target
+for ANTLR generates these types as partial classes so the they are extensible from the parser assembly without
+needing to derive a new type or use virtuals etc. Thus, the Kaleidoscope.Grammar assembly contains partial class
+extensions that provide simpler property accessors and support methods to where an additional AST is not needed.
+(e.g. The parse tree is the AST)
+
+See [Kaleidoscope Parse Tree Examples](Kaleidoscope-Parsetree-examples.md) for more information and example
+diagrams of the parse tree for various language constructs.
+
+## Basic Application Architecture
+
+Generally speaking there are three main components to all of the sample chapter applications.
+
+  1. The main driver application (e.g. program.cs)
+  2. The parser (e.g. Kaleidoscope.Grammar assembly)
+  3. The code generator (e.g. CodeGenerator.cs)
+
+There is an additional utility support library Kaleidoscope.Runtime providing some common adapter/facade pattern
+implementations for working with Kaleidoscope, ANTLR and Llvm.NET.
+
+### Driver
+While each chapter is a bit different from the others. Many of the chapters are virtually identical for the driver.
+In particular Chapters 3-7 only really differ in the language level support. 
+
+[!code-csharp[Program.cs](../../../Samples/Kaleidoscope/Chapter4/Program.cs)]
+
+The Main function starts out by calling WaitForDebugger(). This is a useful utility that doesn't do anything in a
+release build, but in debug builds will check for an attached debugger and if none is found it will wait for one.
+This works around a missing feauture of the .NET Standard C# project system that does not support launching mixed
+native+managed debugging. When you need to go all the way into debugging the LLVM code, you can launch the debug
+version of the app without debugging, then attach to it and select native and managed debugging. (Hopefully this
+feature will be restored to these projects in the future so this trick isn't needed...)
+
+The real heart of the driver app is in the next small block of code. The driver begins by initializing the LLVM
+system, which loads the correct platform architecture version of the LibLLVM.DLL and initializes a number of
+internal LLVM static infrastructure. This requires some teardown for a clean shutdown of LLVM so the initialization
+returns an IDisposable which requires a call to Dispose() to cleanup. The cleanup is handled automatically via a
+C# using statement.
+
+```C#
+using( InitializeLLVM( ) )
+{
+[...]
+}
+```
+
+The next step of initialization for LLVM is registration of platform targets. Since LLVM can target multiple different
+platforms, and support for each target requires some resources applications need to declare the targets they want to use.
+For the JIT Kaleidoscope samples the target is the native host system so that is the only target registered.
+
+Once LLVM is initialized the Kaleidoscope parser is created. The ReplParserStack contains the support for parsing the
+Kaleidoscope language from the REPL loop interactive input. The stakc also maintains the global state of the runtime,
+which controls the language features enabled, and if user defined operators are enabled, contains the operators defined
+along with their precednece.
+
+```C#
+var parser = new ReplParserStack( LanguageLevel.SimpleExpressions );
+```
+
+After the parser is created the code generator is constructed. The code generator is responsible for most of the real work
+of the language. The implementation of the generator is different for each chapter. Howver, since the generator is based
+on the ANTLR4 generated KaleidoscopeParserListener (using a visitor pattern), and the chapters build on one another, for
+the most part, it is fairly easy to diff the generators for each chapter to see the changes needed to introduce the feauture
+the chapter introduces. Each chapter will go into more details on this. Since the generator usually allocates resources in
+Llvm.NET it implements IDisposable to ensure they are released as early as possible.
+
+```C#
+using( var generator = new CodeGenerator( parser.GlobalState ) )
+{
+}
+```
+
+Inside the using statement for the code generator is the core loop for the language runtime. This starts by displaying
+a brief "hello" message indicating the nature of the app and the language level supported. The actual REPL loop is handled
+via a common library class `ReplLoop<T>` (in Kaleidoscope.Runtime) this class handles retieving text from an input source
+(default is Console.In) and producing a complete "statement" for parsings. (Technically speaking Kaleidoscope doesn't have
+statements but to allow a user to type `[...] a+b<newline>+c`) without processing that as two expression invovations a 
+semicolon is used to convey the user's intent that the code is complete and ready for evaluation. The ReplLoop class takes
+care of this in a generalized manner. The ReplLoop can consume input from any `System.TextReader` and uses `System.Console.In`
+as a default. When the loop detects a new line that doesn't have a semicolon it will generate a Ready state changed event
+so the calling application can inform the user with a different prompt (in all the Llvm.NET samples this is '>'). Once a complete
+expression is available, the loop will submit it to the parser to generate a parse tree. The loop then passes the parse tree
+and the parser that created it to the generators Generate() method to actually generate the result. The result type of the
+generator is the generic type parameter for `ReplLoop<T>` as the loop class doesn't need to use the result itself. The
+loop will trigger the GeneratedResultAvailable event to allow the driver application to do whatever it wants with the results.
+
+The calling application will generally hook an event handler to show the results of the generation in some fashion. For the
+basic samples (Chapter 3-7) it indicates the value of any JITed and executed top level expressions, or the name of any functions
+defined. Chapter 2 has additional support for showing an XML representation of the tree but the same basic pattern applies.
+This, helps to keep the samples consistent and as similar as possible to allow diffs to focus on the changes for a particular
+feature. The separation of concerns also aids in making the grammar, runtime and code generation unit-testable without the
+driver. (Although that isn't implemented yet it is intended for the future to help broaden testing of Llvm.NET to more scenarios
+and catch breaking issues quicker.)
+
+```C#
+private static void OnGeneratedResultAvailable( object sender, GeneratedResultAvailableArgs<Value> e )
+{
+    var source = ( ReplLoop<Value> )sender;
+
+    switch( e.Result )
+    {
+    case ConstantFP result:
+        Console.WriteLine( "Evaluated to {0}", result.Value );
+        break;
+
+    case Function function:
+        if( source.AdditionalDiagnostics.HasFlag( DiagnosticRepresentations.LlvmIR ) )
+        {
+            function.ParentModule.WriteToTextFile( Path.ChangeExtension( GetSafeFileName( function.Name ), "ll" ), out string ignoredMsg );
+        }
+
+        Console.WriteLine( "Defined function: {0}", function.Name );
+        break;
+    }
+}
+```
+
+### Special case for Chapter 2
+Chapter 2 sample code, while still following the general patterns, is a bit unique, it doesn't use Lllvm.NET at all. It
+is only focused on the language and parsing. This helps in understanding the basic patterns of the code and support and
+serves as an aid in understanding the language itself. Of particular use is the support for generating DGML and
+[blockdiag](http://blockdiag.com) representations of the parse tree for a given parse (All of the diagrams in these tutorials
+were created by creating the blockdiag files and then generating the SVG files from that). Having a nice visual
+representation of a parser tree result is helpful to understanding the parsing and various parse tree node types.
+
+The visual graph is also immensensly valuable when making changes to the grammar so you can see the results of a parse and
+more readily understand why something isn't right. (In fact this feature was enabled to track down bugs in the parsing for
+user defined operator precedence that was difficult to figure out. Once the visualization was available it became quite easy
+to see the problems). Thus, Chapter 2 is both a simple introductory example and tool for use when doing advanced language
+tweaking.

--- a/docfx/articles/Samples/Kaleidoscope-ch3.md
+++ b/docfx/articles/Samples/Kaleidoscope-ch3.md
@@ -1,5 +1,15 @@
-# Topic Header
-Summary
+# Chapter 3 - Code Generation to LLVM IR
+This chapter focuses on the basics of transforming the ANTLR parse tree into LLVM IR. The general goal is to
+parse Kaleidoscope source code to generate a [BitcodeModule](xref:Llvm.NET.BitcodeModule) representing the
+source as LLVM IR.
 
-## Sub Section
-...
+## Parse Tree Visitors
+When ANTLR processes the language grammar description to generate the lexer and parser it also generates a
+base "visitor" class for applying the [Visitor pattern](https://en.wikipedia.org/wiki/Visitor_pattern) to
+the parse tree. This is the primary mechanism for generating code in these examples. All of the CodeGenerator
+classes derive from the ANTLR generated base visitor class.
+
+There are only a few top level rules in the grammar to consider (although each has many sub rules).
+
+[!code-antlr[repl](../../../Samples/Kaleidoscope/Kaleidoscope.Parser/Kaleidoscope.g4?start=181&end=187)]
+

--- a/docfx/articles/Samples/Kaleidoscope.md
+++ b/docfx/articles/Samples/Kaleidoscope.md
@@ -28,6 +28,8 @@ Kaleidoscope is a simple functional language with the following major features:
 * For loop style control flow
 * User defined operators
   - User defined operators can specify operator precedence
+    - This is arguably the most complex part of implementing the language. Though, ANTLR4's
+      flexibility made it fairly easy to do once fully understood. (more details in [Chapter 6](Kaleidoscope-ch6.md))
 
 ### Example
 The following example is a complete program in Kaleidoscope that will generate a textual representation
@@ -109,6 +111,7 @@ When entered ( or copy/pasted) to the command line Kaleidoscope will print out t
 >The runtime from earlier chapters will generate errors trying to parse this code.
 
 ```
+Ready>mandel(-2.3, -1.3, 0.05, 0.07);
 *******************************************************************************
 *******************************************************************************
 ****************************************++++++*********************************
@@ -150,31 +153,6 @@ When entered ( or copy/pasted) to the command line Kaleidoscope will print out t
 *******************************************************************************
 *******************************************************************************
 *******************************************************************************
+Evaluated to 0
+Ready>
 ```
-
-### Formal Grammar
-#### Lexer symbols
-
-The Kaleidoscope lexer consists of several tokens and is defined in the Kaleidoscope.g4 grammar file
-
-[!code-c[Lexer](../../../Samples/Kaleidoscope/Kaleidoscope.Parser/Kaleidoscope.g4#Lexer)]
-
-This includes basic numeric patterns as well as Identifiers and the symbols allowed for operators and keywords
-for the language. Subsequent chapters will introduce the meaning and use of each of these.
-
-#### Parser
-
-The parser uses a technique of ANTLR called Semantic Predicates, that allows for dynamic adaptation of the grammar
-and parser to handle variations or versions of the language. The Sample code uses that to selectively enable language
-features as the chapters progress, without needing to change the grammar or generated parser code. The parser code
-provides a simple means of expressing the language support level. Semantic predicates play a vital role in supporting
-user defined operators with user defined precedence.
-
-##### Parser grammar
-[!code-c[Lexer](../../../Samples/Kaleidoscope/Kaleidoscope.Parser/Kaleidoscope.g4#Parser)]
-
-A full tutorial on ANTLR is beyond the scope of this tutorial but the basics should be familiar
-enough to anyone acquainted with EBNF form to make enough sense out of it. Don't worry too much
-about the details at this point as subsequent chapters will cover salient points as new features
-are enabled.
-

--- a/docfx/articles/Samples/codegeneration.md
+++ b/docfx/articles/Samples/codegeneration.md
@@ -170,7 +170,7 @@ The function declarations for both of the two function's is mostly the same, fol
   1. Add attributes appropriate for the function
 
 The two functions illustrate a global externally visible function and a static that is visible only locally.
-This is indicated by the [Linkage.Internal](xref:Llvm.NET.Linkage.Internal) linkage value.
+This is indicated by the [Linkage.Internal](xref:Llvm.NET.Values.Linkage.Internal) linkage value.
 
 >[!NOTE]
 >The use of fluent style extension methods in the Llvm.NET API helps make it easy to add to or modify

--- a/docfx/articles/Samples/parsetree-for-loop.svg
+++ b/docfx/articles/Samples/parsetree-for-loop.svg
@@ -1,0 +1,337 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg viewBox="0 0 3904 680" xmlns="http://www.w3.org/2000/svg" xmlns:inkspace="http://www.inkscape.org/namespaces/inkscape" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs id="defs_block">
+    <filter height="1.504" id="filter_blur" inkspace:collect="always" width="1.1575" x="-0.07875" y="-0.252">
+      <feGaussianBlur id="feGaussianBlur3780" inkspace:collect="always" stdDeviation="4.2" />
+    </filter>
+  </defs>
+  <title>blockdiag</title>
+  <desc>blockdiag
+{
+    default_shape = roundedbox
+    orientation = portrait
+
+    // Nodes
+    N21421675 [label= "FunctionDefinition"];
+    N58577354021421675 [label= "def", shape = circle];
+    N57434139121421675 [label= "FunctionPrototype"];
+    N47145209057434139121421675 [label= "printstar", shape = circle];
+    N21653700157434139121421675 [label= "(", shape = circle];
+    N60665573257434139121421675 [label= "n", shape = circle];
+    N9119245357434139121421675 [label= ")", shape = circle];
+    N14964341221421675 [label= "Expression", numbered = 0];
+    N461342014964341221421675 [label= "ForExpression"];
+    N41520810461342014964341221421675 [label= "for", shape = circle];
+    N373687361461342014964341221421675 [label= "Initializer"];
+    N7743060373687361461342014964341221421675 [label= "i", shape = circle];
+    N69687621373687361461342014964341221421675 [label= "=", shape = circle];
+    N627188642373687361461342014964341221421675 [label= "Expression", numbered = 0];
+    N275988690627188642373687361461342014964341221421675 [label= "ConstExpression"];
+    N470632340275988690627188642373687361461342014964341221421675 [label= "1", shape = circle];
+    N209159292461342014964341221421675 [label= ",", shape = circle];
+    N540256333461342014964341221421675 [label= "Expression", numbered = 0];
+    N164686520540256333461342014964341221421675 [label= "VariableExpression"];
+    N140001480164686520540256333461342014964341221421675 [label= "i", shape = circle];
+    N588924731540256333461342014964341221421675 [label= "Binaryop"];
+    N602702120588924731540256333461342014964341221421675 [label= "&lt;", shape = circle];
+    N55609982540256333461342014964341221421675 [label= "Expression", numbered = 11];
+    N50048984055609982540256333461342014964341221421675 [label= "VariableExpression"];
+    N47787675050048984055609982540256333461342014964341221421675 [label= "n", shape = circle];
+    N274358974461342014964341221421675 [label= ",", shape = circle];
+    N455964815461342014964341221421675 [label= "Expression", numbered = 0];
+    N77151500455964815461342014964341221421675 [label= "ConstExpression"];
+    N2327487077151500455964815461342014964341221421675 [label= "1.0", shape = circle];
+    N209473916461342014964341221421675 [label= "in", shape = circle];
+    N543087987461342014964341221421675 [label= "Expression", numbered = 0];
+    N190171420543087987461342014964341221421675 [label= "FunctionCallExpression"];
+    N369365500190171420543087987461342014964341221421675 [label= "putchard", shape = circle];
+    N639934961190171420543087987461342014964341221421675 [label= "(", shape = circle];
+    N390705582190171420543087987461342014964341221421675 [label= "Expression", numbered = 0];
+    N160907030390705582190171420543087987461342014964341221421675 [label= "ConstExpression"];
+    N105986060160907030390705582190171420543087987461342014964341221421675 [label= "42", shape = circle];
+    N282785953190171420543087987461342014964341221421675 [label= ")", shape = circle];
+
+    // Edges
+    N21421675 -&gt; N58577354021421675
+    N57434139121421675 -&gt; N47145209057434139121421675
+    N57434139121421675 -&gt; N21653700157434139121421675
+    N57434139121421675 -&gt; N60665573257434139121421675
+    N57434139121421675 -&gt; N9119245357434139121421675
+    N21421675 -&gt; N57434139121421675
+    N461342014964341221421675 -&gt; N41520810461342014964341221421675
+    N373687361461342014964341221421675 -&gt; N7743060373687361461342014964341221421675
+    N373687361461342014964341221421675 -&gt; N69687621373687361461342014964341221421675
+    N275988690627188642373687361461342014964341221421675 -&gt; N470632340275988690627188642373687361461342014964341221421675
+    N627188642373687361461342014964341221421675 -&gt; N275988690627188642373687361461342014964341221421675
+    N373687361461342014964341221421675 -&gt; N627188642373687361461342014964341221421675
+    N461342014964341221421675 -&gt; N373687361461342014964341221421675
+    N461342014964341221421675 -&gt; N209159292461342014964341221421675
+    N164686520540256333461342014964341221421675 -&gt; N140001480164686520540256333461342014964341221421675
+    N540256333461342014964341221421675 -&gt; N164686520540256333461342014964341221421675
+    N588924731540256333461342014964341221421675 -&gt; N602702120588924731540256333461342014964341221421675
+    N540256333461342014964341221421675 -&gt; N588924731540256333461342014964341221421675
+    N50048984055609982540256333461342014964341221421675 -&gt; N47787675050048984055609982540256333461342014964341221421675
+    N55609982540256333461342014964341221421675 -&gt; N50048984055609982540256333461342014964341221421675
+    N540256333461342014964341221421675 -&gt; N55609982540256333461342014964341221421675
+    N461342014964341221421675 -&gt; N540256333461342014964341221421675
+    N461342014964341221421675 -&gt; N274358974461342014964341221421675
+    N77151500455964815461342014964341221421675 -&gt; N2327487077151500455964815461342014964341221421675
+    N455964815461342014964341221421675 -&gt; N77151500455964815461342014964341221421675
+    N461342014964341221421675 -&gt; N455964815461342014964341221421675
+    N461342014964341221421675 -&gt; N209473916461342014964341221421675
+    N190171420543087987461342014964341221421675 -&gt; N369365500190171420543087987461342014964341221421675
+    N190171420543087987461342014964341221421675 -&gt; N639934961190171420543087987461342014964341221421675
+    N160907030390705582190171420543087987461342014964341221421675 -&gt; N105986060160907030390705582190171420543087987461342014964341221421675
+    N390705582190171420543087987461342014964341221421675 -&gt; N160907030390705582190171420543087987461342014964341221421675
+    N190171420543087987461342014964341221421675 -&gt; N390705582190171420543087987461342014964341221421675
+    N190171420543087987461342014964341221421675 -&gt; N282785953190171420543087987461342014964341221421675
+    N543087987461342014964341221421675 -&gt; N190171420543087987461342014964341221421675
+    N461342014964341221421675 -&gt; N543087987461342014964341221421675
+    N14964341221421675 -&gt; N461342014964341221421675
+    N21421675 -&gt; N14964341221421675
+}
+</desc>
+  <path d="M 75 46 L 187 46 A8,8 0 0 1 195 54 L 195 78 A8,8 0 0 1 187 86 L 75 86 A8,8 0 0 1 67 78 L 67 54 A8,8 0 0 1 75 46" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="131" cy="146" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 267 126 L 379 126 A8,8 0 0 1 387 134 L 387 158 A8,8 0 0 1 379 166 L 267 166 A8,8 0 0 1 259 158 L 259 134 A8,8 0 0 1 267 126" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1035 126 L 1147 126 A8,8 0 0 1 1155 134 L 1155 158 A8,8 0 0 1 1147 166 L 1035 166 A8,8 0 0 1 1027 158 L 1027 134 A8,8 0 0 1 1035 126" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="323" cy="226" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="515" cy="226" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="707" cy="226" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="899" cy="226" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1035 206 L 1147 206 A8,8 0 0 1 1155 214 L 1155 238 A8,8 0 0 1 1147 246 L 1035 246 A8,8 0 0 1 1027 238 L 1027 214 A8,8 0 0 1 1035 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1091" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1227 286 L 1339 286 A8,8 0 0 1 1347 294 L 1347 318 A8,8 0 0 1 1339 326 L 1227 326 A8,8 0 0 1 1219 318 L 1219 294 A8,8 0 0 1 1227 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1859" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1995 286 L 2107 286 A8,8 0 0 1 2115 294 L 2115 318 A8,8 0 0 1 2107 326 L 1995 326 A8,8 0 0 1 1987 318 L 1987 294 A8,8 0 0 1 1995 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="2627" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 2763 286 L 2875 286 A8,8 0 0 1 2883 294 L 2883 318 A8,8 0 0 1 2875 326 L 2763 326 A8,8 0 0 1 2755 318 L 2755 294 A8,8 0 0 1 2763 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="3011" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 3147 286 L 3259 286 A8,8 0 0 1 3267 294 L 3267 318 A8,8 0 0 1 3259 326 L 3147 326 A8,8 0 0 1 3139 318 L 3139 294 A8,8 0 0 1 3147 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1283" cy="386" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1475" cy="386" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1611 366 L 1723 366 A8,8 0 0 1 1731 374 L 1731 398 A8,8 0 0 1 1723 406 L 1611 406 A8,8 0 0 1 1603 398 L 1603 374 A8,8 0 0 1 1611 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1611 446 L 1723 446 A8,8 0 0 1 1731 454 L 1731 478 A8,8 0 0 1 1723 486 L 1611 486 A8,8 0 0 1 1603 478 L 1603 454 A8,8 0 0 1 1611 446" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1667" cy="546" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1995 366 L 2107 366 A8,8 0 0 1 2115 374 L 2115 398 A8,8 0 0 1 2107 406 L 1995 406 A8,8 0 0 1 1987 398 L 1987 374 A8,8 0 0 1 1995 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 2187 366 L 2299 366 A8,8 0 0 1 2307 374 L 2307 398 A8,8 0 0 1 2299 406 L 2187 406 A8,8 0 0 1 2179 398 L 2179 374 A8,8 0 0 1 2187 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 2379 366 L 2491 366 A8,8 0 0 1 2499 374 L 2499 398 A8,8 0 0 1 2491 406 L 2379 406 A8,8 0 0 1 2371 398 L 2371 374 A8,8 0 0 1 2379 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="2051" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="2243" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 2379 446 L 2491 446 A8,8 0 0 1 2499 454 L 2499 478 A8,8 0 0 1 2491 486 L 2379 486 A8,8 0 0 1 2371 478 L 2371 454 A8,8 0 0 1 2379 446" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="2435" cy="546" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 2763 366 L 2875 366 A8,8 0 0 1 2883 374 L 2883 398 A8,8 0 0 1 2875 406 L 2763 406 A8,8 0 0 1 2755 398 L 2755 374 A8,8 0 0 1 2763 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="2819" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 3147 366 L 3259 366 A8,8 0 0 1 3267 374 L 3267 398 A8,8 0 0 1 3259 406 L 3147 406 A8,8 0 0 1 3139 398 L 3139 374 A8,8 0 0 1 3147 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="3203" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="3395" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 3531 446 L 3643 446 A8,8 0 0 1 3651 454 L 3651 478 A8,8 0 0 1 3643 486 L 3531 486 A8,8 0 0 1 3523 478 L 3523 454 A8,8 0 0 1 3531 446" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="3779" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 3531 526 L 3643 526 A8,8 0 0 1 3651 534 L 3651 558 A8,8 0 0 1 3643 566 L 3531 566 A8,8 0 0 1 3523 558 L 3523 534 A8,8 0 0 1 3531 526" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="3587" cy="626" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 72 40 L 184 40 A8,8 0 0 1 192 48 L 192 72 A8,8 0 0 1 184 80 L 72 80 A8,8 0 0 1 64 72 L 64 48 A8,8 0 0 1 72 40" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="108" x="128" y="65">FunctionDefinition</text>
+  <ellipse cx="128" cy="140" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="18" x="128" y="145">def</text>
+  <path d="M 264 120 L 376 120 A8,8 0 0 1 384 128 L 384 152 A8,8 0 0 1 376 160 L 264 160 A8,8 0 0 1 256 152 L 256 128 A8,8 0 0 1 264 120" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="102" x="320" y="146">FunctionPrototype</text>
+  <path d="M 1032 120 L 1144 120 A8,8 0 0 1 1152 128 L 1152 152 A8,8 0 0 1 1144 160 L 1032 160 A8,8 0 0 1 1024 152 L 1024 128 A8,8 0 0 1 1032 120" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="1088" y="146">Expression</text>
+  <ellipse cx="1024" cy="120" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1024" y="125">0</text>
+  <ellipse cx="320" cy="220" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="320" y="220">printsta</text>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="320" y="232">r</text>
+  <ellipse cx="512" cy="220" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="512" y="226">(</text>
+  <ellipse cx="704" cy="220" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="704" y="225">n</text>
+  <ellipse cx="896" cy="220" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="896" y="226">)</text>
+  <path d="M 1032 200 L 1144 200 A8,8 0 0 1 1152 208 L 1152 232 A8,8 0 0 1 1144 240 L 1032 240 A8,8 0 0 1 1024 232 L 1024 208 A8,8 0 0 1 1032 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="78" x="1088" y="226">ForExpression</text>
+  <ellipse cx="1088" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="18" x="1088" y="305">for</text>
+  <path d="M 1224 280 L 1336 280 A8,8 0 0 1 1344 288 L 1344 312 A8,8 0 0 1 1336 320 L 1224 320 A8,8 0 0 1 1216 312 L 1216 288 A8,8 0 0 1 1224 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="66" x="1280" y="305">Initializer</text>
+  <ellipse cx="1856" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1856" y="306">,</text>
+  <path d="M 1992 280 L 2104 280 A8,8 0 0 1 2112 288 L 2112 312 A8,8 0 0 1 2104 320 L 1992 320 A8,8 0 0 1 1984 312 L 1984 288 A8,8 0 0 1 1992 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="2048" y="306">Expression</text>
+  <ellipse cx="1984" cy="280" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1984" y="285">0</text>
+  <ellipse cx="2624" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="2624" y="306">,</text>
+  <path d="M 2760 280 L 2872 280 A8,8 0 0 1 2880 288 L 2880 312 A8,8 0 0 1 2872 320 L 2760 320 A8,8 0 0 1 2752 312 L 2752 288 A8,8 0 0 1 2760 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="2816" y="306">Expression</text>
+  <ellipse cx="2752" cy="280" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="2752" y="285">0</text>
+  <ellipse cx="3008" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="3008" y="305">in</text>
+  <path d="M 3144 280 L 3256 280 A8,8 0 0 1 3264 288 L 3264 312 A8,8 0 0 1 3256 320 L 3144 320 A8,8 0 0 1 3136 312 L 3136 288 A8,8 0 0 1 3144 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="3200" y="306">Expression</text>
+  <ellipse cx="3136" cy="280" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="3136" y="285">0</text>
+  <ellipse cx="1280" cy="380" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1280" y="385">i</text>
+  <ellipse cx="1472" cy="380" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1472" y="385">=</text>
+  <path d="M 1608 360 L 1720 360 A8,8 0 0 1 1728 368 L 1728 392 A8,8 0 0 1 1720 400 L 1608 400 A8,8 0 0 1 1600 392 L 1600 368 A8,8 0 0 1 1608 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="1664" y="386">Expression</text>
+  <ellipse cx="1600" cy="360" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1600" y="365">0</text>
+  <path d="M 1608 440 L 1720 440 A8,8 0 0 1 1728 448 L 1728 472 A8,8 0 0 1 1720 480 L 1608 480 A8,8 0 0 1 1600 472 L 1600 448 A8,8 0 0 1 1608 440" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="1664" y="466">ConstExpression</text>
+  <ellipse cx="1664" cy="540" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1664" y="545">1</text>
+  <path d="M 1992 360 L 2104 360 A8,8 0 0 1 2112 368 L 2112 392 A8,8 0 0 1 2104 400 L 1992 400 A8,8 0 0 1 1984 392 L 1984 368 A8,8 0 0 1 1992 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="108" x="2048" y="386">VariableExpression</text>
+  <path d="M 2184 360 L 2296 360 A8,8 0 0 1 2304 368 L 2304 392 A8,8 0 0 1 2296 400 L 2184 400 A8,8 0 0 1 2176 392 L 2176 368 A8,8 0 0 1 2184 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="2240" y="386">Binaryop</text>
+  <path d="M 2376 360 L 2488 360 A8,8 0 0 1 2496 368 L 2496 392 A8,8 0 0 1 2488 400 L 2376 400 A8,8 0 0 1 2368 392 L 2368 368 A8,8 0 0 1 2376 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="2432" y="386">Expression</text>
+  <ellipse cx="2368" cy="360" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="2368" y="365">11</text>
+  <ellipse cx="2048" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="2048" y="465">i</text>
+  <ellipse cx="2240" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="2240" y="465">&lt;</text>
+  <path d="M 2376 440 L 2488 440 A8,8 0 0 1 2496 448 L 2496 472 A8,8 0 0 1 2488 480 L 2376 480 A8,8 0 0 1 2368 472 L 2368 448 A8,8 0 0 1 2376 440" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="108" x="2432" y="466">VariableExpression</text>
+  <ellipse cx="2432" cy="540" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="2432" y="545">n</text>
+  <path d="M 2760 360 L 2872 360 A8,8 0 0 1 2880 368 L 2880 392 A8,8 0 0 1 2872 400 L 2760 400 A8,8 0 0 1 2752 392 L 2752 368 A8,8 0 0 1 2760 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="2816" y="386">ConstExpression</text>
+  <ellipse cx="2816" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="18" x="2816" y="465">1.0</text>
+  <path d="M 3144 360 L 3256 360 A8,8 0 0 1 3264 368 L 3264 392 A8,8 0 0 1 3256 400 L 3144 400 A8,8 0 0 1 3136 392 L 3136 368 A8,8 0 0 1 3144 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="126" x="3200" y="380">FunctionCallExpressio</text>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="3200" y="392">n</text>
+  <ellipse cx="3200" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="3200" y="466">putchard</text>
+  <ellipse cx="3392" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="3392" y="466">(</text>
+  <path d="M 3528 440 L 3640 440 A8,8 0 0 1 3648 448 L 3648 472 A8,8 0 0 1 3640 480 L 3528 480 A8,8 0 0 1 3520 472 L 3520 448 A8,8 0 0 1 3528 440" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="3584" y="466">Expression</text>
+  <ellipse cx="3520" cy="440" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="3520" y="445">0</text>
+  <ellipse cx="3776" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="3776" y="466">)</text>
+  <path d="M 3528 520 L 3640 520 A8,8 0 0 1 3648 528 L 3648 552 A8,8 0 0 1 3640 560 L 3528 560 A8,8 0 0 1 3520 552 L 3520 528 A8,8 0 0 1 3528 520" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="3584" y="546">ConstExpression</text>
+  <ellipse cx="3584" cy="620" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="3584" y="625">42</text>
+  <path d="M 128 80 L 128 100" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 100 L 320 100" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 320 100 L 320 112" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="320,119 316,112 324,112 320,119" stroke="rgb(0,0,0)" />
+  <path d="M 128 80 L 128 108" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="128,115 124,108 132,108 128,115" stroke="rgb(0,0,0)" />
+  <path d="M 128 80 L 128 100" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 100 L 1088 100" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 100 L 1088 112" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,119 1084,112 1092,112 1088,119" stroke="rgb(0,0,0)" />
+  <path d="M 320 160 L 320 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 320 180 L 704 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 704 180 L 704 188" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="704,195 700,188 708,188 704,195" stroke="rgb(0,0,0)" />
+  <path d="M 320 160 L 320 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 320 180 L 896 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 896 180 L 896 188" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="896,195 892,188 900,188 896,195" stroke="rgb(0,0,0)" />
+  <path d="M 320 160 L 320 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 320 180 L 512 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 512 180 L 512 188" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="512,195 508,188 516,188 512,195" stroke="rgb(0,0,0)" />
+  <path d="M 320 160 L 320 188" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="320,195 316,188 324,188 320,195" stroke="rgb(0,0,0)" />
+  <path d="M 1088 160 L 1088 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,199 1084,192 1092,192 1088,199" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 260 L 2816 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2816 260 L 2816 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2816,279 2812,272 2820,272 2816,279" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,275 1084,268 1092,268 1088,275" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 260 L 3008 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3008 260 L 3008 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3008,275 3004,268 3012,268 3008,275" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 260 L 2048 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2048 260 L 2048 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2048,279 2044,272 2052,272 2048,279" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 260 L 1856 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1856 260 L 1856 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1856,275 1852,268 1860,268 1856,275" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 260 L 3200 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3200 260 L 3200 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3200,279 3196,272 3204,272 3200,279" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 260 L 1280 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1280 260 L 1280 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1280,279 1276,272 1284,272 1280,279" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 260 L 2624 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2624 260 L 2624 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2624,275 2620,268 2628,268 2624,275" stroke="rgb(0,0,0)" />
+  <path d="M 1280 320 L 1280 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1280 340 L 1472 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1472 340 L 1472 348" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1472,355 1468,348 1476,348 1472,355" stroke="rgb(0,0,0)" />
+  <path d="M 1280 320 L 1280 348" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1280,355 1276,348 1284,348 1280,355" stroke="rgb(0,0,0)" />
+  <path d="M 1280 320 L 1280 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1280 340 L 1664 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1664 340 L 1664 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1664,359 1660,352 1668,352 1664,359" stroke="rgb(0,0,0)" />
+  <path d="M 1664 400 L 1664 432" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1664,439 1660,432 1668,432 1664,439" stroke="rgb(0,0,0)" />
+  <path d="M 1664 480 L 1664 508" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1664,515 1660,508 1668,508 1664,515" stroke="rgb(0,0,0)" />
+  <path d="M 2048 320 L 2048 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2048 340 L 2432 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2432 340 L 2432 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2432,359 2428,352 2436,352 2432,359" stroke="rgb(0,0,0)" />
+  <path d="M 2048 320 L 2048 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2048,359 2044,352 2052,352 2048,359" stroke="rgb(0,0,0)" />
+  <path d="M 2048 320 L 2048 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2048 340 L 2240 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2240 340 L 2240 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2240,359 2236,352 2244,352 2240,359" stroke="rgb(0,0,0)" />
+  <path d="M 2048 400 L 2048 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2048,435 2044,428 2052,428 2048,435" stroke="rgb(0,0,0)" />
+  <path d="M 2240 400 L 2240 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2240,435 2236,428 2244,428 2240,435" stroke="rgb(0,0,0)" />
+  <path d="M 2432 400 L 2432 432" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2432,439 2428,432 2436,432 2432,439" stroke="rgb(0,0,0)" />
+  <path d="M 2432 480 L 2432 508" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2432,515 2428,508 2436,508 2432,515" stroke="rgb(0,0,0)" />
+  <path d="M 2816 320 L 2816 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2816,359 2812,352 2820,352 2816,359" stroke="rgb(0,0,0)" />
+  <path d="M 2816 400 L 2816 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2816,435 2812,428 2820,428 2816,435" stroke="rgb(0,0,0)" />
+  <path d="M 3200 320 L 3200 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3200,359 3196,352 3204,352 3200,359" stroke="rgb(0,0,0)" />
+  <path d="M 3200 400 L 3200 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3200 420 L 3392 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3392 420 L 3392 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3392,435 3388,428 3396,428 3392,435" stroke="rgb(0,0,0)" />
+  <path d="M 3200 400 L 3200 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3200 420 L 3776 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3776 420 L 3776 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3776,435 3772,428 3780,428 3776,435" stroke="rgb(0,0,0)" />
+  <path d="M 3200 400 L 3200 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3200 420 L 3584 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3584 420 L 3584 432" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3584,439 3580,432 3588,432 3584,439" stroke="rgb(0,0,0)" />
+  <path d="M 3200 400 L 3200 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3200,435 3196,428 3204,428 3200,435" stroke="rgb(0,0,0)" />
+  <path d="M 3584 480 L 3584 512" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3584,519 3580,512 3588,512 3584,519" stroke="rgb(0,0,0)" />
+  <path d="M 3584 560 L 3584 588" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3584,595 3580,588 3588,588 3584,595" stroke="rgb(0,0,0)" />
+</svg>

--- a/docfx/articles/Samples/parsetree-func-call.svg
+++ b/docfx/articles/Samples/parsetree-func-call.svg
@@ -1,0 +1,159 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg viewBox="0 0 1600 520" xmlns="http://www.w3.org/2000/svg" xmlns:inkspace="http://www.inkscape.org/namespaces/inkscape" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs id="defs_block">
+    <filter height="1.504" id="filter_blur" inkspace:collect="always" width="1.1575" x="-0.07875" y="-0.252">
+      <feGaussianBlur id="feGaussianBlur3780" inkspace:collect="always" stdDeviation="4.2" />
+    </filter>
+  </defs>
+  <title>blockdiag</title>
+  <desc>blockdiag
+{
+    default_shape = roundedbox
+    orientation = portrait
+
+    // Nodes
+    N63220684 [label= "TopLevelExpression"];
+    N32115247063220684 [label= "Expression", numbered = 0];
+    N20601768032115247063220684 [label= "FunctionCallExpression"];
+    N51198184020601768032115247063220684 [label= "foo", shape = circle];
+    N58130472120601768032115247063220684 [label= "(", shape = circle];
+    N53412201220601768032115247063220684 [label= "Expression", numbered = 0];
+    N10947764053412201220601768032115247063220684 [label= "ConstExpression"];
+    N31421019010947764053412201220601768032115247063220684 [label= "1", shape = circle];
+    N14353717320601768032115247063220684 [label= ",", shape = circle];
+    N62074597420601768032115247063220684 [label= "Expression", numbered = 0];
+    N21800467062074597420601768032115247063220684 [label= "ConstExpression"];
+    N61986480021800467062074597420601768032115247063220684 [label= "2", shape = circle];
+    N21007413520601768032115247063220684 [label= ",", shape = circle];
+    N54848996620601768032115247063220684 [label= "Expression", numbered = 0];
+    N23878916054848996620601768032115247063220684 [label= "ConstExpression"];
+    N13583655023878916054848996620601768032115247063220684 [label= "3", shape = circle];
+    N55144039720601768032115247063220684 [label= ")", shape = circle];
+
+    // Edges
+    N20601768032115247063220684 -&gt; N51198184020601768032115247063220684
+    N20601768032115247063220684 -&gt; N58130472120601768032115247063220684
+    N10947764053412201220601768032115247063220684 -&gt; N31421019010947764053412201220601768032115247063220684
+    N53412201220601768032115247063220684 -&gt; N10947764053412201220601768032115247063220684
+    N20601768032115247063220684 -&gt; N53412201220601768032115247063220684
+    N20601768032115247063220684 -&gt; N14353717320601768032115247063220684
+    N21800467062074597420601768032115247063220684 -&gt; N61986480021800467062074597420601768032115247063220684
+    N62074597420601768032115247063220684 -&gt; N21800467062074597420601768032115247063220684
+    N20601768032115247063220684 -&gt; N62074597420601768032115247063220684
+    N20601768032115247063220684 -&gt; N21007413520601768032115247063220684
+    N23878916054848996620601768032115247063220684 -&gt; N13583655023878916054848996620601768032115247063220684
+    N54848996620601768032115247063220684 -&gt; N23878916054848996620601768032115247063220684
+    N20601768032115247063220684 -&gt; N54848996620601768032115247063220684
+    N20601768032115247063220684 -&gt; N55144039720601768032115247063220684
+    N32115247063220684 -&gt; N20601768032115247063220684
+    N63220684 -&gt; N32115247063220684
+}
+</desc>
+  <path d="M 75 46 L 187 46 A8,8 0 0 1 195 54 L 195 78 A8,8 0 0 1 187 86 L 75 86 A8,8 0 0 1 67 78 L 67 54 A8,8 0 0 1 75 46" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 75 126 L 187 126 A8,8 0 0 1 195 134 L 195 158 A8,8 0 0 1 187 166 L 75 166 A8,8 0 0 1 67 158 L 67 134 A8,8 0 0 1 75 126" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 75 206 L 187 206 A8,8 0 0 1 195 214 L 195 238 A8,8 0 0 1 187 246 L 75 246 A8,8 0 0 1 67 238 L 67 214 A8,8 0 0 1 75 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="131" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="323" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 459 286 L 571 286 A8,8 0 0 1 579 294 L 579 318 A8,8 0 0 1 571 326 L 459 326 A8,8 0 0 1 451 318 L 451 294 A8,8 0 0 1 459 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="707" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 843 286 L 955 286 A8,8 0 0 1 963 294 L 963 318 A8,8 0 0 1 955 326 L 843 326 A8,8 0 0 1 835 318 L 835 294 A8,8 0 0 1 843 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1091" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1227 286 L 1339 286 A8,8 0 0 1 1347 294 L 1347 318 A8,8 0 0 1 1339 326 L 1227 326 A8,8 0 0 1 1219 318 L 1219 294 A8,8 0 0 1 1227 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1475" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 459 366 L 571 366 A8,8 0 0 1 579 374 L 579 398 A8,8 0 0 1 571 406 L 459 406 A8,8 0 0 1 451 398 L 451 374 A8,8 0 0 1 459 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="515" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 843 366 L 955 366 A8,8 0 0 1 963 374 L 963 398 A8,8 0 0 1 955 406 L 843 406 A8,8 0 0 1 835 398 L 835 374 A8,8 0 0 1 843 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="899" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1227 366 L 1339 366 A8,8 0 0 1 1347 374 L 1347 398 A8,8 0 0 1 1339 406 L 1227 406 A8,8 0 0 1 1219 398 L 1219 374 A8,8 0 0 1 1227 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1283" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 72 40 L 184 40 A8,8 0 0 1 192 48 L 192 72 A8,8 0 0 1 184 80 L 72 80 A8,8 0 0 1 64 72 L 64 48 A8,8 0 0 1 72 40" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="108" x="128" y="66">TopLevelExpression</text>
+  <path d="M 72 120 L 184 120 A8,8 0 0 1 192 128 L 192 152 A8,8 0 0 1 184 160 L 72 160 A8,8 0 0 1 64 152 L 64 128 A8,8 0 0 1 72 120" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="128" y="146">Expression</text>
+  <ellipse cx="64" cy="120" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="64" y="125">0</text>
+  <path d="M 72 200 L 184 200 A8,8 0 0 1 192 208 L 192 232 A8,8 0 0 1 184 240 L 72 240 A8,8 0 0 1 64 232 L 64 208 A8,8 0 0 1 72 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="126" x="128" y="220">FunctionCallExpressio</text>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="128" y="232">n</text>
+  <ellipse cx="128" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="18" x="128" y="305">foo</text>
+  <ellipse cx="320" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="320" y="306">(</text>
+  <path d="M 456 280 L 568 280 A8,8 0 0 1 576 288 L 576 312 A8,8 0 0 1 568 320 L 456 320 A8,8 0 0 1 448 312 L 448 288 A8,8 0 0 1 456 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="512" y="306">Expression</text>
+  <ellipse cx="448" cy="280" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="448" y="285">0</text>
+  <ellipse cx="704" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="704" y="306">,</text>
+  <path d="M 840 280 L 952 280 A8,8 0 0 1 960 288 L 960 312 A8,8 0 0 1 952 320 L 840 320 A8,8 0 0 1 832 312 L 832 288 A8,8 0 0 1 840 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="896" y="306">Expression</text>
+  <ellipse cx="832" cy="280" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="832" y="285">0</text>
+  <ellipse cx="1088" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1088" y="306">,</text>
+  <path d="M 1224 280 L 1336 280 A8,8 0 0 1 1344 288 L 1344 312 A8,8 0 0 1 1336 320 L 1224 320 A8,8 0 0 1 1216 312 L 1216 288 A8,8 0 0 1 1224 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="1280" y="306">Expression</text>
+  <ellipse cx="1216" cy="280" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1216" y="285">0</text>
+  <ellipse cx="1472" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1472" y="306">)</text>
+  <path d="M 456 360 L 568 360 A8,8 0 0 1 576 368 L 576 392 A8,8 0 0 1 568 400 L 456 400 A8,8 0 0 1 448 392 L 448 368 A8,8 0 0 1 456 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="512" y="386">ConstExpression</text>
+  <ellipse cx="512" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="512" y="465">1</text>
+  <path d="M 840 360 L 952 360 A8,8 0 0 1 960 368 L 960 392 A8,8 0 0 1 952 400 L 840 400 A8,8 0 0 1 832 392 L 832 368 A8,8 0 0 1 840 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="896" y="386">ConstExpression</text>
+  <ellipse cx="896" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="896" y="465">2</text>
+  <path d="M 1224 360 L 1336 360 A8,8 0 0 1 1344 368 L 1344 392 A8,8 0 0 1 1336 400 L 1224 400 A8,8 0 0 1 1216 392 L 1216 368 A8,8 0 0 1 1224 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="1280" y="386">ConstExpression</text>
+  <ellipse cx="1280" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1280" y="465">3</text>
+  <path d="M 128 80 L 128 112" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="128,119 124,112 132,112 128,119" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="128,199 124,192 132,192 128,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 240 L 128 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 260 L 1280 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1280 260 L 1280 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1280,279 1276,272 1284,272 1280,279" stroke="rgb(0,0,0)" />
+  <path d="M 128 240 L 128 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 260 L 704 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 704 260 L 704 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="704,275 700,268 708,268 704,275" stroke="rgb(0,0,0)" />
+  <path d="M 128 240 L 128 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="128,275 124,268 132,268 128,275" stroke="rgb(0,0,0)" />
+  <path d="M 128 240 L 128 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 260 L 1088 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 260 L 1088 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,275 1084,268 1092,268 1088,275" stroke="rgb(0,0,0)" />
+  <path d="M 128 240 L 128 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 260 L 512 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 512 260 L 512 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="512,279 508,272 516,272 512,279" stroke="rgb(0,0,0)" />
+  <path d="M 128 240 L 128 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 260 L 320 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 320 260 L 320 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="320,275 316,268 324,268 320,275" stroke="rgb(0,0,0)" />
+  <path d="M 128 240 L 128 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 260 L 1472 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1472 260 L 1472 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1472,275 1468,268 1476,268 1472,275" stroke="rgb(0,0,0)" />
+  <path d="M 128 240 L 128 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 260 L 896 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 896 260 L 896 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="896,279 892,272 900,272 896,279" stroke="rgb(0,0,0)" />
+  <path d="M 512 320 L 512 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="512,359 508,352 516,352 512,359" stroke="rgb(0,0,0)" />
+  <path d="M 512 400 L 512 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="512,435 508,428 516,428 512,435" stroke="rgb(0,0,0)" />
+  <path d="M 896 320 L 896 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="896,359 892,352 900,352 896,359" stroke="rgb(0,0,0)" />
+  <path d="M 896 400 L 896 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="896,435 892,428 900,428 896,435" stroke="rgb(0,0,0)" />
+  <path d="M 1280 320 L 1280 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1280,359 1276,352 1284,352 1280,359" stroke="rgb(0,0,0)" />
+  <path d="M 1280 400 L 1280 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1280,435 1276,428 1284,428 1280,435" stroke="rgb(0,0,0)" />
+</svg>

--- a/docfx/articles/Samples/parsetree-if-else.svg
+++ b/docfx/articles/Samples/parsetree-if-else.svg
@@ -1,0 +1,478 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg viewBox="0 0 4672 840" xmlns="http://www.w3.org/2000/svg" xmlns:inkspace="http://www.inkscape.org/namespaces/inkscape" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs id="defs_block">
+    <filter height="1.504" id="filter_blur" inkspace:collect="always" width="1.1575" x="-0.07875" y="-0.252">
+      <feGaussianBlur id="feGaussianBlur3780" inkspace:collect="always" stdDeviation="4.2" />
+    </filter>
+  </defs>
+  <title>blockdiag</title>
+  <desc>blockdiag
+{
+    default_shape = roundedbox
+    orientation = portrait
+
+    // Nodes
+    N61705107 [label= "FunctionDefinition"];
+    N18475057061705107 [label= "def", shape = circle];
+    N32057793161705107 [label= "FunctionPrototype"];
+    N20084682032057793161705107 [label= "fib", shape = circle];
+    N46544415132057793161705107 [label= "(", shape = circle];
+    N16246551232057793161705107 [label= "x", shape = circle];
+    N12001237332057793161705107 [label= ")", shape = circle];
+    N40902273261705107 [label= "Expression", numbered = 0];
+    N32576140040902273261705107 [label= "ConditionalExpression"];
+    N24749807032576140040902273261705107 [label= "if", shape = circle];
+    N21421675132576140040902273261705107 [label= "Expression", numbered = 0];
+    N58577354021421675132576140040902273261705107 [label= "ParenExpression"];
+    N57434139058577354021421675132576140040902273261705107 [label= "(", shape = circle];
+    N47145209158577354021421675132576140040902273261705107 [label= "Expression", numbered = 0];
+    N21653700047145209158577354021421675132576140040902273261705107 [label= "VariableExpression"];
+    N60665573021653700047145209158577354021421675132576140040902273261705107 [label= "x", shape = circle];
+    N9119245147145209158577354021421675132576140040902273261705107 [label= "Binaryop"];
+    N1496434109119245147145209158577354021421675132576140040902273261705107 [label= "&lt;", shape = circle];
+    N461342247145209158577354021421675132576140040902273261705107 [label= "Expression", numbered = 11];
+    N41520810461342247145209158577354021421675132576140040902273261705107 [label= "ConstExpression"];
+    N37368736041520810461342247145209158577354021421675132576140040902273261705107 [label= "3", shape = circle];
+    N774306258577354021421675132576140040902273261705107 [label= ")", shape = circle];
+    N6968762232576140040902273261705107 [label= "then", shape = circle];
+    N62718864332576140040902273261705107 [label= "Expression", numbered = 0];
+    N27598869062718864332576140040902273261705107 [label= "ConstExpression"];
+    N47063234027598869062718864332576140040902273261705107 [label= "1", shape = circle];
+    N20915929432576140040902273261705107 [label= "else", shape = circle];
+    N54025633532576140040902273261705107 [label= "Expression", numbered = 0];
+    N16468652054025633532576140040902273261705107 [label= "FunctionCallExpression"];
+    N14000148016468652054025633532576140040902273261705107 [label= "fib", shape = circle];
+    N58892473116468652054025633532576140040902273261705107 [label= "(", shape = circle];
+    N60270212216468652054025633532576140040902273261705107 [label= "Expression", numbered = 0];
+    N5560998060270212216468652054025633532576140040902273261705107 [label= "VariableExpression"];
+    N5004898405560998060270212216468652054025633532576140040902273261705107 [label= "x", shape = circle];
+    N47787675160270212216468652054025633532576140040902273261705107 [label= "Binaryop"];
+    N27435897047787675160270212216468652054025633532576140040902273261705107 [label= "-", shape = circle];
+    N45596481260270212216468652054025633532576140040902273261705107 [label= "Expression", numbered = 21];
+    N7715150045596481260270212216468652054025633532576140040902273261705107 [label= "ConstExpression"];
+    N232748707715150045596481260270212216468652054025633532576140040902273261705107 [label= "1", shape = circle];
+    N20947391316468652054025633532576140040902273261705107 [label= ")", shape = circle];
+    N54308798154025633532576140040902273261705107 [label= "Binaryop"];
+    N19017142054308798154025633532576140040902273261705107 [label= "+", shape = circle];
+    N36936550254025633532576140040902273261705107 [label= "Expression", numbered = 21];
+    N63993496036936550254025633532576140040902273261705107 [label= "FunctionCallExpression"];
+    N39070558063993496036936550254025633532576140040902273261705107 [label= "fib", shape = circle];
+    N16090703163993496036936550254025633532576140040902273261705107 [label= "(", shape = circle];
+    N10598606263993496036936550254025633532576140040902273261705107 [label= "Expression", numbered = 0];
+    N28278595010598606263993496036936550254025633532576140040902273261705107 [label= "VariableExpression"];
+    N53180767028278595010598606263993496036936550254025633532576140040902273261705107 [label= "x", shape = circle];
+    N8864859110598606263993496036936550254025633532576140040902273261705107 [label= "Binaryop"];
+    N1267487208864859110598606263993496036936550254025633532576140040902273261705107 [label= "-", shape = circle];
+    N46964992210598606263993496036936550254025633532576140040902273261705107 [label= "Expression", numbered = 21];
+    N20031746046964992210598606263993496036936550254025633532576140040902273261705107 [label= "ConstExpression"];
+    N46067993020031746046964992210598606263993496036936550254025633532576140040902273261705107 [label= "2", shape = circle];
+    N11958757363993496036936550254025633532576140040902273261705107 [label= ")", shape = circle];
+
+    // Edges
+    N61705107 -&gt; N18475057061705107
+    N32057793161705107 -&gt; N20084682032057793161705107
+    N32057793161705107 -&gt; N46544415132057793161705107
+    N32057793161705107 -&gt; N16246551232057793161705107
+    N32057793161705107 -&gt; N12001237332057793161705107
+    N61705107 -&gt; N32057793161705107
+    N32576140040902273261705107 -&gt; N24749807032576140040902273261705107
+    N58577354021421675132576140040902273261705107 -&gt; N57434139058577354021421675132576140040902273261705107
+    N21653700047145209158577354021421675132576140040902273261705107 -&gt; N60665573021653700047145209158577354021421675132576140040902273261705107
+    N47145209158577354021421675132576140040902273261705107 -&gt; N21653700047145209158577354021421675132576140040902273261705107
+    N9119245147145209158577354021421675132576140040902273261705107 -&gt; N1496434109119245147145209158577354021421675132576140040902273261705107
+    N47145209158577354021421675132576140040902273261705107 -&gt; N9119245147145209158577354021421675132576140040902273261705107
+    N41520810461342247145209158577354021421675132576140040902273261705107 -&gt; N37368736041520810461342247145209158577354021421675132576140040902273261705107
+    N461342247145209158577354021421675132576140040902273261705107 -&gt; N41520810461342247145209158577354021421675132576140040902273261705107
+    N47145209158577354021421675132576140040902273261705107 -&gt; N461342247145209158577354021421675132576140040902273261705107
+    N58577354021421675132576140040902273261705107 -&gt; N47145209158577354021421675132576140040902273261705107
+    N58577354021421675132576140040902273261705107 -&gt; N774306258577354021421675132576140040902273261705107
+    N21421675132576140040902273261705107 -&gt; N58577354021421675132576140040902273261705107
+    N32576140040902273261705107 -&gt; N21421675132576140040902273261705107
+    N32576140040902273261705107 -&gt; N6968762232576140040902273261705107
+    N27598869062718864332576140040902273261705107 -&gt; N47063234027598869062718864332576140040902273261705107
+    N62718864332576140040902273261705107 -&gt; N27598869062718864332576140040902273261705107
+    N32576140040902273261705107 -&gt; N62718864332576140040902273261705107
+    N32576140040902273261705107 -&gt; N20915929432576140040902273261705107
+    N16468652054025633532576140040902273261705107 -&gt; N14000148016468652054025633532576140040902273261705107
+    N16468652054025633532576140040902273261705107 -&gt; N58892473116468652054025633532576140040902273261705107
+    N5560998060270212216468652054025633532576140040902273261705107 -&gt; N5004898405560998060270212216468652054025633532576140040902273261705107
+    N60270212216468652054025633532576140040902273261705107 -&gt; N5560998060270212216468652054025633532576140040902273261705107
+    N47787675160270212216468652054025633532576140040902273261705107 -&gt; N27435897047787675160270212216468652054025633532576140040902273261705107
+    N60270212216468652054025633532576140040902273261705107 -&gt; N47787675160270212216468652054025633532576140040902273261705107
+    N7715150045596481260270212216468652054025633532576140040902273261705107 -&gt; N232748707715150045596481260270212216468652054025633532576140040902273261705107
+    N45596481260270212216468652054025633532576140040902273261705107 -&gt; N7715150045596481260270212216468652054025633532576140040902273261705107
+    N60270212216468652054025633532576140040902273261705107 -&gt; N45596481260270212216468652054025633532576140040902273261705107
+    N16468652054025633532576140040902273261705107 -&gt; N60270212216468652054025633532576140040902273261705107
+    N16468652054025633532576140040902273261705107 -&gt; N20947391316468652054025633532576140040902273261705107
+    N54025633532576140040902273261705107 -&gt; N16468652054025633532576140040902273261705107
+    N54308798154025633532576140040902273261705107 -&gt; N19017142054308798154025633532576140040902273261705107
+    N54025633532576140040902273261705107 -&gt; N54308798154025633532576140040902273261705107
+    N63993496036936550254025633532576140040902273261705107 -&gt; N39070558063993496036936550254025633532576140040902273261705107
+    N63993496036936550254025633532576140040902273261705107 -&gt; N16090703163993496036936550254025633532576140040902273261705107
+    N28278595010598606263993496036936550254025633532576140040902273261705107 -&gt; N53180767028278595010598606263993496036936550254025633532576140040902273261705107
+    N10598606263993496036936550254025633532576140040902273261705107 -&gt; N28278595010598606263993496036936550254025633532576140040902273261705107
+    N8864859110598606263993496036936550254025633532576140040902273261705107 -&gt; N1267487208864859110598606263993496036936550254025633532576140040902273261705107
+    N10598606263993496036936550254025633532576140040902273261705107 -&gt; N8864859110598606263993496036936550254025633532576140040902273261705107
+    N20031746046964992210598606263993496036936550254025633532576140040902273261705107 -&gt; N46067993020031746046964992210598606263993496036936550254025633532576140040902273261705107
+    N46964992210598606263993496036936550254025633532576140040902273261705107 -&gt; N20031746046964992210598606263993496036936550254025633532576140040902273261705107
+    N10598606263993496036936550254025633532576140040902273261705107 -&gt; N46964992210598606263993496036936550254025633532576140040902273261705107
+    N63993496036936550254025633532576140040902273261705107 -&gt; N10598606263993496036936550254025633532576140040902273261705107
+    N63993496036936550254025633532576140040902273261705107 -&gt; N11958757363993496036936550254025633532576140040902273261705107
+    N36936550254025633532576140040902273261705107 -&gt; N63993496036936550254025633532576140040902273261705107
+    N54025633532576140040902273261705107 -&gt; N36936550254025633532576140040902273261705107
+    N32576140040902273261705107 -&gt; N54025633532576140040902273261705107
+    N40902273261705107 -&gt; N32576140040902273261705107
+    N61705107 -&gt; N40902273261705107
+}
+</desc>
+  <path d="M 75 46 L 187 46 A8,8 0 0 1 195 54 L 195 78 A8,8 0 0 1 187 86 L 75 86 A8,8 0 0 1 67 78 L 67 54 A8,8 0 0 1 75 46" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="131" cy="146" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 267 126 L 379 126 A8,8 0 0 1 387 134 L 387 158 A8,8 0 0 1 379 166 L 267 166 A8,8 0 0 1 259 158 L 259 134 A8,8 0 0 1 267 126" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1035 126 L 1147 126 A8,8 0 0 1 1155 134 L 1155 158 A8,8 0 0 1 1147 166 L 1035 166 A8,8 0 0 1 1027 158 L 1027 134 A8,8 0 0 1 1035 126" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="323" cy="226" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="515" cy="226" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="707" cy="226" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="899" cy="226" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1035 206 L 1147 206 A8,8 0 0 1 1155 214 L 1155 238 A8,8 0 0 1 1147 246 L 1035 246 A8,8 0 0 1 1027 238 L 1027 214 A8,8 0 0 1 1035 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1091" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1227 286 L 1339 286 A8,8 0 0 1 1347 294 L 1347 318 A8,8 0 0 1 1339 326 L 1227 326 A8,8 0 0 1 1219 318 L 1219 294 A8,8 0 0 1 1227 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="2051" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 2187 286 L 2299 286 A8,8 0 0 1 2307 294 L 2307 318 A8,8 0 0 1 2299 326 L 2187 326 A8,8 0 0 1 2179 318 L 2179 294 A8,8 0 0 1 2187 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="2435" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 2571 286 L 2683 286 A8,8 0 0 1 2691 294 L 2691 318 A8,8 0 0 1 2683 326 L 2571 326 A8,8 0 0 1 2563 318 L 2563 294 A8,8 0 0 1 2571 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1227 366 L 1339 366 A8,8 0 0 1 1347 374 L 1347 398 A8,8 0 0 1 1339 406 L 1227 406 A8,8 0 0 1 1219 398 L 1219 374 A8,8 0 0 1 1227 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1283" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1419 446 L 1531 446 A8,8 0 0 1 1539 454 L 1539 478 A8,8 0 0 1 1531 486 L 1419 486 A8,8 0 0 1 1411 478 L 1411 454 A8,8 0 0 1 1419 446" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1667" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1419 526 L 1531 526 A8,8 0 0 1 1539 534 L 1539 558 A8,8 0 0 1 1531 566 L 1419 566 A8,8 0 0 1 1411 558 L 1411 534 A8,8 0 0 1 1419 526" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1611 526 L 1723 526 A8,8 0 0 1 1731 534 L 1731 558 A8,8 0 0 1 1723 566 L 1611 566 A8,8 0 0 1 1603 558 L 1603 534 A8,8 0 0 1 1611 526" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1803 526 L 1915 526 A8,8 0 0 1 1923 534 L 1923 558 A8,8 0 0 1 1915 566 L 1803 566 A8,8 0 0 1 1795 558 L 1795 534 A8,8 0 0 1 1803 526" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1475" cy="626" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1667" cy="626" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1803 606 L 1915 606 A8,8 0 0 1 1923 614 L 1923 638 A8,8 0 0 1 1915 646 L 1803 646 A8,8 0 0 1 1795 638 L 1795 614 A8,8 0 0 1 1803 606" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1859" cy="706" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 2187 366 L 2299 366 A8,8 0 0 1 2307 374 L 2307 398 A8,8 0 0 1 2299 406 L 2187 406 A8,8 0 0 1 2179 398 L 2179 374 A8,8 0 0 1 2187 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="2243" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 2571 366 L 2683 366 A8,8 0 0 1 2691 374 L 2691 398 A8,8 0 0 1 2683 406 L 2571 406 A8,8 0 0 1 2563 398 L 2563 374 A8,8 0 0 1 2571 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 3531 366 L 3643 366 A8,8 0 0 1 3651 374 L 3651 398 A8,8 0 0 1 3643 406 L 3531 406 A8,8 0 0 1 3523 398 L 3523 374 A8,8 0 0 1 3531 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 3723 366 L 3835 366 A8,8 0 0 1 3843 374 L 3843 398 A8,8 0 0 1 3835 406 L 3723 406 A8,8 0 0 1 3715 398 L 3715 374 A8,8 0 0 1 3723 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="2627" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="2819" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 2955 446 L 3067 446 A8,8 0 0 1 3075 454 L 3075 478 A8,8 0 0 1 3067 486 L 2955 486 A8,8 0 0 1 2947 478 L 2947 454 A8,8 0 0 1 2955 446" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="3203" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 2955 526 L 3067 526 A8,8 0 0 1 3075 534 L 3075 558 A8,8 0 0 1 3067 566 L 2955 566 A8,8 0 0 1 2947 558 L 2947 534 A8,8 0 0 1 2955 526" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 3147 526 L 3259 526 A8,8 0 0 1 3267 534 L 3267 558 A8,8 0 0 1 3259 566 L 3147 566 A8,8 0 0 1 3139 558 L 3139 534 A8,8 0 0 1 3147 526" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 3339 526 L 3451 526 A8,8 0 0 1 3459 534 L 3459 558 A8,8 0 0 1 3451 566 L 3339 566 A8,8 0 0 1 3331 558 L 3331 534 A8,8 0 0 1 3339 526" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="3011" cy="626" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="3203" cy="626" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 3339 606 L 3451 606 A8,8 0 0 1 3459 614 L 3459 638 A8,8 0 0 1 3451 646 L 3339 646 A8,8 0 0 1 3331 638 L 3331 614 A8,8 0 0 1 3339 606" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="3395" cy="706" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="3587" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 3723 446 L 3835 446 A8,8 0 0 1 3843 454 L 3843 478 A8,8 0 0 1 3835 486 L 3723 486 A8,8 0 0 1 3715 478 L 3715 454 A8,8 0 0 1 3723 446" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="3779" cy="546" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="3971" cy="546" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 4107 526 L 4219 526 A8,8 0 0 1 4227 534 L 4227 558 A8,8 0 0 1 4219 566 L 4107 566 A8,8 0 0 1 4099 558 L 4099 534 A8,8 0 0 1 4107 526" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="4355" cy="546" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 4107 606 L 4219 606 A8,8 0 0 1 4227 614 L 4227 638 A8,8 0 0 1 4219 646 L 4107 646 A8,8 0 0 1 4099 638 L 4099 614 A8,8 0 0 1 4107 606" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 4299 606 L 4411 606 A8,8 0 0 1 4419 614 L 4419 638 A8,8 0 0 1 4411 646 L 4299 646 A8,8 0 0 1 4291 638 L 4291 614 A8,8 0 0 1 4299 606" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 4491 606 L 4603 606 A8,8 0 0 1 4611 614 L 4611 638 A8,8 0 0 1 4603 646 L 4491 646 A8,8 0 0 1 4483 638 L 4483 614 A8,8 0 0 1 4491 606" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="4163" cy="706" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="4355" cy="706" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 4491 686 L 4603 686 A8,8 0 0 1 4611 694 L 4611 718 A8,8 0 0 1 4603 726 L 4491 726 A8,8 0 0 1 4483 718 L 4483 694 A8,8 0 0 1 4491 686" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="4547" cy="786" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 72 40 L 184 40 A8,8 0 0 1 192 48 L 192 72 A8,8 0 0 1 184 80 L 72 80 A8,8 0 0 1 64 72 L 64 48 A8,8 0 0 1 72 40" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="108" x="128" y="65">FunctionDefinition</text>
+  <ellipse cx="128" cy="140" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="18" x="128" y="145">def</text>
+  <path d="M 264 120 L 376 120 A8,8 0 0 1 384 128 L 384 152 A8,8 0 0 1 376 160 L 264 160 A8,8 0 0 1 256 152 L 256 128 A8,8 0 0 1 264 120" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="102" x="320" y="146">FunctionPrototype</text>
+  <path d="M 1032 120 L 1144 120 A8,8 0 0 1 1152 128 L 1152 152 A8,8 0 0 1 1144 160 L 1032 160 A8,8 0 0 1 1024 152 L 1024 128 A8,8 0 0 1 1032 120" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="1088" y="146">Expression</text>
+  <ellipse cx="1024" cy="120" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1024" y="125">0</text>
+  <ellipse cx="320" cy="220" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="18" x="320" y="225">fib</text>
+  <ellipse cx="512" cy="220" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="512" y="226">(</text>
+  <ellipse cx="704" cy="220" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="704" y="225">x</text>
+  <ellipse cx="896" cy="220" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="896" y="226">)</text>
+  <path d="M 1032 200 L 1144 200 A8,8 0 0 1 1152 208 L 1152 232 A8,8 0 0 1 1144 240 L 1032 240 A8,8 0 0 1 1024 232 L 1024 208 A8,8 0 0 1 1032 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="126" x="1088" y="226">ConditionalExpression</text>
+  <ellipse cx="1088" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="1088" y="305">if</text>
+  <path d="M 1224 280 L 1336 280 A8,8 0 0 1 1344 288 L 1344 312 A8,8 0 0 1 1336 320 L 1224 320 A8,8 0 0 1 1216 312 L 1216 288 A8,8 0 0 1 1224 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="1280" y="306">Expression</text>
+  <ellipse cx="1216" cy="280" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1216" y="285">0</text>
+  <ellipse cx="2048" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="24" x="2048" y="305">then</text>
+  <path d="M 2184 280 L 2296 280 A8,8 0 0 1 2304 288 L 2304 312 A8,8 0 0 1 2296 320 L 2184 320 A8,8 0 0 1 2176 312 L 2176 288 A8,8 0 0 1 2184 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="2240" y="306">Expression</text>
+  <ellipse cx="2176" cy="280" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="2176" y="285">0</text>
+  <ellipse cx="2432" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="24" x="2432" y="305">else</text>
+  <path d="M 2568 280 L 2680 280 A8,8 0 0 1 2688 288 L 2688 312 A8,8 0 0 1 2680 320 L 2568 320 A8,8 0 0 1 2560 312 L 2560 288 A8,8 0 0 1 2568 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="2624" y="306">Expression</text>
+  <ellipse cx="2560" cy="280" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="2560" y="285">0</text>
+  <path d="M 1224 360 L 1336 360 A8,8 0 0 1 1344 368 L 1344 392 A8,8 0 0 1 1336 400 L 1224 400 A8,8 0 0 1 1216 392 L 1216 368 A8,8 0 0 1 1224 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="1280" y="386">ParenExpression</text>
+  <ellipse cx="1280" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1280" y="466">(</text>
+  <path d="M 1416 440 L 1528 440 A8,8 0 0 1 1536 448 L 1536 472 A8,8 0 0 1 1528 480 L 1416 480 A8,8 0 0 1 1408 472 L 1408 448 A8,8 0 0 1 1416 440" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="1472" y="466">Expression</text>
+  <ellipse cx="1408" cy="440" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1408" y="445">0</text>
+  <ellipse cx="1664" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1664" y="466">)</text>
+  <path d="M 1416 520 L 1528 520 A8,8 0 0 1 1536 528 L 1536 552 A8,8 0 0 1 1528 560 L 1416 560 A8,8 0 0 1 1408 552 L 1408 528 A8,8 0 0 1 1416 520" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="108" x="1472" y="546">VariableExpression</text>
+  <path d="M 1608 520 L 1720 520 A8,8 0 0 1 1728 528 L 1728 552 A8,8 0 0 1 1720 560 L 1608 560 A8,8 0 0 1 1600 552 L 1600 528 A8,8 0 0 1 1608 520" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="1664" y="546">Binaryop</text>
+  <path d="M 1800 520 L 1912 520 A8,8 0 0 1 1920 528 L 1920 552 A8,8 0 0 1 1912 560 L 1800 560 A8,8 0 0 1 1792 552 L 1792 528 A8,8 0 0 1 1800 520" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="1856" y="546">Expression</text>
+  <ellipse cx="1792" cy="520" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="1792" y="525">11</text>
+  <ellipse cx="1472" cy="620" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1472" y="625">x</text>
+  <ellipse cx="1664" cy="620" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1664" y="625">&lt;</text>
+  <path d="M 1800 600 L 1912 600 A8,8 0 0 1 1920 608 L 1920 632 A8,8 0 0 1 1912 640 L 1800 640 A8,8 0 0 1 1792 632 L 1792 608 A8,8 0 0 1 1800 600" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="1856" y="626">ConstExpression</text>
+  <ellipse cx="1856" cy="700" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1856" y="705">3</text>
+  <path d="M 2184 360 L 2296 360 A8,8 0 0 1 2304 368 L 2304 392 A8,8 0 0 1 2296 400 L 2184 400 A8,8 0 0 1 2176 392 L 2176 368 A8,8 0 0 1 2184 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="2240" y="386">ConstExpression</text>
+  <ellipse cx="2240" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="2240" y="465">1</text>
+  <path d="M 2568 360 L 2680 360 A8,8 0 0 1 2688 368 L 2688 392 A8,8 0 0 1 2680 400 L 2568 400 A8,8 0 0 1 2560 392 L 2560 368 A8,8 0 0 1 2568 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="126" x="2624" y="380">FunctionCallExpressio</text>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="2624" y="392">n</text>
+  <path d="M 3528 360 L 3640 360 A8,8 0 0 1 3648 368 L 3648 392 A8,8 0 0 1 3640 400 L 3528 400 A8,8 0 0 1 3520 392 L 3520 368 A8,8 0 0 1 3528 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="3584" y="386">Binaryop</text>
+  <path d="M 3720 360 L 3832 360 A8,8 0 0 1 3840 368 L 3840 392 A8,8 0 0 1 3832 400 L 3720 400 A8,8 0 0 1 3712 392 L 3712 368 A8,8 0 0 1 3720 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="3776" y="386">Expression</text>
+  <ellipse cx="3712" cy="360" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="3712" y="365">21</text>
+  <ellipse cx="2624" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="18" x="2624" y="465">fib</text>
+  <ellipse cx="2816" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="2816" y="466">(</text>
+  <path d="M 2952 440 L 3064 440 A8,8 0 0 1 3072 448 L 3072 472 A8,8 0 0 1 3064 480 L 2952 480 A8,8 0 0 1 2944 472 L 2944 448 A8,8 0 0 1 2952 440" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="3008" y="466">Expression</text>
+  <ellipse cx="2944" cy="440" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="2944" y="445">0</text>
+  <ellipse cx="3200" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="3200" y="466">)</text>
+  <path d="M 2952 520 L 3064 520 A8,8 0 0 1 3072 528 L 3072 552 A8,8 0 0 1 3064 560 L 2952 560 A8,8 0 0 1 2944 552 L 2944 528 A8,8 0 0 1 2952 520" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="108" x="3008" y="546">VariableExpression</text>
+  <path d="M 3144 520 L 3256 520 A8,8 0 0 1 3264 528 L 3264 552 A8,8 0 0 1 3256 560 L 3144 560 A8,8 0 0 1 3136 552 L 3136 528 A8,8 0 0 1 3144 520" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="3200" y="546">Binaryop</text>
+  <path d="M 3336 520 L 3448 520 A8,8 0 0 1 3456 528 L 3456 552 A8,8 0 0 1 3448 560 L 3336 560 A8,8 0 0 1 3328 552 L 3328 528 A8,8 0 0 1 3336 520" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="3392" y="546">Expression</text>
+  <ellipse cx="3328" cy="520" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="3328" y="525">21</text>
+  <ellipse cx="3008" cy="620" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="3008" y="625">x</text>
+  <ellipse cx="3200" cy="620" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="3200" y="625">-</text>
+  <path d="M 3336 600 L 3448 600 A8,8 0 0 1 3456 608 L 3456 632 A8,8 0 0 1 3448 640 L 3336 640 A8,8 0 0 1 3328 632 L 3328 608 A8,8 0 0 1 3336 600" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="3392" y="626">ConstExpression</text>
+  <ellipse cx="3392" cy="700" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="3392" y="705">1</text>
+  <ellipse cx="3584" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="3584" y="465">+</text>
+  <path d="M 3720 440 L 3832 440 A8,8 0 0 1 3840 448 L 3840 472 A8,8 0 0 1 3832 480 L 3720 480 A8,8 0 0 1 3712 472 L 3712 448 A8,8 0 0 1 3720 440" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="126" x="3776" y="460">FunctionCallExpressio</text>
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="3776" y="472">n</text>
+  <ellipse cx="3776" cy="540" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="18" x="3776" y="545">fib</text>
+  <ellipse cx="3968" cy="540" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="3968" y="546">(</text>
+  <path d="M 4104 520 L 4216 520 A8,8 0 0 1 4224 528 L 4224 552 A8,8 0 0 1 4216 560 L 4104 560 A8,8 0 0 1 4096 552 L 4096 528 A8,8 0 0 1 4104 520" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="4160" y="546">Expression</text>
+  <ellipse cx="4096" cy="520" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="4096" y="525">0</text>
+  <ellipse cx="4352" cy="540" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="4352" y="546">)</text>
+  <path d="M 4104 600 L 4216 600 A8,8 0 0 1 4224 608 L 4224 632 A8,8 0 0 1 4216 640 L 4104 640 A8,8 0 0 1 4096 632 L 4096 608 A8,8 0 0 1 4104 600" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="108" x="4160" y="626">VariableExpression</text>
+  <path d="M 4296 600 L 4408 600 A8,8 0 0 1 4416 608 L 4416 632 A8,8 0 0 1 4408 640 L 4296 640 A8,8 0 0 1 4288 632 L 4288 608 A8,8 0 0 1 4296 600" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="4352" y="626">Binaryop</text>
+  <path d="M 4488 600 L 4600 600 A8,8 0 0 1 4608 608 L 4608 632 A8,8 0 0 1 4600 640 L 4488 640 A8,8 0 0 1 4480 632 L 4480 608 A8,8 0 0 1 4488 600" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="4544" y="626">Expression</text>
+  <ellipse cx="4480" cy="600" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="4480" y="605">21</text>
+  <ellipse cx="4160" cy="700" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="4160" y="705">x</text>
+  <ellipse cx="4352" cy="700" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="4352" y="705">-</text>
+  <path d="M 4488 680 L 4600 680 A8,8 0 0 1 4608 688 L 4608 712 A8,8 0 0 1 4600 720 L 4488 720 A8,8 0 0 1 4480 712 L 4480 688 A8,8 0 0 1 4488 680" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="4544" y="706">ConstExpression</text>
+  <ellipse cx="4544" cy="780" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="4544" y="785">2</text>
+  <path d="M 128 80 L 128 100" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 100 L 320 100" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 320 100 L 320 112" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="320,119 316,112 324,112 320,119" stroke="rgb(0,0,0)" />
+  <path d="M 128 80 L 128 108" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="128,115 124,108 132,108 128,115" stroke="rgb(0,0,0)" />
+  <path d="M 128 80 L 128 100" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 100 L 1088 100" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 100 L 1088 112" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,119 1084,112 1092,112 1088,119" stroke="rgb(0,0,0)" />
+  <path d="M 320 160 L 320 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 320 180 L 704 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 704 180 L 704 188" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="704,195 700,188 708,188 704,195" stroke="rgb(0,0,0)" />
+  <path d="M 320 160 L 320 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 320 180 L 896 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 896 180 L 896 188" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="896,195 892,188 900,188 896,195" stroke="rgb(0,0,0)" />
+  <path d="M 320 160 L 320 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 320 180 L 512 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 512 180 L 512 188" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="512,195 508,188 516,188 512,195" stroke="rgb(0,0,0)" />
+  <path d="M 320 160 L 320 188" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="320,195 316,188 324,188 320,195" stroke="rgb(0,0,0)" />
+  <path d="M 1088 160 L 1088 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,199 1084,192 1092,192 1088,199" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 260 L 2240 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2240 260 L 2240 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2240,279 2236,272 2244,272 2240,279" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 260 L 2432 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2432 260 L 2432 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2432,275 2428,268 2436,268 2432,275" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 260 L 1280 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1280 260 L 1280 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1280,279 1276,272 1284,272 1280,279" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,275 1084,268 1092,268 1088,275" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 260 L 2048 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2048 260 L 2048 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2048,275 2044,268 2052,268 2048,275" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 260 L 2624 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2624 260 L 2624 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2624,279 2620,272 2628,272 2624,279" stroke="rgb(0,0,0)" />
+  <path d="M 1280 320 L 1280 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1280,359 1276,352 1284,352 1280,359" stroke="rgb(0,0,0)" />
+  <path d="M 1280 400 L 1280 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1280,435 1276,428 1284,428 1280,435" stroke="rgb(0,0,0)" />
+  <path d="M 1280 400 L 1280 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1280 420 L 1472 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1472 420 L 1472 432" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1472,439 1468,432 1476,432 1472,439" stroke="rgb(0,0,0)" />
+  <path d="M 1280 400 L 1280 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1280 420 L 1664 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1664 420 L 1664 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1664,435 1660,428 1668,428 1664,435" stroke="rgb(0,0,0)" />
+  <path d="M 1472 480 L 1472 500" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1472 500 L 1664 500" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1664 500 L 1664 512" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1664,519 1660,512 1668,512 1664,519" stroke="rgb(0,0,0)" />
+  <path d="M 1472 480 L 1472 512" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1472,519 1468,512 1476,512 1472,519" stroke="rgb(0,0,0)" />
+  <path d="M 1472 480 L 1472 500" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1472 500 L 1856 500" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1856 500 L 1856 512" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1856,519 1852,512 1860,512 1856,519" stroke="rgb(0,0,0)" />
+  <path d="M 1472 560 L 1472 588" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1472,595 1468,588 1476,588 1472,595" stroke="rgb(0,0,0)" />
+  <path d="M 1664 560 L 1664 588" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1664,595 1660,588 1668,588 1664,595" stroke="rgb(0,0,0)" />
+  <path d="M 1856 560 L 1856 592" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1856,599 1852,592 1860,592 1856,599" stroke="rgb(0,0,0)" />
+  <path d="M 1856 640 L 1856 668" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1856,675 1852,668 1860,668 1856,675" stroke="rgb(0,0,0)" />
+  <path d="M 2240 320 L 2240 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2240,359 2236,352 2244,352 2240,359" stroke="rgb(0,0,0)" />
+  <path d="M 2240 400 L 2240 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2240,435 2236,428 2244,428 2240,435" stroke="rgb(0,0,0)" />
+  <path d="M 2624 320 L 2624 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2624 340 L 3776 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3776 340 L 3776 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3776,359 3772,352 3780,352 3776,359" stroke="rgb(0,0,0)" />
+  <path d="M 2624 320 L 2624 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2624 340 L 3584 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3584 340 L 3584 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3584,359 3580,352 3588,352 3584,359" stroke="rgb(0,0,0)" />
+  <path d="M 2624 320 L 2624 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2624,359 2620,352 2628,352 2624,359" stroke="rgb(0,0,0)" />
+  <path d="M 2624 400 L 2624 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2624 420 L 3008 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3008 420 L 3008 432" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3008,439 3004,432 3012,432 3008,439" stroke="rgb(0,0,0)" />
+  <path d="M 2624 400 L 2624 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2624 420 L 2816 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2816 420 L 2816 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2816,435 2812,428 2820,428 2816,435" stroke="rgb(0,0,0)" />
+  <path d="M 2624 400 L 2624 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2624,435 2620,428 2628,428 2624,435" stroke="rgb(0,0,0)" />
+  <path d="M 2624 400 L 2624 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2624 420 L 3200 420" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3200 420 L 3200 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3200,435 3196,428 3204,428 3200,435" stroke="rgb(0,0,0)" />
+  <path d="M 3008 480 L 3008 500" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3008 500 L 3200 500" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3200 500 L 3200 512" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3200,519 3196,512 3204,512 3200,519" stroke="rgb(0,0,0)" />
+  <path d="M 3008 480 L 3008 500" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3008 500 L 3392 500" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3392 500 L 3392 512" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3392,519 3388,512 3396,512 3392,519" stroke="rgb(0,0,0)" />
+  <path d="M 3008 480 L 3008 512" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3008,519 3004,512 3012,512 3008,519" stroke="rgb(0,0,0)" />
+  <path d="M 3008 560 L 3008 588" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3008,595 3004,588 3012,588 3008,595" stroke="rgb(0,0,0)" />
+  <path d="M 3200 560 L 3200 588" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3200,595 3196,588 3204,588 3200,595" stroke="rgb(0,0,0)" />
+  <path d="M 3392 560 L 3392 592" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3392,599 3388,592 3396,592 3392,599" stroke="rgb(0,0,0)" />
+  <path d="M 3392 640 L 3392 668" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3392,675 3388,668 3396,668 3392,675" stroke="rgb(0,0,0)" />
+  <path d="M 3584 400 L 3584 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3584,435 3580,428 3588,428 3584,435" stroke="rgb(0,0,0)" />
+  <path d="M 3776 400 L 3776 432" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3776,439 3772,432 3780,432 3776,439" stroke="rgb(0,0,0)" />
+  <path d="M 3776 480 L 3776 500" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3776 500 L 3968 500" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3968 500 L 3968 508" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3968,515 3964,508 3972,508 3968,515" stroke="rgb(0,0,0)" />
+  <path d="M 3776 480 L 3776 500" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3776 500 L 4352 500" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 4352 500 L 4352 508" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="4352,515 4348,508 4356,508 4352,515" stroke="rgb(0,0,0)" />
+  <path d="M 3776 480 L 3776 500" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 3776 500 L 4160 500" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 4160 500 L 4160 512" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="4160,519 4156,512 4164,512 4160,519" stroke="rgb(0,0,0)" />
+  <path d="M 3776 480 L 3776 508" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="3776,515 3772,508 3780,508 3776,515" stroke="rgb(0,0,0)" />
+  <path d="M 4160 560 L 4160 580" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 4160 580 L 4544 580" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 4544 580 L 4544 592" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="4544,599 4540,592 4548,592 4544,599" stroke="rgb(0,0,0)" />
+  <path d="M 4160 560 L 4160 592" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="4160,599 4156,592 4164,592 4160,599" stroke="rgb(0,0,0)" />
+  <path d="M 4160 560 L 4160 580" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 4160 580 L 4352 580" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 4352 580 L 4352 592" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="4352,599 4348,592 4356,592 4352,599" stroke="rgb(0,0,0)" />
+  <path d="M 4160 640 L 4160 668" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="4160,675 4156,668 4164,668 4160,675" stroke="rgb(0,0,0)" />
+  <path d="M 4352 640 L 4352 668" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="4352,675 4348,668 4356,668 4352,675" stroke="rgb(0,0,0)" />
+  <path d="M 4544 640 L 4544 672" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="4544,679 4540,672 4548,672 4544,679" stroke="rgb(0,0,0)" />
+  <path d="M 4544 720 L 4544 748" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="4544,755 4540,748 4548,748 4544,755" stroke="rgb(0,0,0)" />
+</svg>

--- a/docfx/articles/Samples/parsetree-paren-expr.svg
+++ b/docfx/articles/Samples/parsetree-paren-expr.svg
@@ -1,0 +1,163 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg viewBox="0 0 1216 600" xmlns="http://www.w3.org/2000/svg" xmlns:inkspace="http://www.inkscape.org/namespaces/inkscape" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs id="defs_block">
+    <filter height="1.504" id="filter_blur" inkspace:collect="always" width="1.1575" x="-0.07875" y="-0.252">
+      <feGaussianBlur id="feGaussianBlur3780" inkspace:collect="always" stdDeviation="4.2" />
+    </filter>
+  </defs>
+  <title>blockdiag</title>
+  <desc>blockdiag
+{
+    default_shape = roundedbox
+    orientation = portrait
+
+    // Nodes
+    N21083178 [label= "TopLevelExpression"];
+    N55530882021083178 [label= "Expression", numbered = 0];
+    N30015890055530882021083178 [label= "ParenExpression"];
+    N1707556030015890055530882021083178 [label= "(", shape = circle];
+    N15368010130015890055530882021083178 [label= "Expression", numbered = 0];
+    N4094363015368010130015890055530882021083178 [label= "ConstExpression"];
+    N3684927404094363015368010130015890055530882021083178 [label= "1", shape = circle];
+    N63208015115368010130015890055530882021083178 [label= "Binaryop"];
+    N32001227063208015115368010130015890055530882021083178 [label= "+", shape = circle];
+    N19575591215368010130015890055530882021083178 [label= "Expression", numbered = 21];
+    N41962596019575591215368010130015890055530882021083178 [label= "ConstExpression"];
+    N42119052041962596019575591215368010130015890055530882021083178 [label= "2", shape = circle];
+    N43527150230015890055530882021083178 [label= ")", shape = circle];
+    N56200037155530882021083178 [label= "Binaryop"];
+    N36038289056200037155530882021083178 [label= "/", shape = circle];
+    N55909147255530882021083178 [label= "Expression", numbered = 41];
+    N33420276055909147255530882021083178 [label= "ConstExpression"];
+    N32347029033420276055909147255530882021083178 [label= "3", shape = circle];
+
+    // Edges
+    N30015890055530882021083178 -&gt; N1707556030015890055530882021083178
+    N4094363015368010130015890055530882021083178 -&gt; N3684927404094363015368010130015890055530882021083178
+    N15368010130015890055530882021083178 -&gt; N4094363015368010130015890055530882021083178
+    N63208015115368010130015890055530882021083178 -&gt; N32001227063208015115368010130015890055530882021083178
+    N15368010130015890055530882021083178 -&gt; N63208015115368010130015890055530882021083178
+    N41962596019575591215368010130015890055530882021083178 -&gt; N42119052041962596019575591215368010130015890055530882021083178
+    N19575591215368010130015890055530882021083178 -&gt; N41962596019575591215368010130015890055530882021083178
+    N15368010130015890055530882021083178 -&gt; N19575591215368010130015890055530882021083178
+    N30015890055530882021083178 -&gt; N15368010130015890055530882021083178
+    N30015890055530882021083178 -&gt; N43527150230015890055530882021083178
+    N55530882021083178 -&gt; N30015890055530882021083178
+    N56200037155530882021083178 -&gt; N36038289056200037155530882021083178
+    N55530882021083178 -&gt; N56200037155530882021083178
+    N33420276055909147255530882021083178 -&gt; N32347029033420276055909147255530882021083178
+    N55909147255530882021083178 -&gt; N33420276055909147255530882021083178
+    N55530882021083178 -&gt; N55909147255530882021083178
+    N21083178 -&gt; N55530882021083178
+}
+</desc>
+  <path d="M 75 46 L 187 46 A8,8 0 0 1 195 54 L 195 78 A8,8 0 0 1 187 86 L 75 86 A8,8 0 0 1 67 78 L 67 54 A8,8 0 0 1 75 46" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 75 126 L 187 126 A8,8 0 0 1 195 134 L 195 158 A8,8 0 0 1 187 166 L 75 166 A8,8 0 0 1 67 158 L 67 134 A8,8 0 0 1 75 126" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 75 206 L 187 206 A8,8 0 0 1 195 214 L 195 238 A8,8 0 0 1 187 246 L 75 246 A8,8 0 0 1 67 238 L 67 214 A8,8 0 0 1 75 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 843 206 L 955 206 A8,8 0 0 1 963 214 L 963 238 A8,8 0 0 1 955 246 L 843 246 A8,8 0 0 1 835 238 L 835 214 A8,8 0 0 1 843 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1035 206 L 1147 206 A8,8 0 0 1 1155 214 L 1155 238 A8,8 0 0 1 1147 246 L 1035 246 A8,8 0 0 1 1027 238 L 1027 214 A8,8 0 0 1 1035 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="131" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 267 286 L 379 286 A8,8 0 0 1 387 294 L 387 318 A8,8 0 0 1 379 326 L 267 326 A8,8 0 0 1 259 318 L 259 294 A8,8 0 0 1 267 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="515" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 267 366 L 379 366 A8,8 0 0 1 387 374 L 387 398 A8,8 0 0 1 379 406 L 267 406 A8,8 0 0 1 259 398 L 259 374 A8,8 0 0 1 267 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 459 366 L 571 366 A8,8 0 0 1 579 374 L 579 398 A8,8 0 0 1 571 406 L 459 406 A8,8 0 0 1 451 398 L 451 374 A8,8 0 0 1 459 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 651 366 L 763 366 A8,8 0 0 1 771 374 L 771 398 A8,8 0 0 1 763 406 L 651 406 A8,8 0 0 1 643 398 L 643 374 A8,8 0 0 1 651 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="323" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="515" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 651 446 L 763 446 A8,8 0 0 1 771 454 L 771 478 A8,8 0 0 1 763 486 L 651 486 A8,8 0 0 1 643 478 L 643 454 A8,8 0 0 1 651 446" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="707" cy="546" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="899" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1035 286 L 1147 286 A8,8 0 0 1 1155 294 L 1155 318 A8,8 0 0 1 1147 326 L 1035 326 A8,8 0 0 1 1027 318 L 1027 294 A8,8 0 0 1 1035 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1091" cy="386" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 72 40 L 184 40 A8,8 0 0 1 192 48 L 192 72 A8,8 0 0 1 184 80 L 72 80 A8,8 0 0 1 64 72 L 64 48 A8,8 0 0 1 72 40" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="108" x="128" y="66">TopLevelExpression</text>
+  <path d="M 72 120 L 184 120 A8,8 0 0 1 192 128 L 192 152 A8,8 0 0 1 184 160 L 72 160 A8,8 0 0 1 64 152 L 64 128 A8,8 0 0 1 72 120" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="128" y="146">Expression</text>
+  <ellipse cx="64" cy="120" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="64" y="125">0</text>
+  <path d="M 72 200 L 184 200 A8,8 0 0 1 192 208 L 192 232 A8,8 0 0 1 184 240 L 72 240 A8,8 0 0 1 64 232 L 64 208 A8,8 0 0 1 72 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="128" y="226">ParenExpression</text>
+  <path d="M 840 200 L 952 200 A8,8 0 0 1 960 208 L 960 232 A8,8 0 0 1 952 240 L 840 240 A8,8 0 0 1 832 232 L 832 208 A8,8 0 0 1 840 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="896" y="226">Binaryop</text>
+  <path d="M 1032 200 L 1144 200 A8,8 0 0 1 1152 208 L 1152 232 A8,8 0 0 1 1144 240 L 1032 240 A8,8 0 0 1 1024 232 L 1024 208 A8,8 0 0 1 1032 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="1088" y="226">Expression</text>
+  <ellipse cx="1024" cy="200" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="1024" y="205">41</text>
+  <ellipse cx="128" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="128" y="306">(</text>
+  <path d="M 264 280 L 376 280 A8,8 0 0 1 384 288 L 384 312 A8,8 0 0 1 376 320 L 264 320 A8,8 0 0 1 256 312 L 256 288 A8,8 0 0 1 264 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="320" y="306">Expression</text>
+  <ellipse cx="256" cy="280" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="256" y="285">0</text>
+  <ellipse cx="512" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="512" y="306">)</text>
+  <path d="M 264 360 L 376 360 A8,8 0 0 1 384 368 L 384 392 A8,8 0 0 1 376 400 L 264 400 A8,8 0 0 1 256 392 L 256 368 A8,8 0 0 1 264 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="320" y="386">ConstExpression</text>
+  <path d="M 456 360 L 568 360 A8,8 0 0 1 576 368 L 576 392 A8,8 0 0 1 568 400 L 456 400 A8,8 0 0 1 448 392 L 448 368 A8,8 0 0 1 456 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="512" y="386">Binaryop</text>
+  <path d="M 648 360 L 760 360 A8,8 0 0 1 768 368 L 768 392 A8,8 0 0 1 760 400 L 648 400 A8,8 0 0 1 640 392 L 640 368 A8,8 0 0 1 648 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="704" y="386">Expression</text>
+  <ellipse cx="640" cy="360" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="640" y="365">21</text>
+  <ellipse cx="320" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="320" y="465">1</text>
+  <ellipse cx="512" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="512" y="465">+</text>
+  <path d="M 648 440 L 760 440 A8,8 0 0 1 768 448 L 768 472 A8,8 0 0 1 760 480 L 648 480 A8,8 0 0 1 640 472 L 640 448 A8,8 0 0 1 648 440" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="704" y="466">ConstExpression</text>
+  <ellipse cx="704" cy="540" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="704" y="545">2</text>
+  <ellipse cx="896" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="896" y="306">/</text>
+  <path d="M 1032 280 L 1144 280 A8,8 0 0 1 1152 288 L 1152 312 A8,8 0 0 1 1144 320 L 1032 320 A8,8 0 0 1 1024 312 L 1024 288 A8,8 0 0 1 1032 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="1088" y="306">ConstExpression</text>
+  <ellipse cx="1088" cy="380" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1088" y="385">3</text>
+  <path d="M 128 80 L 128 112" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="128,119 124,112 132,112 128,119" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 180 L 896 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 896 180 L 896 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="896,199 892,192 900,192 896,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 180 L 1088 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 180 L 1088 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,199 1084,192 1092,192 1088,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="128,199 124,192 132,192 128,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 240 L 128 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 260 L 512 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 512 260 L 512 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="512,275 508,268 516,268 512,275" stroke="rgb(0,0,0)" />
+  <path d="M 128 240 L 128 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="128,275 124,268 132,268 128,275" stroke="rgb(0,0,0)" />
+  <path d="M 128 240 L 128 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 260 L 320 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 320 260 L 320 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="320,279 316,272 324,272 320,279" stroke="rgb(0,0,0)" />
+  <path d="M 320 320 L 320 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 320 340 L 704 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 704 340 L 704 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="704,359 700,352 708,352 704,359" stroke="rgb(0,0,0)" />
+  <path d="M 320 320 L 320 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="320,359 316,352 324,352 320,359" stroke="rgb(0,0,0)" />
+  <path d="M 320 320 L 320 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 320 340 L 512 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 512 340 L 512 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="512,359 508,352 516,352 512,359" stroke="rgb(0,0,0)" />
+  <path d="M 320 400 L 320 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="320,435 316,428 324,428 320,435" stroke="rgb(0,0,0)" />
+  <path d="M 512 400 L 512 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="512,435 508,428 516,428 512,435" stroke="rgb(0,0,0)" />
+  <path d="M 704 400 L 704 432" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="704,439 700,432 708,432 704,439" stroke="rgb(0,0,0)" />
+  <path d="M 704 480 L 704 508" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="704,515 700,508 708,508 704,515" stroke="rgb(0,0,0)" />
+  <path d="M 896 240 L 896 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="896,275 892,268 900,268 896,275" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,279 1084,272 1092,272 1088,279" stroke="rgb(0,0,0)" />
+  <path d="M 1088 320 L 1088 348" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,355 1084,348 1092,348 1088,355" stroke="rgb(0,0,0)" />
+</svg>

--- a/docfx/articles/Samples/parsetree-simpleexp-1.svg
+++ b/docfx/articles/Samples/parsetree-simpleexp-1.svg
@@ -1,0 +1,287 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg viewBox="0 0 2176 600" xmlns="http://www.w3.org/2000/svg" xmlns:inkspace="http://www.inkscape.org/namespaces/inkscape" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs id="defs_block">
+    <filter height="1.504" id="filter_blur" inkspace:collect="always" width="1.1575" x="-0.07875" y="-0.252">
+      <feGaussianBlur id="feGaussianBlur3780" inkspace:collect="always" stdDeviation="4.2" />
+    </filter>
+  </defs>
+  <title>blockdiag</title>
+  <desc>blockdiag
+{
+    default_shape = roundedbox
+    orientation = portrait
+
+    // Nodes
+    N21083178 [label= "TopLevelExpression"];
+    N55530882021083178 [label= "Expression", numbered = 0];
+    N30015890055530882021083178 [label= "ConstExpression"];
+    N1707556030015890055530882021083178 [label= "1", shape = circle];
+    N15368010155530882021083178 [label= "Binaryop"];
+    N4094363015368010155530882021083178 [label= "Builtinop"];
+    N3684927404094363015368010155530882021083178 [label= "+", shape = circle];
+    N63208015255530882021083178 [label= "Expression", numbered = 21];
+    N32001227063208015255530882021083178 [label= "ConstExpression"];
+    N19575591032001227063208015255530882021083178 [label= "2", shape = circle];
+    N41962596163208015255530882021083178 [label= "Binaryop"];
+    N42119052041962596163208015255530882021083178 [label= "Builtinop"];
+    N43527150042119052041962596163208015255530882021083178 [label= "*", shape = circle];
+    N56200037263208015255530882021083178 [label= "Expression", numbered = 41];
+    N36038289056200037263208015255530882021083178 [label= "ConstExpression"];
+    N55909147036038289056200037263208015255530882021083178 [label= "3", shape = circle];
+    N33420276355530882021083178 [label= "Binaryop"];
+    N32347029033420276355530882021083178 [label= "Builtinop"];
+    N22687807032347029033420276355530882021083178 [label= "-", shape = circle];
+    N2863675455530882021083178 [label= "Expression", numbered = 21];
+    N2577308302863675455530882021083178 [label= "ConstExpression"];
+    N3063115902577308302863675455530882021083178 [label= "4", shape = circle];
+    N724497512863675455530882021083178 [label= "Binaryop"];
+    N652047820724497512863675455530882021083178 [label= "Builtinop"];
+    N499721320652047820724497512863675455530882021083178 [label= "/", shape = circle];
+    N4709601022863675455530882021083178 [label= "Expression", numbered = 41];
+    N2121091404709601022863675455530882021083178 [label= "ConstExpression"];
+    N5668049902121091404709601022863675455530882021083178 [label= "5", shape = circle];
+    N4036244814709601022863675455530882021083178 [label= "Binaryop"];
+    N2771771204036244814709601022863675455530882021083178 [label= "Builtinop"];
+    N4813282202771771204036244814709601022863675455530882021083178 [label= "^", shape = circle];
+    N3054221824709601022863675455530882021083178 [label= "Expression", numbered = 50];
+    N644450903054221824709601022863675455530882021083178 [label= "ConstExpression"];
+    N580005840644450903054221824709601022863675455530882021083178 [label= "6", shape = circle];
+
+    // Edges
+    N30015890055530882021083178 -&gt; N1707556030015890055530882021083178
+    N55530882021083178 -&gt; N30015890055530882021083178
+    N4094363015368010155530882021083178 -&gt; N3684927404094363015368010155530882021083178
+    N15368010155530882021083178 -&gt; N4094363015368010155530882021083178
+    N55530882021083178 -&gt; N15368010155530882021083178
+    N32001227063208015255530882021083178 -&gt; N19575591032001227063208015255530882021083178
+    N63208015255530882021083178 -&gt; N32001227063208015255530882021083178
+    N42119052041962596163208015255530882021083178 -&gt; N43527150042119052041962596163208015255530882021083178
+    N41962596163208015255530882021083178 -&gt; N42119052041962596163208015255530882021083178
+    N63208015255530882021083178 -&gt; N41962596163208015255530882021083178
+    N36038289056200037263208015255530882021083178 -&gt; N55909147036038289056200037263208015255530882021083178
+    N56200037263208015255530882021083178 -&gt; N36038289056200037263208015255530882021083178
+    N63208015255530882021083178 -&gt; N56200037263208015255530882021083178
+    N55530882021083178 -&gt; N63208015255530882021083178
+    N32347029033420276355530882021083178 -&gt; N22687807032347029033420276355530882021083178
+    N33420276355530882021083178 -&gt; N32347029033420276355530882021083178
+    N55530882021083178 -&gt; N33420276355530882021083178
+    N2577308302863675455530882021083178 -&gt; N3063115902577308302863675455530882021083178
+    N2863675455530882021083178 -&gt; N2577308302863675455530882021083178
+    N652047820724497512863675455530882021083178 -&gt; N499721320652047820724497512863675455530882021083178
+    N724497512863675455530882021083178 -&gt; N652047820724497512863675455530882021083178
+    N2863675455530882021083178 -&gt; N724497512863675455530882021083178
+    N2121091404709601022863675455530882021083178 -&gt; N5668049902121091404709601022863675455530882021083178
+    N4709601022863675455530882021083178 -&gt; N2121091404709601022863675455530882021083178
+    N2771771204036244814709601022863675455530882021083178 -&gt; N4813282202771771204036244814709601022863675455530882021083178
+    N4036244814709601022863675455530882021083178 -&gt; N2771771204036244814709601022863675455530882021083178
+    N4709601022863675455530882021083178 -&gt; N4036244814709601022863675455530882021083178
+    N644450903054221824709601022863675455530882021083178 -&gt; N580005840644450903054221824709601022863675455530882021083178
+    N3054221824709601022863675455530882021083178 -&gt; N644450903054221824709601022863675455530882021083178
+    N4709601022863675455530882021083178 -&gt; N3054221824709601022863675455530882021083178
+    N2863675455530882021083178 -&gt; N4709601022863675455530882021083178
+    N55530882021083178 -&gt; N2863675455530882021083178
+    N21083178 -&gt; N55530882021083178
+}
+</desc>
+  <path d="M 75 46 L 187 46 A8,8 0 0 1 195 54 L 195 78 A8,8 0 0 1 187 86 L 75 86 A8,8 0 0 1 67 78 L 67 54 A8,8 0 0 1 75 46" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 75 126 L 187 126 A8,8 0 0 1 195 134 L 195 158 A8,8 0 0 1 187 166 L 75 166 A8,8 0 0 1 67 158 L 67 134 A8,8 0 0 1 75 126" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 75 206 L 187 206 A8,8 0 0 1 195 214 L 195 238 A8,8 0 0 1 187 246 L 75 246 A8,8 0 0 1 67 238 L 67 214 A8,8 0 0 1 75 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 267 206 L 379 206 A8,8 0 0 1 387 214 L 387 238 A8,8 0 0 1 379 246 L 267 246 A8,8 0 0 1 259 238 L 259 214 A8,8 0 0 1 267 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 459 206 L 571 206 A8,8 0 0 1 579 214 L 579 238 A8,8 0 0 1 571 246 L 459 246 A8,8 0 0 1 451 238 L 451 214 A8,8 0 0 1 459 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1035 206 L 1147 206 A8,8 0 0 1 1155 214 L 1155 238 A8,8 0 0 1 1147 246 L 1035 246 A8,8 0 0 1 1027 238 L 1027 214 A8,8 0 0 1 1035 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1227 206 L 1339 206 A8,8 0 0 1 1347 214 L 1347 238 A8,8 0 0 1 1339 246 L 1227 246 A8,8 0 0 1 1219 238 L 1219 214 A8,8 0 0 1 1227 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="131" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 267 286 L 379 286 A8,8 0 0 1 387 294 L 387 318 A8,8 0 0 1 379 326 L 267 326 A8,8 0 0 1 259 318 L 259 294 A8,8 0 0 1 267 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="323" cy="386" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 459 286 L 571 286 A8,8 0 0 1 579 294 L 579 318 A8,8 0 0 1 571 326 L 459 326 A8,8 0 0 1 451 318 L 451 294 A8,8 0 0 1 459 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 651 286 L 763 286 A8,8 0 0 1 771 294 L 771 318 A8,8 0 0 1 763 326 L 651 326 A8,8 0 0 1 643 318 L 643 294 A8,8 0 0 1 651 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 843 286 L 955 286 A8,8 0 0 1 963 294 L 963 318 A8,8 0 0 1 955 326 L 843 326 A8,8 0 0 1 835 318 L 835 294 A8,8 0 0 1 843 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="515" cy="386" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 651 366 L 763 366 A8,8 0 0 1 771 374 L 771 398 A8,8 0 0 1 763 406 L 651 406 A8,8 0 0 1 643 398 L 643 374 A8,8 0 0 1 651 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="707" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 843 366 L 955 366 A8,8 0 0 1 963 374 L 963 398 A8,8 0 0 1 955 406 L 843 406 A8,8 0 0 1 835 398 L 835 374 A8,8 0 0 1 843 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="899" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1035 286 L 1147 286 A8,8 0 0 1 1155 294 L 1155 318 A8,8 0 0 1 1147 326 L 1035 326 A8,8 0 0 1 1027 318 L 1027 294 A8,8 0 0 1 1035 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1091" cy="386" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1227 286 L 1339 286 A8,8 0 0 1 1347 294 L 1347 318 A8,8 0 0 1 1339 326 L 1227 326 A8,8 0 0 1 1219 318 L 1219 294 A8,8 0 0 1 1227 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1419 286 L 1531 286 A8,8 0 0 1 1539 294 L 1539 318 A8,8 0 0 1 1531 326 L 1419 326 A8,8 0 0 1 1411 318 L 1411 294 A8,8 0 0 1 1419 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1611 286 L 1723 286 A8,8 0 0 1 1731 294 L 1731 318 A8,8 0 0 1 1723 326 L 1611 326 A8,8 0 0 1 1603 318 L 1603 294 A8,8 0 0 1 1611 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1283" cy="386" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1419 366 L 1531 366 A8,8 0 0 1 1539 374 L 1539 398 A8,8 0 0 1 1531 406 L 1419 406 A8,8 0 0 1 1411 398 L 1411 374 A8,8 0 0 1 1419 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1475" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1611 366 L 1723 366 A8,8 0 0 1 1731 374 L 1731 398 A8,8 0 0 1 1723 406 L 1611 406 A8,8 0 0 1 1603 398 L 1603 374 A8,8 0 0 1 1611 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1803 366 L 1915 366 A8,8 0 0 1 1923 374 L 1923 398 A8,8 0 0 1 1915 406 L 1803 406 A8,8 0 0 1 1795 398 L 1795 374 A8,8 0 0 1 1803 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1995 366 L 2107 366 A8,8 0 0 1 2115 374 L 2115 398 A8,8 0 0 1 2107 406 L 1995 406 A8,8 0 0 1 1987 398 L 1987 374 A8,8 0 0 1 1995 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1667" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1803 446 L 1915 446 A8,8 0 0 1 1923 454 L 1923 478 A8,8 0 0 1 1915 486 L 1803 486 A8,8 0 0 1 1795 478 L 1795 454 A8,8 0 0 1 1803 446" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1859" cy="546" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1995 446 L 2107 446 A8,8 0 0 1 2115 454 L 2115 478 A8,8 0 0 1 2107 486 L 1995 486 A8,8 0 0 1 1987 478 L 1987 454 A8,8 0 0 1 1995 446" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="2051" cy="546" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 72 40 L 184 40 A8,8 0 0 1 192 48 L 192 72 A8,8 0 0 1 184 80 L 72 80 A8,8 0 0 1 64 72 L 64 48 A8,8 0 0 1 72 40" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="108" x="128" y="66">TopLevelExpression</text>
+  <path d="M 72 120 L 184 120 A8,8 0 0 1 192 128 L 192 152 A8,8 0 0 1 184 160 L 72 160 A8,8 0 0 1 64 152 L 64 128 A8,8 0 0 1 72 120" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="128" y="146">Expression</text>
+  <ellipse cx="64" cy="120" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="64" y="125">0</text>
+  <path d="M 72 200 L 184 200 A8,8 0 0 1 192 208 L 192 232 A8,8 0 0 1 184 240 L 72 240 A8,8 0 0 1 64 232 L 64 208 A8,8 0 0 1 72 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="128" y="226">ConstExpression</text>
+  <path d="M 264 200 L 376 200 A8,8 0 0 1 384 208 L 384 232 A8,8 0 0 1 376 240 L 264 240 A8,8 0 0 1 256 232 L 256 208 A8,8 0 0 1 264 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="320" y="226">Binaryop</text>
+  <path d="M 456 200 L 568 200 A8,8 0 0 1 576 208 L 576 232 A8,8 0 0 1 568 240 L 456 240 A8,8 0 0 1 448 232 L 448 208 A8,8 0 0 1 456 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="512" y="226">Expression</text>
+  <ellipse cx="448" cy="200" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="448" y="205">21</text>
+  <path d="M 1032 200 L 1144 200 A8,8 0 0 1 1152 208 L 1152 232 A8,8 0 0 1 1144 240 L 1032 240 A8,8 0 0 1 1024 232 L 1024 208 A8,8 0 0 1 1032 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="1088" y="226">Binaryop</text>
+  <path d="M 1224 200 L 1336 200 A8,8 0 0 1 1344 208 L 1344 232 A8,8 0 0 1 1336 240 L 1224 240 A8,8 0 0 1 1216 232 L 1216 208 A8,8 0 0 1 1224 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="1280" y="226">Expression</text>
+  <ellipse cx="1216" cy="200" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="1216" y="205">21</text>
+  <ellipse cx="128" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="128" y="305">1</text>
+  <path d="M 264 280 L 376 280 A8,8 0 0 1 384 288 L 384 312 A8,8 0 0 1 376 320 L 264 320 A8,8 0 0 1 256 312 L 256 288 A8,8 0 0 1 264 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="54" x="320" y="306">Builtinop</text>
+  <ellipse cx="320" cy="380" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="320" y="385">+</text>
+  <path d="M 456 280 L 568 280 A8,8 0 0 1 576 288 L 576 312 A8,8 0 0 1 568 320 L 456 320 A8,8 0 0 1 448 312 L 448 288 A8,8 0 0 1 456 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="512" y="306">ConstExpression</text>
+  <path d="M 648 280 L 760 280 A8,8 0 0 1 768 288 L 768 312 A8,8 0 0 1 760 320 L 648 320 A8,8 0 0 1 640 312 L 640 288 A8,8 0 0 1 648 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="704" y="306">Binaryop</text>
+  <path d="M 840 280 L 952 280 A8,8 0 0 1 960 288 L 960 312 A8,8 0 0 1 952 320 L 840 320 A8,8 0 0 1 832 312 L 832 288 A8,8 0 0 1 840 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="896" y="306">Expression</text>
+  <ellipse cx="832" cy="280" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="832" y="285">41</text>
+  <ellipse cx="512" cy="380" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="512" y="385">2</text>
+  <path d="M 648 360 L 760 360 A8,8 0 0 1 768 368 L 768 392 A8,8 0 0 1 760 400 L 648 400 A8,8 0 0 1 640 392 L 640 368 A8,8 0 0 1 648 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="54" x="704" y="386">Builtinop</text>
+  <ellipse cx="704" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="704" y="465">*</text>
+  <path d="M 840 360 L 952 360 A8,8 0 0 1 960 368 L 960 392 A8,8 0 0 1 952 400 L 840 400 A8,8 0 0 1 832 392 L 832 368 A8,8 0 0 1 840 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="896" y="386">ConstExpression</text>
+  <ellipse cx="896" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="896" y="465">3</text>
+  <path d="M 1032 280 L 1144 280 A8,8 0 0 1 1152 288 L 1152 312 A8,8 0 0 1 1144 320 L 1032 320 A8,8 0 0 1 1024 312 L 1024 288 A8,8 0 0 1 1032 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="54" x="1088" y="306">Builtinop</text>
+  <ellipse cx="1088" cy="380" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1088" y="385">-</text>
+  <path d="M 1224 280 L 1336 280 A8,8 0 0 1 1344 288 L 1344 312 A8,8 0 0 1 1336 320 L 1224 320 A8,8 0 0 1 1216 312 L 1216 288 A8,8 0 0 1 1224 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="1280" y="306">ConstExpression</text>
+  <path d="M 1416 280 L 1528 280 A8,8 0 0 1 1536 288 L 1536 312 A8,8 0 0 1 1528 320 L 1416 320 A8,8 0 0 1 1408 312 L 1408 288 A8,8 0 0 1 1416 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="1472" y="306">Binaryop</text>
+  <path d="M 1608 280 L 1720 280 A8,8 0 0 1 1728 288 L 1728 312 A8,8 0 0 1 1720 320 L 1608 320 A8,8 0 0 1 1600 312 L 1600 288 A8,8 0 0 1 1608 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="1664" y="306">Expression</text>
+  <ellipse cx="1600" cy="280" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="1600" y="285">41</text>
+  <ellipse cx="1280" cy="380" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1280" y="385">4</text>
+  <path d="M 1416 360 L 1528 360 A8,8 0 0 1 1536 368 L 1536 392 A8,8 0 0 1 1528 400 L 1416 400 A8,8 0 0 1 1408 392 L 1408 368 A8,8 0 0 1 1416 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="54" x="1472" y="386">Builtinop</text>
+  <ellipse cx="1472" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1472" y="466">/</text>
+  <path d="M 1608 360 L 1720 360 A8,8 0 0 1 1728 368 L 1728 392 A8,8 0 0 1 1720 400 L 1608 400 A8,8 0 0 1 1600 392 L 1600 368 A8,8 0 0 1 1608 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="1664" y="386">ConstExpression</text>
+  <path d="M 1800 360 L 1912 360 A8,8 0 0 1 1920 368 L 1920 392 A8,8 0 0 1 1912 400 L 1800 400 A8,8 0 0 1 1792 392 L 1792 368 A8,8 0 0 1 1800 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="1856" y="386">Binaryop</text>
+  <path d="M 1992 360 L 2104 360 A8,8 0 0 1 2112 368 L 2112 392 A8,8 0 0 1 2104 400 L 1992 400 A8,8 0 0 1 1984 392 L 1984 368 A8,8 0 0 1 1992 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="2048" y="386">Expression</text>
+  <ellipse cx="1984" cy="360" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="1984" y="365">50</text>
+  <ellipse cx="1664" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1664" y="465">5</text>
+  <path d="M 1800 440 L 1912 440 A8,8 0 0 1 1920 448 L 1920 472 A8,8 0 0 1 1912 480 L 1800 480 A8,8 0 0 1 1792 472 L 1792 448 A8,8 0 0 1 1800 440" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="54" x="1856" y="466">Builtinop</text>
+  <ellipse cx="1856" cy="540" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1856" y="545">^</text>
+  <path d="M 1992 440 L 2104 440 A8,8 0 0 1 2112 448 L 2112 472 A8,8 0 0 1 2104 480 L 1992 480 A8,8 0 0 1 1984 472 L 1984 448 A8,8 0 0 1 1992 440" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="2048" y="466">ConstExpression</text>
+  <ellipse cx="2048" cy="540" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="2048" y="545">6</text>
+  <path d="M 128 80 L 128 112" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="128,119 124,112 132,112 128,119" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 180 L 320 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 320 180 L 320 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="320,199 316,192 324,192 320,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="128,199 124,192 132,192 128,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 180 L 1088 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 180 L 1088 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,199 1084,192 1092,192 1088,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 180 L 1280 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1280 180 L 1280 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1280,199 1276,192 1284,192 1280,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 180 L 512 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 512 180 L 512 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="512,199 508,192 516,192 512,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 240 L 128 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="128,275 124,268 132,268 128,275" stroke="rgb(0,0,0)" />
+  <path d="M 320 240 L 320 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="320,279 316,272 324,272 320,279" stroke="rgb(0,0,0)" />
+  <path d="M 320 320 L 320 348" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="320,355 316,348 324,348 320,355" stroke="rgb(0,0,0)" />
+  <path d="M 512 240 L 512 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 512 260 L 704 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 704 260 L 704 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="704,279 700,272 708,272 704,279" stroke="rgb(0,0,0)" />
+  <path d="M 512 240 L 512 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 512 260 L 896 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 896 260 L 896 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="896,279 892,272 900,272 896,279" stroke="rgb(0,0,0)" />
+  <path d="M 512 240 L 512 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="512,279 508,272 516,272 512,279" stroke="rgb(0,0,0)" />
+  <path d="M 512 320 L 512 348" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="512,355 508,348 516,348 512,355" stroke="rgb(0,0,0)" />
+  <path d="M 704 320 L 704 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="704,359 700,352 708,352 704,359" stroke="rgb(0,0,0)" />
+  <path d="M 704 400 L 704 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="704,435 700,428 708,428 704,435" stroke="rgb(0,0,0)" />
+  <path d="M 896 320 L 896 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="896,359 892,352 900,352 896,359" stroke="rgb(0,0,0)" />
+  <path d="M 896 400 L 896 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="896,435 892,428 900,428 896,435" stroke="rgb(0,0,0)" />
+  <path d="M 1088 240 L 1088 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,279 1084,272 1092,272 1088,279" stroke="rgb(0,0,0)" />
+  <path d="M 1088 320 L 1088 348" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,355 1084,348 1092,348 1088,355" stroke="rgb(0,0,0)" />
+  <path d="M 1280 240 L 1280 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1280 260 L 1664 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1664 260 L 1664 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1664,279 1660,272 1668,272 1664,279" stroke="rgb(0,0,0)" />
+  <path d="M 1280 240 L 1280 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1280,279 1276,272 1284,272 1280,279" stroke="rgb(0,0,0)" />
+  <path d="M 1280 240 L 1280 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1280 260 L 1472 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1472 260 L 1472 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1472,279 1468,272 1476,272 1472,279" stroke="rgb(0,0,0)" />
+  <path d="M 1280 320 L 1280 348" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1280,355 1276,348 1284,348 1280,355" stroke="rgb(0,0,0)" />
+  <path d="M 1472 320 L 1472 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1472,359 1468,352 1476,352 1472,359" stroke="rgb(0,0,0)" />
+  <path d="M 1472 400 L 1472 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1472,435 1468,428 1476,428 1472,435" stroke="rgb(0,0,0)" />
+  <path d="M 1664 320 L 1664 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1664 340 L 1856 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1856 340 L 1856 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1856,359 1852,352 1860,352 1856,359" stroke="rgb(0,0,0)" />
+  <path d="M 1664 320 L 1664 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1664 340 L 2048 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 2048 340 L 2048 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2048,359 2044,352 2052,352 2048,359" stroke="rgb(0,0,0)" />
+  <path d="M 1664 320 L 1664 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1664,359 1660,352 1668,352 1664,359" stroke="rgb(0,0,0)" />
+  <path d="M 1664 400 L 1664 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1664,435 1660,428 1668,428 1664,435" stroke="rgb(0,0,0)" />
+  <path d="M 1856 400 L 1856 432" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1856,439 1852,432 1860,432 1856,439" stroke="rgb(0,0,0)" />
+  <path d="M 1856 480 L 1856 508" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1856,515 1852,508 1860,508 1856,515" stroke="rgb(0,0,0)" />
+  <path d="M 2048 400 L 2048 432" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2048,439 2044,432 2052,432 2048,439" stroke="rgb(0,0,0)" />
+  <path d="M 2048 480 L 2048 508" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="2048,515 2044,508 2052,508 2048,515" stroke="rgb(0,0,0)" />
+</svg>

--- a/docfx/articles/Samples/parsetree-userops.svg
+++ b/docfx/articles/Samples/parsetree-userops.svg
@@ -1,0 +1,278 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg viewBox="0 0 1984 600" xmlns="http://www.w3.org/2000/svg" xmlns:inkspace="http://www.inkscape.org/namespaces/inkscape" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs id="defs_block">
+    <filter height="1.504" id="filter_blur" inkspace:collect="always" width="1.1575" x="-0.07875" y="-0.252">
+      <feGaussianBlur id="feGaussianBlur3780" inkspace:collect="always" stdDeviation="4.2" />
+    </filter>
+  </defs>
+  <title>blockdiag</title>
+  <desc>blockdiag
+{
+    default_shape = roundedbox
+    orientation = portrait
+
+    // Nodes
+    N20908074 [label= "TopLevelExpression"];
+    N53954942020908074 [label= "Expression", numbered = 0];
+    N15832433053954942020908074 [label= "ConstExpression"];
+    N8274172015832433053954942020908074 [label= "2", shape = circle];
+    N7358688153954942020908074 [label= "Binaryop"];
+    N6622819907358688153954942020908074 [label= "Userdefinedop"];
+    N5918288006622819907358688153954942020908074 [label= "==", shape = circle];
+    N62883878253954942020908074 [label= "Expression", numbered = 10];
+    N29083993062883878253954942020908074 [label= "ConstExpression"];
+    N60429346029083993062883878253954942020908074 [label= "3", shape = circle];
+    N6993202353954942020908074 [label= "Binaryop"];
+    N6293881806993202353954942020908074 [label= "Userdefinedop"];
+    N2957845106293881806993202353954942020908074 [label= "|", shape = circle];
+    N64879470453954942020908074 [label= "Expression", numbered = 6];
+    N47044325064879470453954942020908074 [label= "ConstExpression"];
+    N20745743047044325064879470453954942020908074 [label= "5", shape = circle];
+    N52493967164879470453954942020908074 [label= "Binaryop"];
+    N2683661052493967164879470453954942020908074 [label= "Builtinop"];
+    N2415295402683661052493967164879470453954942020908074 [label= "&lt;", shape = circle];
+    N16049999264879470453954942020908074 [label= "Expression", numbered = 11];
+    N10232270016049999264879470453954942020908074 [label= "ConstExpression"];
+    N24981566010232270016049999264879470453954942020908074 [label= "4", shape = circle];
+    N23507505553954942020908074 [label= "Binaryop"];
+    N10240961023507505553954942020908074 [label= "Userdefinedop"];
+    N25059790010240961023507505553954942020908074 [label= "|", shape = circle];
+    N24211521653954942020908074 [label= "Expression", numbered = 6];
+    N16577099024211521653954942020908074 [label= "UnaryOpExpression"];
+    N14976165016577099024211521653954942020908074 [label= "Unaryop"];
+    N567760014976165016577099024211521653954942020908074 [label= "Userdefinedop"];
+    N51098460567760014976165016577099024211521653954942020908074 [label= "!", shape = circle];
+    N45988614116577099024211521653954942020908074 [label= "Expression", numbered = 0];
+    N11244347045988614116577099024211521653954942020908074 [label= "ConstExpression"];
+    N34090260011244347045988614116577099024211521653954942020908074 [label= "1", shape = circle];
+
+    // Edges
+    N15832433053954942020908074 -&gt; N8274172015832433053954942020908074
+    N53954942020908074 -&gt; N15832433053954942020908074
+    N6622819907358688153954942020908074 -&gt; N5918288006622819907358688153954942020908074
+    N7358688153954942020908074 -&gt; N6622819907358688153954942020908074
+    N53954942020908074 -&gt; N7358688153954942020908074
+    N29083993062883878253954942020908074 -&gt; N60429346029083993062883878253954942020908074
+    N62883878253954942020908074 -&gt; N29083993062883878253954942020908074
+    N53954942020908074 -&gt; N62883878253954942020908074
+    N6293881806993202353954942020908074 -&gt; N2957845106293881806993202353954942020908074
+    N6993202353954942020908074 -&gt; N6293881806993202353954942020908074
+    N53954942020908074 -&gt; N6993202353954942020908074
+    N47044325064879470453954942020908074 -&gt; N20745743047044325064879470453954942020908074
+    N64879470453954942020908074 -&gt; N47044325064879470453954942020908074
+    N2683661052493967164879470453954942020908074 -&gt; N2415295402683661052493967164879470453954942020908074
+    N52493967164879470453954942020908074 -&gt; N2683661052493967164879470453954942020908074
+    N64879470453954942020908074 -&gt; N52493967164879470453954942020908074
+    N10232270016049999264879470453954942020908074 -&gt; N24981566010232270016049999264879470453954942020908074
+    N16049999264879470453954942020908074 -&gt; N10232270016049999264879470453954942020908074
+    N64879470453954942020908074 -&gt; N16049999264879470453954942020908074
+    N53954942020908074 -&gt; N64879470453954942020908074
+    N10240961023507505553954942020908074 -&gt; N25059790010240961023507505553954942020908074
+    N23507505553954942020908074 -&gt; N10240961023507505553954942020908074
+    N53954942020908074 -&gt; N23507505553954942020908074
+    N567760014976165016577099024211521653954942020908074 -&gt; N51098460567760014976165016577099024211521653954942020908074
+    N14976165016577099024211521653954942020908074 -&gt; N567760014976165016577099024211521653954942020908074
+    N16577099024211521653954942020908074 -&gt; N14976165016577099024211521653954942020908074
+    N11244347045988614116577099024211521653954942020908074 -&gt; N34090260011244347045988614116577099024211521653954942020908074
+    N45988614116577099024211521653954942020908074 -&gt; N11244347045988614116577099024211521653954942020908074
+    N16577099024211521653954942020908074 -&gt; N45988614116577099024211521653954942020908074
+    N24211521653954942020908074 -&gt; N16577099024211521653954942020908074
+    N53954942020908074 -&gt; N24211521653954942020908074
+    N20908074 -&gt; N53954942020908074
+}
+</desc>
+  <path d="M 75 46 L 187 46 A8,8 0 0 1 195 54 L 195 78 A8,8 0 0 1 187 86 L 75 86 A8,8 0 0 1 67 78 L 67 54 A8,8 0 0 1 75 46" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 75 126 L 187 126 A8,8 0 0 1 195 134 L 195 158 A8,8 0 0 1 187 166 L 75 166 A8,8 0 0 1 67 158 L 67 134 A8,8 0 0 1 75 126" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 75 206 L 187 206 A8,8 0 0 1 195 214 L 195 238 A8,8 0 0 1 187 246 L 75 246 A8,8 0 0 1 67 238 L 67 214 A8,8 0 0 1 75 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 267 206 L 379 206 A8,8 0 0 1 387 214 L 387 238 A8,8 0 0 1 379 246 L 267 246 A8,8 0 0 1 259 238 L 259 214 A8,8 0 0 1 267 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 459 206 L 571 206 A8,8 0 0 1 579 214 L 579 238 A8,8 0 0 1 571 246 L 459 246 A8,8 0 0 1 451 238 L 451 214 A8,8 0 0 1 459 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 651 206 L 763 206 A8,8 0 0 1 771 214 L 771 238 A8,8 0 0 1 763 246 L 651 246 A8,8 0 0 1 643 238 L 643 214 A8,8 0 0 1 651 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 843 206 L 955 206 A8,8 0 0 1 963 214 L 963 238 A8,8 0 0 1 955 246 L 843 246 A8,8 0 0 1 835 238 L 835 214 A8,8 0 0 1 843 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1419 206 L 1531 206 A8,8 0 0 1 1539 214 L 1539 238 A8,8 0 0 1 1531 246 L 1419 246 A8,8 0 0 1 1411 238 L 1411 214 A8,8 0 0 1 1419 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1611 206 L 1723 206 A8,8 0 0 1 1731 214 L 1731 238 A8,8 0 0 1 1723 246 L 1611 246 A8,8 0 0 1 1603 238 L 1603 214 A8,8 0 0 1 1611 206" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="131" cy="306" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 267 286 L 379 286 A8,8 0 0 1 387 294 L 387 318 A8,8 0 0 1 379 326 L 267 326 A8,8 0 0 1 259 318 L 259 294 A8,8 0 0 1 267 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="323" cy="386" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 459 286 L 571 286 A8,8 0 0 1 579 294 L 579 318 A8,8 0 0 1 571 326 L 459 326 A8,8 0 0 1 451 318 L 451 294 A8,8 0 0 1 459 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="515" cy="386" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 651 286 L 763 286 A8,8 0 0 1 771 294 L 771 318 A8,8 0 0 1 763 326 L 651 326 A8,8 0 0 1 643 318 L 643 294 A8,8 0 0 1 651 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="707" cy="386" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 843 286 L 955 286 A8,8 0 0 1 963 294 L 963 318 A8,8 0 0 1 955 326 L 843 326 A8,8 0 0 1 835 318 L 835 294 A8,8 0 0 1 843 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1035 286 L 1147 286 A8,8 0 0 1 1155 294 L 1155 318 A8,8 0 0 1 1147 326 L 1035 326 A8,8 0 0 1 1027 318 L 1027 294 A8,8 0 0 1 1035 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1227 286 L 1339 286 A8,8 0 0 1 1347 294 L 1347 318 A8,8 0 0 1 1339 326 L 1227 326 A8,8 0 0 1 1219 318 L 1219 294 A8,8 0 0 1 1227 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="899" cy="386" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1035 366 L 1147 366 A8,8 0 0 1 1155 374 L 1155 398 A8,8 0 0 1 1147 406 L 1035 406 A8,8 0 0 1 1027 398 L 1027 374 A8,8 0 0 1 1035 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1091" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1227 366 L 1339 366 A8,8 0 0 1 1347 374 L 1347 398 A8,8 0 0 1 1339 406 L 1227 406 A8,8 0 0 1 1219 398 L 1219 374 A8,8 0 0 1 1227 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1283" cy="466" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1419 286 L 1531 286 A8,8 0 0 1 1539 294 L 1539 318 A8,8 0 0 1 1531 326 L 1419 326 A8,8 0 0 1 1411 318 L 1411 294 A8,8 0 0 1 1419 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1475" cy="386" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1611 286 L 1723 286 A8,8 0 0 1 1731 294 L 1731 318 A8,8 0 0 1 1723 326 L 1611 326 A8,8 0 0 1 1603 318 L 1603 294 A8,8 0 0 1 1611 286" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1611 366 L 1723 366 A8,8 0 0 1 1731 374 L 1731 398 A8,8 0 0 1 1723 406 L 1611 406 A8,8 0 0 1 1603 398 L 1603 374 A8,8 0 0 1 1611 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1803 366 L 1915 366 A8,8 0 0 1 1923 374 L 1923 398 A8,8 0 0 1 1915 406 L 1803 406 A8,8 0 0 1 1795 398 L 1795 374 A8,8 0 0 1 1803 366" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1611 446 L 1723 446 A8,8 0 0 1 1731 454 L 1731 478 A8,8 0 0 1 1723 486 L 1611 486 A8,8 0 0 1 1603 478 L 1603 454 A8,8 0 0 1 1611 446" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1667" cy="546" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 1803 446 L 1915 446 A8,8 0 0 1 1923 454 L 1923 478 A8,8 0 0 1 1915 486 L 1803 486 A8,8 0 0 1 1795 478 L 1795 454 A8,8 0 0 1 1803 446" fill="rgb(0,0,0)" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <ellipse cx="1859" cy="546" fill="rgb(0,0,0)" rx="24" ry="24" stroke="rgb(0,0,0)" style="filter:url(#filter_blur);opacity:0.7;fill-opacity:1" />
+  <path d="M 72 40 L 184 40 A8,8 0 0 1 192 48 L 192 72 A8,8 0 0 1 184 80 L 72 80 A8,8 0 0 1 64 72 L 64 48 A8,8 0 0 1 72 40" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="108" x="128" y="66">TopLevelExpression</text>
+  <path d="M 72 120 L 184 120 A8,8 0 0 1 192 128 L 192 152 A8,8 0 0 1 184 160 L 72 160 A8,8 0 0 1 64 152 L 64 128 A8,8 0 0 1 72 120" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="128" y="146">Expression</text>
+  <ellipse cx="64" cy="120" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="64" y="125">0</text>
+  <path d="M 72 200 L 184 200 A8,8 0 0 1 192 208 L 192 232 A8,8 0 0 1 184 240 L 72 240 A8,8 0 0 1 64 232 L 64 208 A8,8 0 0 1 72 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="128" y="226">ConstExpression</text>
+  <path d="M 264 200 L 376 200 A8,8 0 0 1 384 208 L 384 232 A8,8 0 0 1 376 240 L 264 240 A8,8 0 0 1 256 232 L 256 208 A8,8 0 0 1 264 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="320" y="226">Binaryop</text>
+  <path d="M 456 200 L 568 200 A8,8 0 0 1 576 208 L 576 232 A8,8 0 0 1 568 240 L 456 240 A8,8 0 0 1 448 232 L 448 208 A8,8 0 0 1 456 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="512" y="226">Expression</text>
+  <ellipse cx="448" cy="200" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="448" y="205">10</text>
+  <path d="M 648 200 L 760 200 A8,8 0 0 1 768 208 L 768 232 A8,8 0 0 1 760 240 L 648 240 A8,8 0 0 1 640 232 L 640 208 A8,8 0 0 1 648 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="704" y="226">Binaryop</text>
+  <path d="M 840 200 L 952 200 A8,8 0 0 1 960 208 L 960 232 A8,8 0 0 1 952 240 L 840 240 A8,8 0 0 1 832 232 L 832 208 A8,8 0 0 1 840 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="896" y="226">Expression</text>
+  <ellipse cx="832" cy="200" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="832" y="205">6</text>
+  <path d="M 1416 200 L 1528 200 A8,8 0 0 1 1536 208 L 1536 232 A8,8 0 0 1 1528 240 L 1416 240 A8,8 0 0 1 1408 232 L 1408 208 A8,8 0 0 1 1416 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="1472" y="226">Binaryop</text>
+  <path d="M 1608 200 L 1720 200 A8,8 0 0 1 1728 208 L 1728 232 A8,8 0 0 1 1720 240 L 1608 240 A8,8 0 0 1 1600 232 L 1600 208 A8,8 0 0 1 1608 200" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="1664" y="226">Expression</text>
+  <ellipse cx="1600" cy="200" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1600" y="205">6</text>
+  <ellipse cx="128" cy="300" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="128" y="305">2</text>
+  <path d="M 264 280 L 376 280 A8,8 0 0 1 384 288 L 384 312 A8,8 0 0 1 376 320 L 264 320 A8,8 0 0 1 256 312 L 256 288 A8,8 0 0 1 264 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="78" x="320" y="306">Userdefinedop</text>
+  <ellipse cx="320" cy="380" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="320" y="385">==</text>
+  <path d="M 456 280 L 568 280 A8,8 0 0 1 576 288 L 576 312 A8,8 0 0 1 568 320 L 456 320 A8,8 0 0 1 448 312 L 448 288 A8,8 0 0 1 456 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="512" y="306">ConstExpression</text>
+  <ellipse cx="512" cy="380" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="512" y="385">3</text>
+  <path d="M 648 280 L 760 280 A8,8 0 0 1 768 288 L 768 312 A8,8 0 0 1 760 320 L 648 320 A8,8 0 0 1 640 312 L 640 288 A8,8 0 0 1 648 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="78" x="704" y="306">Userdefinedop</text>
+  <ellipse cx="704" cy="380" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="704" y="386">|</text>
+  <path d="M 840 280 L 952 280 A8,8 0 0 1 960 288 L 960 312 A8,8 0 0 1 952 320 L 840 320 A8,8 0 0 1 832 312 L 832 288 A8,8 0 0 1 840 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="896" y="306">ConstExpression</text>
+  <path d="M 1032 280 L 1144 280 A8,8 0 0 1 1152 288 L 1152 312 A8,8 0 0 1 1144 320 L 1032 320 A8,8 0 0 1 1024 312 L 1024 288 A8,8 0 0 1 1032 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="48" x="1088" y="306">Binaryop</text>
+  <path d="M 1224 280 L 1336 280 A8,8 0 0 1 1344 288 L 1344 312 A8,8 0 0 1 1336 320 L 1224 320 A8,8 0 0 1 1216 312 L 1216 288 A8,8 0 0 1 1224 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="1280" y="306">Expression</text>
+  <ellipse cx="1216" cy="280" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="12" x="1216" y="285">11</text>
+  <ellipse cx="896" cy="380" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="896" y="385">5</text>
+  <path d="M 1032 360 L 1144 360 A8,8 0 0 1 1152 368 L 1152 392 A8,8 0 0 1 1144 400 L 1032 400 A8,8 0 0 1 1024 392 L 1024 368 A8,8 0 0 1 1032 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="54" x="1088" y="386">Builtinop</text>
+  <ellipse cx="1088" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1088" y="465">&lt;</text>
+  <path d="M 1224 360 L 1336 360 A8,8 0 0 1 1344 368 L 1344 392 A8,8 0 0 1 1336 400 L 1224 400 A8,8 0 0 1 1216 392 L 1216 368 A8,8 0 0 1 1224 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="1280" y="386">ConstExpression</text>
+  <ellipse cx="1280" cy="460" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1280" y="465">4</text>
+  <path d="M 1416 280 L 1528 280 A8,8 0 0 1 1536 288 L 1536 312 A8,8 0 0 1 1528 320 L 1416 320 A8,8 0 0 1 1408 312 L 1408 288 A8,8 0 0 1 1416 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="78" x="1472" y="306">Userdefinedop</text>
+  <ellipse cx="1472" cy="380" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1472" y="386">|</text>
+  <path d="M 1608 280 L 1720 280 A8,8 0 0 1 1728 288 L 1728 312 A8,8 0 0 1 1720 320 L 1608 320 A8,8 0 0 1 1600 312 L 1600 288 A8,8 0 0 1 1608 280" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="102" x="1664" y="306">UnaryOpExpression</text>
+  <path d="M 1608 360 L 1720 360 A8,8 0 0 1 1728 368 L 1728 392 A8,8 0 0 1 1720 400 L 1608 400 A8,8 0 0 1 1600 392 L 1600 368 A8,8 0 0 1 1608 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="42" x="1664" y="386">Unaryop</text>
+  <path d="M 1800 360 L 1912 360 A8,8 0 0 1 1920 368 L 1920 392 A8,8 0 0 1 1912 400 L 1800 400 A8,8 0 0 1 1792 392 L 1792 368 A8,8 0 0 1 1800 360" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="60" x="1856" y="386">Expression</text>
+  <ellipse cx="1792" cy="360" fill="pink" rx="12" ry="12" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1792" y="365">0</text>
+  <path d="M 1608 440 L 1720 440 A8,8 0 0 1 1728 448 L 1728 472 A8,8 0 0 1 1720 480 L 1608 480 A8,8 0 0 1 1600 472 L 1600 448 A8,8 0 0 1 1608 440" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="78" x="1664" y="466">Userdefinedop</text>
+  <ellipse cx="1664" cy="540" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1664" y="545">!</text>
+  <path d="M 1800 440 L 1912 440 A8,8 0 0 1 1920 448 L 1920 472 A8,8 0 0 1 1912 480 L 1800 480 A8,8 0 0 1 1792 472 L 1792 448 A8,8 0 0 1 1800 440" fill="rgb(255,255,255)" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="90" x="1856" y="466">ConstExpression</text>
+  <ellipse cx="1856" cy="540" fill="rgb(255,255,255)" rx="24" ry="24" stroke="rgb(0,0,0)" />
+  <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="6" x="1856" y="545">1</text>
+  <path d="M 128 80 L 128 112" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="128,119 124,112 132,112 128,119" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="128,199 124,192 132,192 128,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 180 L 704 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 704 180 L 704 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="704,199 700,192 708,192 704,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 180 L 896 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 896 180 L 896 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="896,199 892,192 900,192 896,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 180 L 320 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 320 180 L 320 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="320,199 316,192 324,192 320,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 180 L 1472 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1472 180 L 1472 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1472,199 1468,192 1476,192 1472,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 180 L 1664 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1664 180 L 1664 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1664,199 1660,192 1668,192 1664,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 160 L 128 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 128 180 L 512 180" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 512 180 L 512 192" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="512,199 508,192 516,192 512,199" stroke="rgb(0,0,0)" />
+  <path d="M 128 240 L 128 268" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="128,275 124,268 132,268 128,275" stroke="rgb(0,0,0)" />
+  <path d="M 320 240 L 320 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="320,279 316,272 324,272 320,279" stroke="rgb(0,0,0)" />
+  <path d="M 320 320 L 320 348" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="320,355 316,348 324,348 320,355" stroke="rgb(0,0,0)" />
+  <path d="M 512 240 L 512 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="512,279 508,272 516,272 512,279" stroke="rgb(0,0,0)" />
+  <path d="M 512 320 L 512 348" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="512,355 508,348 516,348 512,355" stroke="rgb(0,0,0)" />
+  <path d="M 704 240 L 704 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="704,279 700,272 708,272 704,279" stroke="rgb(0,0,0)" />
+  <path d="M 704 320 L 704 348" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="704,355 700,348 708,348 704,355" stroke="rgb(0,0,0)" />
+  <path d="M 896 240 L 896 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 896 260 L 1280 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1280 260 L 1280 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1280,279 1276,272 1284,272 1280,279" stroke="rgb(0,0,0)" />
+  <path d="M 896 240 L 896 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="896,279 892,272 900,272 896,279" stroke="rgb(0,0,0)" />
+  <path d="M 896 240 L 896 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 896 260 L 1088 260" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1088 260 L 1088 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,279 1084,272 1092,272 1088,279" stroke="rgb(0,0,0)" />
+  <path d="M 896 320 L 896 348" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="896,355 892,348 900,348 896,355" stroke="rgb(0,0,0)" />
+  <path d="M 1088 320 L 1088 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,359 1084,352 1092,352 1088,359" stroke="rgb(0,0,0)" />
+  <path d="M 1088 400 L 1088 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1088,435 1084,428 1092,428 1088,435" stroke="rgb(0,0,0)" />
+  <path d="M 1280 320 L 1280 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1280,359 1276,352 1284,352 1280,359" stroke="rgb(0,0,0)" />
+  <path d="M 1280 400 L 1280 428" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1280,435 1276,428 1284,428 1280,435" stroke="rgb(0,0,0)" />
+  <path d="M 1472 240 L 1472 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1472,279 1468,272 1476,272 1472,279" stroke="rgb(0,0,0)" />
+  <path d="M 1472 320 L 1472 348" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1472,355 1468,348 1476,348 1472,355" stroke="rgb(0,0,0)" />
+  <path d="M 1664 240 L 1664 272" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1664,279 1660,272 1668,272 1664,279" stroke="rgb(0,0,0)" />
+  <path d="M 1664 320 L 1664 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1664,359 1660,352 1668,352 1664,359" stroke="rgb(0,0,0)" />
+  <path d="M 1664 320 L 1664 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1664 340 L 1856 340" fill="none" stroke="rgb(0,0,0)" />
+  <path d="M 1856 340 L 1856 352" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1856,359 1852,352 1860,352 1856,359" stroke="rgb(0,0,0)" />
+  <path d="M 1664 400 L 1664 432" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1664,439 1660,432 1668,432 1664,439" stroke="rgb(0,0,0)" />
+  <path d="M 1664 480 L 1664 508" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1664,515 1660,508 1668,508 1664,515" stroke="rgb(0,0,0)" />
+  <path d="M 1856 400 L 1856 432" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1856,439 1852,432 1860,432 1856,439" stroke="rgb(0,0,0)" />
+  <path d="M 1856 480 L 1856 508" fill="none" stroke="rgb(0,0,0)" />
+  <polygon fill="rgb(0,0,0)" points="1856,515 1852,508 1860,508 1856,515" stroke="rgb(0,0,0)" />
+</svg>

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -27,7 +27,7 @@
                    "api/**.md",
                    "api/**.yml",
                    "articles/**.md",
-                   "articles/**.yml"
+                   "articles/**.yml",
                  ],
         "exclude": [ "obj/**" ]
       }
@@ -35,7 +35,11 @@
     "resource":
     [
       {
-        "files": ["favicon.ico", "DragonSharp48x48.png", "DragonSharp.png"]
+        "files": ["favicon.ico",
+                  "DragonSharp48x48.png",
+                  "DragonSharp.png",
+                  "articles/**.svg"
+                  ]
       }
     ],
     "overwrite":

--- a/src/Llvm.NET.sln
+++ b/src/Llvm.NET.sln
@@ -36,7 +36,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Repo Items", "Repo Items", 
 		..\appveyor.yml = ..\appveyor.yml
 		..\Build-docs.ps1 = ..\Build-docs.ps1
 		..\BuildAll.ps1 = ..\BuildAll.ps1
-		buildutils.ps1 = buildutils.ps1
 		..\Directory.Build.props = ..\Directory.Build.props
 		..\Directory.Build.targets = ..\Directory.Build.targets
 		..\docs-appveyor.yml = ..\docs-appveyor.yml
@@ -89,7 +88,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{D04D
 		..\docfx\articles\Samples\Kaleidoscope-ch7.md = ..\docfx\articles\Samples\Kaleidoscope-ch7.md
 		..\docfx\articles\Samples\Kaleidoscope-ch8.md = ..\docfx\articles\Samples\Kaleidoscope-ch8.md
 		..\docfx\articles\Samples\Kaleidoscope-ch9.md = ..\docfx\articles\Samples\Kaleidoscope-ch9.md
+		..\docfx\articles\Samples\Kaleidoscope-Parsetree-examples.md = ..\docfx\articles\Samples\Kaleidoscope-Parsetree-examples.md
 		..\docfx\articles\Samples\Kaleidoscope.md = ..\docfx\articles\Samples\Kaleidoscope.md
+		..\docfx\articles\Samples\parsetree-for-loop.svg = ..\docfx\articles\Samples\parsetree-for-loop.svg
+		..\docfx\articles\Samples\parsetree-func-call.svg = ..\docfx\articles\Samples\parsetree-func-call.svg
+		..\docfx\articles\Samples\parsetree-if-else.svg = ..\docfx\articles\Samples\parsetree-if-else.svg
+		..\docfx\articles\Samples\parsetree-paren-expr.svg = ..\docfx\articles\Samples\parsetree-paren-expr.svg
+		..\docfx\articles\Samples\parsetree-simpleexp-1.svg = ..\docfx\articles\Samples\parsetree-simpleexp-1.svg
+		..\docfx\articles\Samples\parsetree-userops.svg = ..\docfx\articles\Samples\parsetree-userops.svg
 		..\docfx\articles\Samples\toc.md = ..\docfx\articles\Samples\toc.md
 	EndProjectSection
 EndProject


### PR DESCRIPTION
* Added support for BlockDiag format generation for conversion to SVG for docs
* removed redundant unused TestWriter from the ReplLoop<T> implementation
* updated chapter 2 sample to generate all the tree representations and not show the xml anymore (it was noisy and not all that helpful to see in the command line anyway)
* Fixed bug in getCharinterval utility that would crash if the token was EOF.