### PR TITLE
Docs update

### DIFF
--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -43,6 +43,20 @@ try
         rd -Recurse -Force -Path $buildPaths.BuildOutputPath
     }
 
+    if( $env:CI -and !(Test-Path ".\BuildOutput\docs\.git" -PathType Container))
+    {
+        Write-Information "Cloning Docs repo"
+        pushd BuildOutput -ErrorAction Stop
+        try
+        {
+            git clone https://github.com/UbiquityDotNET/Llvm.NET.git -b gh-pages docs -q
+        }
+        finally
+        {
+            popd
+        }
+    }
+
     md BuildOutput\NuGet\ | Out-Null
 
     $BuildInfo = Get-BuildInformation $buildPaths

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -43,6 +43,8 @@ try
         rd -Recurse -Force -Path $buildPaths.BuildOutputPath
     }
 
+    md BuildOutput\NuGet\ | Out-Null
+
     if( $env:CI -and !(Test-Path ".\BuildOutput\docs\.git" -PathType Container))
     {
         Write-Information "Cloning Docs repo"
@@ -56,8 +58,6 @@ try
             popd
         }
     }
-
-    md BuildOutput\NuGet\ | Out-Null
 
     $BuildInfo = Get-BuildInformation $buildPaths
     if($env:APPVEYOR)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -61,7 +61,7 @@
                 <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
             </PropertyGroup>
             <ItemGroup Condition="'$(NoCommonAnalyzers)'!='true' and '$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">
-                 <PackageReference Include="SourceLink.Create.CommandLine" Version="2.6.1" PrivateAssets="All" />
+                 <PackageReference Include="SourceLink.Create.CommandLine" Version="2.7.4" PrivateAssets="All" />
             </ItemGroup>
             <ItemGroup Condition="'$(NoCommonAnalyzers)'!='true'">
                 <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" PrivateAssets="All" />

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -79,7 +79,7 @@ Users should be encouraged to participate in the life of the project and the com
 contributions enable the project team to ensure that they are satisfying the needs of those users. Common user
 activities include (but are not limited to):
 
-* Evangelising about the project
+* Evangelizing about the project
 * Informing developers of project strengths and weaknesses from a new user’s perspective
 * Providing moral support (a ‘thank you’ goes a long way)
 * Providing financial support
@@ -90,7 +90,7 @@ involved. Such users may then go on to become contributors, as described above.
 ### Support
 
 All participants in the community are encouraged to provide support for new users within the project management
-infrastructure. This support is provided as a way of growing the community. Those seeking support should recognise that
+infrastructure. This support is provided as a way of growing the community. Those seeking support should recognize that
 all support activity within the project is voluntary and is therefore provided as and when time allows. A user requiring
 guaranteed response times or results should therefore seek to purchase a support contract from a vendor. (Of course,
 that vendor should be an active member of the community.) However, for those willing to engage with the project on its

--- a/README.md
+++ b/README.md
@@ -36,34 +36,42 @@ C API with a C# adapter layer to provide the full experience .NET developers exp
 tedious one very little application code required changes.
 
 ### Platform Support
-Currently LLVM.NET supports Win32 and x64 buids targeting the full desktop framework v4.7 and .NET standard 2.0. Idealy other platforms are possible in the future. To keep life simpler the Llvm.NET nuget package is built for the "AnyCPU" platform and references the LibLLVM.NET package to bring in the native binary support. Llvm.NET contains code to dynamically detect the platform it is running on and load the appropriate DLL. This allows applications to build for AnyCPU without creating multiple build configurations and release vehicles for applications. (Any new platforms would need to update the dynamic loading support and include the appropriate P/Invokable binaries)
+Currently LLVM.NET supports Win32 and x64 builds targeting the full desktop framework v4.7 and .NET standard 2.0. Ideally
+other platforms are possible in the future. To keep life simpler the Llvm.NET NuGet package is built for the "AnyCPU"
+platform and references the LibLLVM.NET package to bring in the native binary support. Llvm.NET contains code to dynamically
+detect the platform it is running on and load the appropriate DLL. This allows applications to build for AnyCPU without
+creating multiple build configurations and release vehicles for applications. (Any new platforms would need to update the
+dynamic loading support and include the appropriate P/Invokable binaries)
 
-### CI Build Nuget Packages
-The CI Builds on AppVeyor provide a [Nuget Feed](https://ci.appveyor.com/nuget/Ubiquity.Llvm.NET
-) of the NuGet package built from the lates source in the master branch. 
+### CI Build NuGet Packages
+The CI Builds on AppVeyor provide a [NuGet Feed](https://ci.appveyor.com/NuGet/Ubiquity.Llvm.NET
+) of the NuGet package built from the latest source in the master branch. 
 
-### Building Llvm.NET
-#### Pre-requsites
+### API Documentation
+The full API documentation on using Llvm.NET is available on the [Llvm.NET documentation site](https://ubiquitydotnet.github.io/Llvm.NET/).
+
+## Building Llvm.NET
+### Pre-requsites
 * Visual Studio 2017 (15.4+)
-* Llvm.Libs Nuget Package
-  - To build the Llvm.Libs nuget package locally you can use the build support from the [Llvm.Libs ](https://github.com/UbiquityDotNET/Llvm.Libs) repository
+* Llvm.Libs NuGet Package
+  - To build the Llvm.Libs NuGet package locally you can use the build support from the [Llvm.Libs ](https://github.com/UbiquityDotNET/Llvm.Libs) repository
 
 #### Using Visual Studio
 The repository contains a Visual Studio solution files that allow building the components individually for modifying
 Llvm.NET and LibLLVM, as well as running the available unit tests. This is the primary mode of working with the
-Llvm.NET source code duing development.
+Llvm.NET source code during development.
 
-#### Replicating the automated build
-The Automated build support for Llvm.NET uses BuildAll.ps1 powershell script to build all the binaries, sign them
-[SHA256 hash only at present], and generate a nuget package. To build the full package simply run `BuildAll.ps1`
-from a powershell command prompt with msbuild tools on the system search path.
+### Replicating the automated build
+The Automated build support for Llvm.NET uses BuildAll.ps1 PowerShell script to build all the binaries, sign them
+[SHA256 hash only at present], and generate a NuGet package. To build the full package simply run `BuildAll.ps1`
+from a PowerShell command prompt with MSBuild tools on the system search path.
 
-#### Sample Application
+### Sample Application
 The [CodeGenWithDebugInfo](https://github.com/UbiquityDotNET/Llvm.Net/tree/master/Samples/CodeGenWithDebugInfo) sample application provides an example of using Llvm.NET to generate
 LLVM Bit code equivalent to what the Clang compiler generates for a [simple C language file](https://github.com/UbiquityDotNET/Llvm.Net/blob/master/Samples/CodeGenWithDebugInfo/Support%20Files/test.c).
-The sample applictation doesn't actually parse the source, instead it is a manually constructed and documented example of how to use Llvm.NET to accomplish the bit-code generation. 
+The sample application doesn't actually parse the source, instead it is a manually constructed and documented example of how to use Llvm.NET to accomplish the bit-code generation. 
 
-#### Code of Conduct
+### Code of Conduct
 This project has adopted the code of conduct defined by the [Contributor Covenant](http://contributor-covenant.org/)
 to clarify expected behavior in our community. For more information, see the
 [.NET Foundation Code of Conduct.](http://www.dotnetfoundation.org/code-of-conduct)

--- a/Samples/Kaleidoscope/Kaleidoscope.Parser/Kaleidoscope.g4
+++ b/Samples/Kaleidoscope/Kaleidoscope.Parser/Kaleidoscope.g4
@@ -1,6 +1,6 @@
 // ANTLR4 Grammar for the LLVM Tutorial Sample Kaleidoscope language
 // To support a progression through the chapters the language features are
-// selectable and dynamicly adjust the parsing accordingly. This allows a
+// selectable and dynamically adjust the parsing accordingly. This allows a
 // single parser implementation for all chapters, which allows the tutorial
 // to focus on the actual use of Llvm.NET itself rather than on parsing.
 //

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,9 @@ nuget:
 build_script:
   - ps: .\BuildAll.ps1
 
+deploy_script:
+  - ps: .\Push-Docs.ps1
+
 test_script:
   - ps: .\Invoke-UnitTests.ps1
   - ps: Set-Culture fr-FR; .\Invoke-UnitTests.ps1

--- a/docfx/Llvm.Net.Docfx.csproj
+++ b/docfx/Llvm.Net.Docfx.csproj
@@ -1,0 +1,59 @@
+<Project>
+    <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+    <PropertyGroup>
+        <TargetFramework>net47</TargetFramework>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <CompileDependsOn>ResolveReferences;BeforeCompile</CompileDependsOn>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <ProjectReference Include="..\src\Llvm.NET\Llvm.NET.csproj">
+            <PrivateAssets>All</PrivateAssets>
+            <Private>false</Private>
+        </ProjectReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Remove="Docfx-*.log" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="docfx.console" Version="2.29.1" Condition="'$(TargetFramework)'=='net47'" PrivateAssets="All" />
+        <PackageReference Include="memberpage" Version="2.29.1" Condition="'$(TargetFramework)'=='net47'" PrivateAssets="All" />
+        <PackageReference Include="msdn.4.5.2" Version="0.1.0-alpha-1611021200" Condition="'$(TargetFramework)'=='net47'" PrivateAssets="All" />
+    </ItemGroup>
+
+    <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+    <Target Name="GetDocfxPackagePaths" BeforeTargets="DocBuild">
+        <ItemGroup>
+            <docfxpkg Include="@(PackageDefinitions)" Condition="'%(PackageDefinitions.Name)'=='docfx.console'" />
+            <memberpage Include="@(PackageDefinitions)" Condition="'%(PackageDefinitions.Name)'=='memberpage'" />
+            <Msdn4_5_2 Include="@(PackageDefinitions)" Condition="'%(PackageDefinitions.Name)'=='msdn.4.5.2'" />
+            <DocFxInputAssembly Include="@(ReferencePath)" Condition="'%(ReferencePath.ReferenceSourceTarget)'=='ProjectReference'" />
+        </ItemGroup>
+        <PropertyGroup>
+            <DocfxConsolePath>%(docfxpkg.ResolvedPath)</DocfxConsolePath>
+            <MemberPagePath>%(memberpage.ResolvedPath)</MemberPagePath>
+            <MsdnXRefPath>%(msdn4_5_2.ResolvedPath)</MsdnXRefPath>
+            <LogLevel>Warning</LogLevel>
+            <LogFile>Docfx-$(TargetFramework).log</LogFile>
+            <DocParameters>$(DocParameters) --disableGitFeatures</DocParameters>
+            <DocParameters>$(DocParameters) --cleanupCacheHistory</DocParameters>
+            <DocParameters>$(DocParameters) --lruSize=0</DocParameters>
+            <DocParameters>$(DocParameters) --intermediateFolder=$(IntermediateOutputPath)</DocParameters>
+            <DocParameters>$(DocParameters) --xref=llvm-xref.yml,$(MsdnXrefPath)\content\msdn.4.5.2.zip,$(MsdnXrefPath)\content\namespaces.4.5.2.zip</DocParameters>
+            <DocTemplate>statictoc,$(MemberPagePath)\content,templates\Ubiquity</DocTemplate>
+        </PropertyGroup>
+        <Message Importance="high" Text="DocFxInputAssembly: %(DocFxInputAssembly.ReferenceAssembly)" />
+    </Target>
+
+    <!-- Stub the build target as this project only builds the documentation -->
+    <Target Name="CoreCompile" DependsOnTargets="$(CoreCompileDependsOn)">
+    </Target>
+
+    <Target Name="CopyFilesToOutputDirectory">
+    </Target>
+</Project>

--- a/docfx/articles/Samples/Kaleidoscope.md
+++ b/docfx/articles/Samples/Kaleidoscope.md
@@ -110,7 +110,7 @@ When entered ( or copy/pasted) to the command line Kaleidoscope will print out t
 >This example uses features of the language only enabled/discussed in Chapter 6 of the tutorial.
 >The runtime from earlier chapters will generate errors trying to parse this code.
 
-```
+```shell
 Ready>mandel(-2.3, -1.3, 0.05, 0.07);
 *******************************************************************************
 *******************************************************************************

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -5,7 +5,7 @@
       "src":
       [
         {
-          "files": [ "src/Llvm.Net/**.cs"  ],
+          "files": [ "src/Llvm.Net/**.cs" ],
           "src":".."
         }
       ],
@@ -18,7 +18,6 @@
   ],
   "build":
   {
-    "xref": [ "llvm-xref.yml", "../tools/msdn.4.5.2/content/msdn.4.5.2.zip", "../tools/msdn.4.5.2/content/namespaces.4.5.2.zip"],
     "content":
     [
       {
@@ -60,8 +59,8 @@
       "_appFooter" : "Copyright (C) 2017, Dot NET Foundation",
       "_appLogoPath": "DragonSharp48x48.png",
       "_disableBreadcrumb" : true,
-      "llvmVersion": "5.0.0"
+      "llvmVersion": "5.0.0",
+      "assemblies": ["Llvm.NET"],
     },
-    "template": ["statictoc","../tools/memberpage/content","templates/Ubiquity"]
   }
 }

--- a/docfx/llvm-xref.yml
+++ b/docfx/llvm-xref.yml
@@ -1,22 +1,22 @@
 references:
   - uid: llvm_langref
     name: LLVM Language reference
-    href: http://releases.llvm.org/5.0.0/docs/LangRef.html
+    href: http://releases.llvm.org/5.0.1/docs/LangRef.html
   - uid: llvm_sourceleveldebugging
     name: LLVM Source Level Debugging
-    href: http://releases.llvm.org/5.0.0/docs/SourceLevelDebugging.html
+    href: http://releases.llvm.org/5.0.1/docs/SourceLevelDebugging.html
   - uid: llvm_docs_garbagecollection
     name: LLVM Garbage Collection
-    href: http://releases.llvm.org/5.0.0/docs/GarbageCollection.html
+    href: http://releases.llvm.org/5.0.1/docs/GarbageCollection.html
   - uid: llvm_docs_passes
     name: LLVM Analysis and Transform Passes
-    href: http://releases.llvm.org/5.0.0/docs/Passes.html
+    href: http://releases.llvm.org/5.0.1/docs/Passes.html
   - uid: llvm_exception_handling
     name: LLVM Exception Handling
-    href: http://releases.llvm.org/5.0.0/docs/ExceptionHandling.html
+    href: http://releases.llvm.org/5.0.1/docs/ExceptionHandling.html
   - uid: llvm_misunderstood_gep
     name: LLVM The Misunderstood GEP Instruction
-    href: http://releases.llvm.org/5.0.0/docs/GetElementPtr.html
+    href: http://releases.llvm.org/5.0.1/docs/GetElementPtr.html
   - uid: llvm_sourcelevel_debugging
     name: LLVM Source Level Debugging
-    href: http://releases.llvm.org/5.0.0/docs/SourceLevelDebugging.html
+    href: http://releases.llvm.org/5.0.1/docs/SourceLevelDebugging.html

--- a/docfx/templates/Ubiquity/partials/class.header.tmpl.partial
+++ b/docfx/templates/Ubiquity/partials/class.header.tmpl.partial
@@ -1,4 +1,4 @@
-<h1 id="{{id}}" data-uid="{{uid}}">{{>partials/title}}</h1>
+<h1 id="{{id}}" data-uid="{{uid}}" class="text-break">{{>partials/title}}</h1>
 <div class="markdown level0 summary">{{{summary}}}</div>
 <div class="markdown level0 conceptual">{{{conceptual}}}</div>
 
@@ -62,16 +62,16 @@
 </div>
 {{/implements.0}}
 
-<h6><strong>{{__global.namespace}}</strong>: {{{namespace.specName.0.value}}}</h6>
-<h6><strong>{{__global.assembly}}</strong>: {{assemblies.0}}.dll</h6>
+<h5><strong>{{__global.namespace}}</strong>: {{{namespace.specName.0.value}}}</h5>
+<h5><strong>{{__global.assembly}}</strong>: {{assemblies.0}}.dll</h5>
 
-<h5 id="{{id}}_syntax">{{__global.syntax}}</h5>
+<h3 id="{{id}}_syntax"><strong>{{__global.syntax}}</strong></h3>
 <div class="codewrapper">
   <pre><code class="lang-{{_lang}} hljs">{{syntax.content.0.value}}</code></pre>
 </div>
 
 {{#syntax.parameters.0}}
-<h5 class="parameters">{{__global.parameters}}</h5>
+<h2 class="parameters">{{__global.parameters}}</h2>
 <table>
 {{/syntax.parameters.0}}
 {{#syntax.parameters}}
@@ -88,7 +88,7 @@
 {{/syntax.parameters.0}}
 
 {{#syntax.return}}
-<h5 class="returns">{{__global.returns}}</h5>
+<h2 class="returns">{{__global.returns}}</h2>
 <table>
   <tr>
     <td>
@@ -100,7 +100,7 @@
 {{/syntax.return}}
 
 {{#syntax.typeParameters.0}}
-<h5 class="typeParameters">{{__global.typeParameters}}</h5>
+<h2 class="typeParameters">{{__global.typeParameters}}</h2>
 <table>
 {{/syntax.typeParameters.0}}
 {{#syntax.typeParameters}}
@@ -116,12 +116,12 @@
 {{/syntax.typeParameters.0}}
 
 {{#remarks}}
-<h5 id="{{id}}_remarks"><strong>{{__global.remarks}}</strong></h5>
+<h3 id="{{id}}_remarks"><strong>{{__global.remarks}}</strong></h3>
 <div class="markdown level0 remarks">{{{remarks}}}</div>
 {{/remarks}}
 
 {{#example.0}}
-<h5 id="{{id}}_examples"><strong>{{__global.examples}}</strong></h5>
+<h3 id="{{id}}_examples"><strong>{{__global.examples}}</strong></h3>
 {{/example.0}}
 {{#example}}
 {{{.}}}

--- a/docfx/templates/Ubiquity/partials/class.tmpl.partial
+++ b/docfx/templates/Ubiquity/partials/class.tmpl.partial
@@ -1,0 +1,51 @@
+﻿{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+
+{{>partials/class.header}}
+{{#children}}
+{{#overload}}
+<a id="{{id}}" data-uid="{{uid}}"></a>
+{{/overload}}
+<h3 id="{{id}}">{{>partials/classSubtitle}}</h3>
+{{#children.0}}
+<table class="table table-bordered table-striped table-condensed">
+  {{/children.0}}
+    {{#children}}
+    <tr>
+      <td id="{{id}}" data-uid="{{uid}}">
+        <xref uid="{{uid}}" altProperty="fullName" displayProperty="name"/>
+      </td>
+      <td class="markdown level1 summary">{{{summary}}}</td>
+    </tr>
+    {{/children}}
+  {{#children.0}}
+</table>
+{{/children.0}}
+{{/children}}
+{{#extensionMethods.0}}
+<h3 id="extensionmethods">{{__global.extensionMethods}}</h3>
+{{/extensionMethods.0}}
+{{#extensionMethods}}
+<div>
+  {{#definition}}
+    <xref uid="{{definition}}" altProperty="fullName" displayProperty="nameWithType"/>
+  {{/definition}}
+  {{^definition}}
+    <xref uid="{{uid}}" altProperty="fullName" displayProperty="nameWithType"/>
+  {{/definition}}
+</div>
+{{/extensionMethods}}
+{{#seealso.0}}
+<h3 id="seealso">{{__global.seealso}}</h3>
+<div class="seealso">
+{{/seealso.0}}
+{{#seealso}}
+  {{#isCref}}
+    <div>{{{type.specName.0.value}}}</div>
+  {{/isCref}}
+  {{^isCref}}
+    <div>{{{url}}}</div>
+  {{/isCref}}
+{{/seealso}}
+{{#seealso.0}}
+</div>
+{{/seealso.0}}

--- a/docfx/templates/Ubiquity/partials/collection.tmpl.partial
+++ b/docfx/templates/Ubiquity/partials/collection.tmpl.partial
@@ -1,0 +1,177 @@
+{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+
+<h1 id="{{id}}" data-uid="{{uid}}">{{>partials/title}}</h1>
+<div class="markdown level0 summary">{{{summary}}}</div>
+<div class="markdown level0 conceptual">{{{conceptual}}}</div>
+
+{{#children}}
+{{#children}}
+{{^_disableContribution}}
+{{#docurl}}
+<span class="small pull-right mobile-hide">
+  <span class="divider">|</span>
+  <a href="{{docurl}}">{{__global.improveThisDoc}}</a>
+</span>{{/docurl}}
+{{#sourceurl}}
+<span class="small pull-right mobile-hide">
+  <a href="{{sourceurl}}">{{__global.viewSource}}</a>
+</span>{{/sourceurl}}
+{{/_disableContribution}}
+{{#overload}}
+<a id="{{id}}" data-uid="{{uid}}"></a>
+{{/overload}}
+<h2 id="{{id}}" data-uid="{{uid}}">{{name.0.value}}</h2>
+<div class="markdown level1 summary">{{{summary}}}</div>
+<div class="markdown level1 conceptual">{{{conceptual}}}</div>
+<h3 class="decalaration">{{__global.declaration}}</h5>
+{{#syntax}}
+<div class="codewrapper">
+  <pre><code class="lang-{{_lang}} hljs">{{syntax.content.0.value}}</code></pre>
+</div>
+{{#parameters.0}}
+<h2 class="parameters">{{__global.parameters}}</h2>
+<table class="table table-bordered table-striped table-condensed">
+{{/parameters.0}}
+{{#parameters}}
+    <tr>
+      <td>{{{type.specName.0.value}}}</td>
+      <td><span class="parametername">{{{id}}}</span></td>
+      <td>{{{description}}}</td>
+    </tr>
+{{/parameters}}
+{{#parameters.0}}
+</table>
+{{/parameters.0}}
+{{#return}}
+<h2 class="returns">{{__global.returns}}</h2>
+<table class="table table-bordered table-striped table-condensed">
+    <tr>
+      <td>{{{type.specName.0.value}}}</td>
+      <td>{{{description}}}</td>
+    </tr>
+</table>
+{{/return}}
+{{#typeParameters.0}}
+<h2 class="typeParameters">{{__global.typeParameters}}</h2>
+<table class="table table-bordered table-striped table-condensed">
+{{/typeParameters.0}}
+{{#typeParameters}}
+    <tr>
+      <td><span class="parametername">{{{id}}}</span></td>
+      <td>{{{description}}}</td>
+    </tr>
+{{/typeParameters}}
+{{#typeParameters.0}}
+</table>
+{{/typeParameters.0}}
+{{#fieldValue}}
+<h2 class="fieldValue">{{__global.fieldValue}}</h2>
+<table class="table table-bordered table-striped table-condensed">
+    <tr>
+      <td>{{{type.specName.0.value}}}</td>
+      <td>{{{description}}}</td>
+    </tr>
+</table>
+{{/fieldValue}}
+{{#propertyValue}}
+<h2 class="propertyValue">{{__global.propertyValue}}</h2>
+<table class="table table-bordered table-striped table-condensed">
+    <tr>
+      <td>{{{type.specName.0.value}}}</td>
+      <td>{{{description}}}</td>
+    </tr>
+</table>
+{{/propertyValue}}
+{{#eventType}}
+<h2 class="eventType">{{__global.eventType}}</h2>
+<table class="table table-bordered table-striped table-condensed">
+    <tr>
+      <td>{{{type.specName.0.value}}}</td>
+      <td>{{{description}}}</td>
+    </tr>
+</table>
+{{/eventType}}
+{{/syntax}}
+{{#overridden}}
+<h2 class="overrides">{{__global.overrides}}</h2>
+<div><xref uid="{{uid}}" altProperty="fullName" displayProperty="nameWithType"/></div>
+{{/overridden}}
+{{#implements.0}}
+<h2 class="implements">{{__global.implements}}</h2>
+{{/implements.0}}
+{{#implements}}
+  {{#definition}}
+    <div><xref uid="{{definition}}" altProperty="fullName" displayProperty="nameWithType"/></div>
+  {{/definition}}
+  {{^definition}}
+    <div><xref uid="{{uid}}" altProperty="fullName" displayProperty="nameWithType"/></div>
+  {{/definition}}
+{{/implements}}
+{{#remarks}}
+<h2 id="{{id}}_remarks">{{__global.remarks}}</h2>
+<div class="markdown level1 remarks">{{{remarks}}}</div>
+{{/remarks}}
+{{#example.0}}
+<h2 id="{{id}}_examples">{{__global.examples}}</h2>
+{{/example.0}}
+{{#example}}
+{{{.}}}
+{{/example}}
+{{#exceptions.0}}
+<h2 class="exceptions">{{__global.exceptions}}</h2>
+<table class="table table-bordered table-striped table-condensed">
+{{/exceptions.0}}
+{{#exceptions}}
+    <tr>
+      <td>{{{type.specName.0.value}}}</td>
+      <td>{{{description}}}</td>
+    </tr>
+{{/exceptions}}
+{{#exceptions.0}}
+</table>
+{{/exceptions.0}}
+{{#seealso.0}}
+<h2 id="{{id}}_seealso">{{__global.seealso}}</h2>
+<div class="seealso">
+{{/seealso.0}}
+{{#seealso}}
+  {{#isCref}}
+    <div>{{{type.specName.0.value}}}</div>
+  {{/isCref}}
+  {{^isCref}}
+    <div>{{{url}}}</div>
+  {{/isCref}}
+{{/seealso}}
+{{#seealso.0}}
+</div>
+{{/seealso.0}}
+{{/children}}
+{{/children}}
+{{#extensionMethods.0}}
+<h3 id="extensionmethods">{{__global.extensionMethods}}</h3>
+{{/extensionMethods.0}}
+{{#extensionMethods}}
+<div>
+  {{#definition}}
+    <xref uid="{{definition}}" altProperty="fullName" displayProperty="nameWithType"/>
+  {{/definition}}
+  {{^definition}}
+    <xref uid="{{uid}}" altProperty="fullName" displayProperty="nameWithType"/>
+  {{/definition}}
+</div>
+{{/extensionMethods}}
+{{#seealso.0}}
+<h3 id="seealso">{{__global.seealso}}</h3>
+<div class="seealso">
+{{/seealso.0}}
+{{#seealso}}
+  {{#isCref}}
+    <div>{{{type.specName.0.value}}}</div>
+  {{/isCref}}
+  {{^isCref}}
+    <div>{{{url}}}</div>
+  {{/isCref}}
+{{/seealso}}
+{{#seealso.0}}
+</div>
+{{/seealso.0}}

--- a/docfx/templates/Ubiquity/partials/enum.tmpl.partial
+++ b/docfx/templates/Ubiquity/partials/enum.tmpl.partial
@@ -1,0 +1,27 @@
+{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+
+{{>partials/class.header}}
+{{#children}}
+<h3 id="{{id}}">{{>partials/classSubtitle}}</h3>
+<table class="table table-bordered table-striped table-condensed">
+  {{#children}}
+    <tr>
+      <td id="{{id}}">{{name.0.value}}</td>
+      <td>{{{summary}}}</td>
+    </tr>
+  {{/children}}
+</table>
+{{/children}}
+{{#extensionMethods.0}}
+<h3 id="extensionmethods">{{__global.extensionMethods}}</h3>
+{{/extensionMethods.0}}
+{{#extensionMethods}}
+<div>
+  {{#definition}}
+    <xref uid="{{definition}}" fullName="{{fullName.0.value}}" name="{{nameWithType.0.value}}"/>
+  {{/definition}}
+  {{^definition}}
+    <xref uid="{{uid}}" fullName="{{fullName.0.value}}" name="{{nameWithType.0.value}}"/>
+  {{/definition}}
+</div>
+{{/extensionMethods}}

--- a/docfx/templates/Ubiquity/partials/namespace.tmpl.partial
+++ b/docfx/templates/Ubiquity/partials/namespace.tmpl.partial
@@ -1,4 +1,4 @@
-<h1 id="{{id}}" data-uid="{{uid}}">{{>partials/title}}</h1>
+<h1 id="{{id}}" data-uid="{{uid}}" class="text-break">{{>partials/title}}</h1>
 <div class="markdown level0 summary">{{{summary}}}</div>
 <div class="markdown level0 conceptual">{{{conceptual}}}</div>
 <div class="markdown level0 remarks">{{{remarks}}}</div>

--- a/docfx/templates/Ubiquity/readme.md
+++ b/docfx/templates/Ubiquity/readme.md
@@ -1,14 +1,19 @@
 # Attribution
 
-This template is a modification (color choices) of the template provided by Mathew Sachin
+This template is a modification of the template provided by Mathew Sachin
 see: https://github.com/MathewSachin/docfx-tmpl
+combined with a modification of the DocFX memberpage template
 
 Changes:
-* Color Changed from greenish theme to default neutral grey
-* Removed Custom Enum template as the default looks and works better with member-pages
-* Removed custom Class template as the default table layout works better with member-pages
+* Dark color theme
+* Changed tags for many headers for items rendering really small due to use of h5/h6
+* Modified Enum template from member-pages to remove redundant table headers
+* Modified Class template from member-pages to remove redundant headers
+* Modified Collections template from default to remove redundant headers
 * Fixed bug on class namespace name rendering (Was always saying System.Dynamic.ExpandoObject)
 * Added Collapse region for Inherited Members list (Initially collapsed)
 * Added Collapse region for Inheritance chain (Initially collapsed)
 * Added Collapse region for Derived classes list (Initially collapsed)
+* Added Collapse region for Implemented interfaces (Initially collapsed)
+* Added llvm language from highlightjs.org as it is not part of the docfx.vendor.js by default
 

--- a/docfx/templates/Ubiquity/styles/main.css
+++ b/docfx/templates/Ubiquity/styles/main.css
@@ -1,11 +1,17 @@
-@import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css");
+/* @import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css");*/
+
+body,
+html {
+    font-family: segoe-ui_normal,Segoe UI,Segoe,Segoe WP,Helvetica Neue,Helvetica,sans-serif;
+    font-size: 100%;
+}
 
 /* Clickability fix for selector on sm devices */
 @media (min-width: 768px) and (max-width: 991px) {
   article h1:first-of-type:before {
     height: 0;
     margin-top: 0;
-  }  
+  }
 }
 
 #search {
@@ -19,7 +25,7 @@
 .sidetoc,
 body .toc,
 .sidefilter,
-.sidetoggle { 
+.sidetoggle {
 }
 
 .sidenav,
@@ -111,21 +117,21 @@ article h4 {
 .affix ul > li > a:hover,
 .affix ul > li.active > a,
 .affix ul > li > a:focus {
-  color: #563d7c;                 
-  text-decoration: none;          
-  background-color: transparent;  
-  border-left-color: #563d7c; 
+  color: #ad9017;
+  text-decoration: none;
+  background-color: transparent;
+  border-left-color: #ad9017;
 }
 
 /* all active links */
-.affix ul > li.active > a, 
+.affix ul > li.active > a,
 .affix ul > li.active:hover > a,
 .affix ul > li.active:focus >a {
     font-weight: 700;
 }
 
 /* nested active links */
-.affix ul ul > li.active > a, 
+.affix ul ul > li.active > a,
 .affix ul ul > li.active:hover > a,
 .affix ul ul > li.active:focus > a {
     font-weight: 500;
@@ -190,30 +196,30 @@ article h4 {
    ------------------------------------------------------- */
 .navbar-inverse {
   opacity: 0.95;
-  border-color: #02735f;
+  border-color: #375c86;
 }
 .navbar-inverse .navbar-brand {
-  color: #ffffff;
+  color: #E0E0E0;
 }
 .navbar-inverse .navbar-brand:hover,
 .navbar-inverse .navbar-brand:focus {
   color: #ecdbff;
 }
 .navbar-inverse .navbar-text {
-  color: #ffffff;
+  color: #E0E0E0;
 }
 .navbar-inverse .navbar-nav > li > a {
-  color: #ffffff;
+  color: #E0E0E0;
 }
 .navbar-inverse .navbar-nav > li > a:hover,
 .navbar-inverse .navbar-nav > li > a:focus {
-  color: #ecdbff;
+  color: #58acff;
 }
 .navbar-inverse .navbar-nav > .active > a,
 .navbar-inverse .navbar-nav > .active > a:hover,
 .navbar-inverse .navbar-nav > .active > a:focus {
-  color: #ecdbff;
-  background-color: #02735f;
+  color: #000;
+  background-color: #337AB7;
 }
 .navbar-inverse .navbar-nav > .open > a,
 .navbar-inverse .navbar-nav > .open > a:hover,
@@ -229,14 +235,14 @@ article h4 {
   background-color: #02735f;
 }
 .navbar-inverse .navbar-toggle .icon-bar {
-  background-color: #ffffff;
+  background-color: #E0E0E0;
 }
 .navbar-inverse .navbar-collapse,
 .navbar-inverse .navbar-form {
   border: none;
 }
 .navbar-inverse .navbar-link {
-  color: #ffffff;
+  color: #E0E0E0;
 }
 .navbar-inverse .navbar-link:hover {
   color: #ecdbff;
@@ -244,7 +250,7 @@ article h4 {
 
 @media (max-width: 767px) {
   .navbar-inverse .navbar-nav .open .dropdown-menu > li > a {
-    color: #ffffff;
+    color: #E0E0E0;
   }
   .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:hover,
   .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:focus {
@@ -257,3 +263,433 @@ article h4 {
     background-color: #02735f;
   }
 }
+
+/* Ubiquity layout overrides */
+.article {
+    margin-top: 35px;
+}
+
+article {
+  margin: 1em;
+}
+
+/* Overrides for - Ubiquity DocFX Dark theme */
+body {
+    color:#ccc;
+    background-color: #0A0A0A;
+}
+
+pre {
+    background-color:#0A0A0A;
+    border:1px solid #55595c;
+    font-size: .875rem;
+}
+
+img {
+    vertical-align: middle;
+    background-color: #303030;
+}
+
+.table .table {
+    background-color:#0A0A0A;
+}
+
+.table-bordered,
+.table-bordered>tbody>tr>td,
+.table-bordered>tbody>tr>th,
+.table-bordered>tfoot>tr>td,
+.table-bordered>tfoot>tr>th,
+.table-bordered>thead>tr>td,
+.table-bordered>thead>tr>th {
+    border: none;
+    border-top: 1px solid #29393b;
+    border-bottom: 1px solid #29393b;
+}
+
+.table-striped>tbody>tr:nth-of-type(odd) {
+    background-color:#0A0A0A;
+}
+
+.sidenav,
+.fixed_header,
+.toc {
+  background-color: #0A0A0A;
+}
+
+.sidetoc {
+  background-color: #0A0A0A;
+  border-left: 1px dotted #1e324d;
+  border-right: 1px dotted #1e324d;
+}
+
+body .toc {
+  background-color: #0A0A0A;
+}
+
+.toc .nav > li > a {
+  color: #ccc;
+}
+
+.toc .nav > li > a:hover,
+.toc .nav > li > a:focus {
+  color: #0078d7;
+  text-decoration: underline;
+}
+
+.sidefilter {
+  background-color: #0A0A0A;
+  border-left: 1px dotted #1e324d;
+  border-right: 1px dotted #1e324d;
+}
+
+.sideaffix > div.contribution > ul > li > a.contribution-link:hover {
+  background-color: #0A0A0A;
+}
+
+.affix ul > li > a:before {
+  color: #FFFFFF;
+}
+
+.affix ul > li > a:hover {
+  color: #eab22a;;
+}
+
+.affix ul > li > a:hover {
+  color: #eab22a;;
+}
+
+.affix ul > li > a {
+  color: #eab22a;
+}
+
+.footer {
+  border-top: 1px solid #1e324d;
+  background-color: #0A0A0A;
+}
+
+.toc li:after {
+    color: #eab22a;
+}
+
+.alert-info {
+    color: #73d1ff;
+    background-color: #0c0e0f;
+    border-color: #bce8f1;
+}
+
+.alert-warning {
+    color: #8a6d3b;
+    background-color: #000;
+    border-color: #f00;
+}
+
+button, a {
+    color: #00a4f3;
+}
+
+button:hover,
+button:focus,
+a:hover,
+a:focus {
+    color: #0078d7;
+    text-decoration: underline;
+}
+
+a.expander.hover {
+  text-decoration:none;
+}
+
+code {
+    color: #4EC9B0;
+    background-color: #000;
+    border-radius: 1px;
+}
+
+pre code {
+    color: #ccc
+}
+
+svg:hover text {
+    fill: #58acff;
+}
+
+svg:hover path {
+    fill: #58acff;
+}
+
+/* Highlight.JS Ubiquity Dark theme */
+.hljs {
+  display: block;
+  overflow-x: auto;
+  background: #0A0A0A;
+  color: #C0C0C0;
+  padding: 0.5em;
+  -webkit-text-size-adjust:none
+}
+
+.hljs-comment {
+  color:#e9d585;
+}
+
+.hljs-quote {
+  color: #9c9491;
+}
+
+.hljs-variable,
+.hljs-template-variable,
+.hljs-attribute,
+.hljs-tag,
+.hljs-name,
+.hljs-regexp,
+.hljs-link,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class {
+  color: #f22c40;
+}
+
+.hljs-meta {
+  color: #c0c682;
+}
+
+.hljs-symbol
+{
+  color: #C0C0C0;
+}
+
+.hljs-title,
+.hljs-type,
+.hljs-class {
+  color: #4EC9B0;
+}
+
+.hljs-string,
+.hljs-bullet {
+  color: #D69D85;
+}
+
+.hljs-params
+.hljs-section {
+  color: #C0C0C0;
+}
+
+.hljs-built_in,
+.hljs-builtin-name,
+.hljs-keyword,
+.hljs-selector-tag {
+  color: #569CD6;
+}
+
+.hljs-number,
+.hljs-literal {
+  color: #B5CEA8
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
+/* Override docfx.vendor.css language specific hljs styles */
+.bash .hljs-shebang,
+.java .hljs-javadoc,
+.javascript .hljs-javadoc,
+.rust .hljs-preprocessor {
+    color:#e9d585
+}
+
+.apache .hljs-sqbracket,
+.c .hljs-preprocessor,
+.coffeescript .hljs-regexp,
+.coffeescript .hljs-subst,
+.cpp .hljs-preprocessor,
+.javascript .hljs-regexp,
+.json .hljs-attribute,
+.less .hljs-built_in,
+.makefile .hljs-variable,
+.markdown .hljs-blockquote,
+.markdown .hljs-emphasis,
+.markdown .hljs-link_label,
+.markdown .hljs-strong,
+.markdown .hljs-value,
+.nginx .hljs-number,
+.nginx .hljs-regexp,
+.objectivec .hljs-preprocessor .hljs-title,
+.perl .hljs-regexp,
+.php .hljs-regexp,.scss .hljs-built_in,
+.xml .hljs-value {
+    color:#bd63c5
+}
+
+.css .hljs-at_rule,
+.css .hljs-important,
+.go .hljs-typename,.haskell .hljs-type,
+.http .hljs-request,
+.ini .hljs-setting,
+.java .hljs-javadoctag,
+.javascript .hljs-javadoctag,
+.javascript .hljs-tag,
+.less .hljs-at_rule,
+.less .hljs-tag,
+.nginx .hljs-title,
+.objectivec .hljs-preprocessor,
+.php .hljs-phpdoc,
+.scss .hljs-at_rule,
+.scss .hljs-important,
+.scss .hljs-tag,
+.sql .hljs-built_in,
+.stylus .hljs-at_rule,
+.swift .hljs-preprocessor {
+    color:#a71d5d
+}
+
+.apache .hljs-cbracket,
+.apache .hljs-common,
+.apache .hljs-keyword,
+.bash .hljs-built_in,
+.bash .hljs-literal,
+.c .hljs-built_in,
+.c .hljs-number,
+.coffeescript .hljs-built_in,
+.coffeescript .hljs-literal,
+.coffeescript .hljs-number,
+.cpp .hljs-built_in,
+.cpp .hljs-number,
+.cs .hljs-built_in,
+.cs .hljs-number,
+.css .hljs-attribute,
+.css .hljs-function,
+.css .hljs-hexcolor,
+.css .hljs-number,
+.go .hljs-built_in,
+.go .hljs-constant,
+.haskell .hljs-number,
+.http .hljs-attribute,
+.http .hljs-literal,
+.java .hljs-number,
+.javascript .hljs-built_in,
+.javascript .hljs-literal,
+.javascript .hljs-number,
+.json .hljs-number,
+.less .hljs-attribute,
+.less .hljs-function,
+.less .hljs-hexcolor,
+.less .hljs-number,
+.makefile .hljs-keyword,
+.markdown .hljs-link_reference,
+.nginx .hljs-built_in,
+.objectivec .hljs-built_in,
+.objectivec .hljs-literal,
+.objectivec .hljs-number,
+.php .hljs-literal,
+.php .hljs-number,
+.puppet .hljs-function,
+.python .hljs-number,
+.ruby .hljs-constant,
+.ruby .hljs-number,
+.ruby .hljs-prompt,
+.ruby .hljs-subst .hljs-keyword,
+.ruby .hljs-symbol,
+.rust .hljs-number,
+.scss .hljs-attribute,
+.scss .hljs-function,
+.scss .hljs-hexcolor,
+.scss .hljs-number,
+.scss .hljs-preprocessor,
+.sql .hljs-number,
+.stylus .hljs-attribute,
+.stylus .hljs-hexcolor,
+.stylus .hljs-number,
+.stylus .hljs-params,
+.swift .hljs-built_in,
+.swift .hljs-number {
+    color:#4EC9B0
+}
+
+.apache .hljs-tag,
+.cs .hljs-xmlDocTag,
+.css .hljs-tag,
+.stylus .hljs-tag,
+.xml .hljs-title {
+    color:#63a35c
+}
+
+.bash .hljs-variable,
+.cs .hljs-preprocessor,
+.cs .hljs-preprocessor .hljs-keyword,
+.css .hljs-attr_selector,
+.css .hljs-value,
+.ini .hljs-keyword,
+.ini .hljs-value,
+.javascript .hljs-tag .hljs-title,
+.makefile .hljs-constant,
+.nginx .hljs-variable,
+.scss .hljs-variable,
+.xml .hljs-tag {
+    color:#333
+}
+
+.bash .hljs-title,
+.c .hljs-title,
+.coffeescript .hljs-title,
+.cpp .hljs-title,
+.cs .hljs-title,
+.css .hljs-class,
+.css .hljs-id,
+.css .hljs-pseudo,
+.diff .hljs-chunk,
+.haskell .hljs-pragma,
+.haskell .hljs-title,
+.ini .hljs-title,
+.java .hljs-title,
+.javascript .hljs-title,
+.less .hljs-class,
+.less .hljs-id,
+.less .hljs-pseudo,
+.makefile .hljs-title,
+.objectivec .hljs-title,
+.perl .hljs-sub,
+.php .hljs-title,
+.puppet .hljs-title,
+.python .hljs-decorator,
+.python .hljs-title,
+.ruby .hljs-parent,
+.ruby .hljs-title,
+.rust .hljs-title,
+.scss .hljs-class,
+.scss .hljs-id,
+.scss .hljs-pseudo,
+.stylus .hljs-class,
+.stylus .hljs-id,.stylus .hljs-pseudo,
+.stylus .hljs-title,
+.swift .hljs-title,
+.xml .hljs-attribute {
+    color:#4EC9B0
+}
+
+.coffeescript .hljs-attribute,
+.coffeescript .hljs-reserved {
+    color:#1d3e81
+}
+
+.diff .hljs-chunk {
+    font-weight:700
+}
+
+.diff .hljs-addition {
+    color:#55a532;
+    background-color:#eaffea
+}
+
+.diff .hljs-deletion {
+    color:#bd2c00;
+    background-color:#ffecec
+}
+
+.markdown .hljs-link_url {
+    text-decoration:underline
+}
+

--- a/docfx/templates/Ubiquity/styles/main.js
+++ b/docfx/templates/Ubiquity/styles/main.js
@@ -4,8 +4,8 @@ containers.removeClass("container");
 containers.addClass("container-fluid");
 
 // Navbar Hamburger
-$(function() {
-    $(".navbar-toggle").click(function() {
+$(function () {
+    $(".navbar-toggle").click(function () {
         $(this).toggleClass("change");
     })
 })
@@ -24,7 +24,7 @@ $(function () {
     form.append(selector);
     form.prependTo("article");
 
-    selector.change(function() {
+    selector.change(function () {
         window.location = $(this).find("option:selected").val();
     })
 
@@ -55,3 +55,97 @@ $(function () {
         work($(this), 0);
     });
 })
+
+// Add LLVM IR language support from highlightjs.org
+hljs.registerLanguage("llvm", function (e) {
+    var n = "([-a-zA-Z$._][\\w\\-$.]*)";
+    return {
+        k: "begin end true false declare define global constant private linker_private internal available_externally linkonce linkonce_odr weak weak_odr appending dllimport dllexport common default hidden protected extern_weak external thread_local zeroinitializer undef null to tail target triple datalayout volatile nuw nsw nnan ninf nsz arcp fast exact inbounds align addrspace section alias module asm sideeffect gc dbg linker_private_weak attributes blockaddress initialexec localdynamic localexec prefix unnamed_addr ccc fastcc coldcc x86_stdcallcc x86_fastcallcc arm_apcscc arm_aapcscc arm_aapcs_vfpcc ptx_device ptx_kernel intel_ocl_bicc msp430_intrcc spir_func spir_kernel x86_64_sysvcc x86_64_win64cc x86_thiscallcc cc c signext zeroext inreg sret nounwind noreturn noalias nocapture byval nest readnone readonly inlinehint noinline alwaysinline optsize ssp sspreq noredzone noimplicitfloat naked builtin cold nobuiltin noduplicate nonlazybind optnone returns_twice sanitize_address sanitize_memory sanitize_thread sspstrong uwtable returned type opaque eq ne slt sgt sle sge ult ugt ule uge oeq one olt ogt ole oge ord uno ueq une x acq_rel acquire alignstack atomic catch cleanup filter inteldialect max min monotonic nand personality release seq_cst singlethread umax umin unordered xchg add fadd sub fsub mul fmul udiv sdiv fdiv urem srem frem shl lshr ashr and or xor icmp fcmp phi call trunc zext sext fptrunc fpext uitofp sitofp fptoui fptosi inttoptr ptrtoint bitcast addrspacecast select va_arg ret br switch invoke unwind unreachable indirectbr landingpad resume malloc alloca free load store getelementptr extractelement insertelement shufflevector getresult extractvalue insertvalue atomicrmw cmpxchg fence argmemonly double distinct",
+        c: [{
+            cN: "keyword",
+            b: "i\\d+"
+        }, e.C(";", "\\n", {
+            r: 0
+        }), e.QSM, {
+            cN: "string",
+            v: [{
+                b: '"',
+                e: '[^\\\\]"'
+            }],
+            r: 0
+        }, {
+            cN: "title",
+            v: [{
+                b: "@" + n
+            }, {
+                b: "@\\d+"
+            }, {
+                b: "!" + n
+            }, {
+                b: "!\\d+" + n
+            }]
+        }, {
+            cN: "symbol",
+            v: [{
+                b: "%" + n
+            }, {
+                b: "%\\d+"
+            }, {
+                b: "#\\d+"
+            }]
+        }, {
+            cN: "number",
+            v: [{
+                b: "0[xX][a-fA-F0-9]+"
+            }, {
+                b: "-?\\d+(?:[.]\\d+)?(?:[eE][-+]?\\d+(?:[.]\\d+)?)?"
+            }],
+            r: 0
+        }]
+    }
+});
+// Custom ANTLR language support
+hljs.registerLanguage("antlr", function (e) {
+    return {
+        k:
+          'grammar fragment',
+        c: [
+          e.C(
+            '//', '\\n', { r: 0 }
+          ),
+          e.QSM,
+          e.ASM,
+          {
+              cN: 'meta',
+              v: [
+                { b: '{', e: '}' },
+                { b: '{', e: '}\?' },
+              ],
+              r: 0
+          },
+          {
+              cN: 'symbol',
+              v: [
+                { b: '([A-Z][\\w\\-$.]*)' },
+              ]
+          },
+          {
+              cN: 'number',
+              v: [
+                  { b: '0[xX][a-fA-F0-9]+' },
+                  { b: '-?\\d+(?:[.]\\d+)?(?:[eE][-+]?\\d+(?:[.]\\d+)?)?' }
+              ],
+              r: 0
+          },
+          {
+              cN: 'title',
+              v: [
+                { b: '([-a-zA-Z$._][\\w\\-$.]*)' },
+              ]
+          },
+
+        ]
+    };
+}
+);
+

--- a/docfx/toc.yml
+++ b/docfx/toc.yml
@@ -7,4 +7,4 @@
 - name: LLVM.org
   href: http://LLVM.org
 - name: LLVM Docs
-  href: http://releases.llvm.org/5.0.0/docs/index.html
+  href: http://releases.llvm.org/5.0.1/docs/index.html

--- a/src/Llvm.NET.sln
+++ b/src/Llvm.NET.sln
@@ -34,7 +34,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Repo Items", "Repo Items", "{BA4F7BCF-67BC-49E4-B2F9-DCED3D57619D}"
 	ProjectSection(SolutionItems) = preProject
 		..\appveyor.yml = ..\appveyor.yml
-		..\Build-docs.ps1 = ..\Build-docs.ps1
 		..\BuildAll.ps1 = ..\BuildAll.ps1
 		..\Directory.Build.props = ..\Directory.Build.props
 		..\Directory.Build.targets = ..\Directory.Build.targets
@@ -101,6 +100,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{D04D
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kaleidoscope.Runtime", "..\Samples\Kaleidoscope\Kaleidoscope.Runtime\Kaleidoscope.Runtime.csproj", "{DF586B9E-C590-459F-AD5A-F2E023E3CB45}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Llvm.Net.Docfx", "..\docfx\Llvm.Net.Docfx.csproj", "{887D41FB-C927-4AF2-9A0C-A60AD86CA277}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -159,6 +160,10 @@ Global
 		{DF586B9E-C590-459F-AD5A-F2E023E3CB45}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DF586B9E-C590-459F-AD5A-F2E023E3CB45}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DF586B9E-C590-459F-AD5A-F2E023E3CB45}.Release|Any CPU.Build.0 = Release|Any CPU
+		{887D41FB-C927-4AF2-9A0C-A60AD86CA277}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{887D41FB-C927-4AF2-9A0C-A60AD86CA277}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{887D41FB-C927-4AF2-9A0C-A60AD86CA277}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{887D41FB-C927-4AF2-9A0C-A60AD86CA277}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Llvm.NET/Llvm.NET.csproj
+++ b/src/Llvm.NET/Llvm.NET.csproj
@@ -22,8 +22,6 @@
     </ItemGroup>
     <ItemGroup>
         <Content Include="NugetPkg\build\Llvm.NET.props" PackagePath="build" />
-        <Content Include="$(OutputPath)net47\Llvm.Net.pdb" PackagePath="lib\net47" InProject="false" />
-        <Content Include="$(OutputPath)netstandard2.0\Llvm.Net.pdb" PackagePath="lib\netstandard2.0" InProject="false" />
     </ItemGroup>
     <ItemGroup>
         <CodeAnalysisDictionary Include="..\CustomDictionary.xml">


### PR DESCRIPTION
* Complete refactoring of docs build. The docs are now built as a distinct project and included in the Llvm.NET.sln
* removed Build-docs.ps1 and updated Appveyor build support for the docs
* Buildall.ps1 now really does build all.
* Customized docs template/theme to use a dark theme that more closely resembles the dark theme of the .NET APIs
* added syntax highlighting for llvm-IR and rudimentary ANTLR grammar support for docs.