### PR TITLE
Fixed package reference to x86 binaries

### DIFF
--- a/src/Llvm.NET/NugetPkg/build/Llvm.NET.props
+++ b/src/Llvm.NET/NugetPkg/build/Llvm.NET.props
@@ -15,15 +15,5 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <PackagePath>runtimes\win-x64\native\LibLLVM.pdb</PackagePath>
         </Content>
-        <Content Include="$(LlvmNetPackageRoot)runtimes\win-x86\native\LibLLVM.dll">
-            <Link>runtimes\win-x86\native\LibLLVM.dll</Link>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <PackagePath>runtimes\win-x86\native\LibLLVM.dll</PackagePath>
-        </Content>
-        <Content Include="$(LlvmNetPackageRoot)runtimes\win-x86\native\LibLLVM.pdb">
-            <Link>runtimes\win-x86\native\LibLLVM.pdb</Link>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <PackagePath>runtimes\win-x86\native\LibLLVM.pdb</PackagePath>
-        </Content>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Removed reference to now non-existent x86 binaries in the Llvm.NET package