### PR TITLE
Fixed bug causing Appending Module flags to fail

### DIFF
--- a/src/Llvm.NET/Native/CustomGenerated.cs
+++ b/src/Llvm.NET/Native/CustomGenerated.cs
@@ -356,7 +356,7 @@ namespace Llvm.NET.Native
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
         internal static extern int LLVMGetValueID( LLVMValueRef @val );
 
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
+        [DllImport( LibraryPath, EntryPoint = "LLVMBuildIntCast2", CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
         internal static extern LLVMValueRef LLVMBuildIntCast( LLVMBuilderRef @param0, LLVMValueRef @Val, LLVMTypeRef @DestTy, [MarshalAs( UnmanagedType.Bool )]bool isSigned, [MarshalAs( UnmanagedType.LPStr )] string @Name );
 
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
@@ -401,7 +401,7 @@ namespace Llvm.NET.Native
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
         internal static extern void LLVMAddModuleFlag( LLVMModuleRef @M, LLVMModFlagBehavior behavior, [MarshalAs( UnmanagedType.LPStr )] string @name, UInt32 @value );
 
-        [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
+        [DllImport( LibraryPath, EntryPoint = "LLVMAddModuleFlagMetadata", CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]
         internal static extern void LLVMAddModuleFlag( LLVMModuleRef @M, LLVMModFlagBehavior behavior, [MarshalAs( UnmanagedType.LPStr )] string @name, LLVMMetadataRef @value );
 
         [DllImport( LibraryPath, CallingConvention = CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true )]

--- a/src/Llvm.NETTests/MDNodeTests.cs
+++ b/src/Llvm.NETTests/MDNodeTests.cs
@@ -23,6 +23,24 @@ namespace Llvm.NET.Tests
         //    Assert.Inconclusive( );
         //}
         */
+        [TestMethod]
+        public void AppendingModuleFlagsTest( )
+        {
+            var targetMachine = TargetTests.GetTargetMachine( );
+            using( var ctx = new Context( ) )
+            using( var module = ctx.CreateBitcodeModule( "test.bc", SourceLanguage.CSharp, "test.cs", "unittests" ) )
+            {
+                module.AddModuleFlag( ModuleFlagBehavior.Append, "testMD", module.CreateMDNode( "testValue" ) );
+                Assert.AreEqual( 1, module.ModuleFlags.Count );
+                var flag = module.ModuleFlags[ "testMD" ];
+                Assert.IsNotNull( flag );
+                Assert.AreEqual( ModuleFlagBehavior.Append, flag.Behavior );
+                Assert.AreEqual( "testMD", flag.Name );
+                Assert.IsInstanceOfType( flag.Metadata, typeof( MDTuple ) );
+                var tuple = ( MDTuple )flag.Metadata;
+                Assert.AreEqual( "testValue", tuple.GetOperandString( 0 ) );
+            }
+        }
 
         [TestMethod]
         public void OperandsAreAccessibleTest()


### PR DESCRIPTION
* Restored Entrypoint names on overloaded P/Invokes
* Added tests to validate appending ModuleFLags operate correctly.