### PR TITLE
Fixes #84,#85,#86

### DIFF
--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -1,7 +1,8 @@
 Param(
     [string]$Configuration="Release",
     [switch]$AllowVsPreReleases,
-    [switch]$NoClean
+    [switch]$NoClean,
+    [switch]$SkipDocs
 )
 
 . .\buildutils.ps1
@@ -80,7 +81,7 @@ try
     Install-LlvmLibs $buildPaths.LlvmLibsRoot "8.0.0" "msvc" "15.9"
 
     # clone docs output location so it is available as a destination for the rest of the build
-    if( !(Test-Path (Join-Path $buildPaths.DocsOutput '.git') -PathType Container))
+    if(!$SkipDocs -and !(Test-Path (Join-Path $buildPaths.DocsOutput '.git') -PathType Container))
     {
         Write-Information "Cloning Docs repository"
         pushd BuildOutput -ErrorAction Stop
@@ -105,8 +106,11 @@ try
     Write-Information "Restoring Docs Project"
     Invoke-MSBuild -Targets Restore -Project docfx\Llvm.NET.DocFX.csproj -Properties $msBuildProperties -LoggerArgs $msbuildLoggerArgs ($msbuildLoggerArgs + @("/bl:Llvm.NET-docfx-restore.binlog") )
 
-    Write-Information "Building Docs"
-    Invoke-MSBuild -Targets Build -Project docfx\Llvm.NET.DocFX.csproj -Properties $msBuildProperties -LoggerArgs $msbuildLoggerArgs ($msbuildLoggerArgs + @("/bl:Llvm.NET-docfx-build.binlog") )
+    if(!$SkipDocs)
+    {
+        Write-Information "Building Docs"
+        Invoke-MSBuild -Targets Build -Project docfx\Llvm.NET.DocFX.csproj -Properties $msBuildProperties -LoggerArgs $msbuildLoggerArgs ($msbuildLoggerArgs + @("/bl:Llvm.NET-docfx-build.binlog") )
+    }
 
     if( $env:APPVEYOR_PULL_REQUEST_NUMBER )
     {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -71,7 +71,7 @@
                 <PackageReference Include="Ubiquity.ArgValidators" Version="6.0.1" />
                 <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.2" PrivateAssets="All" />
                 <PackageReference Include="RefactoringEssentials" Version="5.6.0" PrivateAssets="All" />
-                <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta009" PrivateAssets="All" />
+                <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
                 <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
                 <None Include="$(MSBuildThisFileDirectory)Ubiquity.NET.ruleset" Link="Ubiquity.NET.ruleset" />
             </ItemGroup>

--- a/Samples/CodeGenWithDebugInfo/Program.cs
+++ b/Samples/CodeGenWithDebugInfo/Program.cs
@@ -187,6 +187,7 @@ namespace TestDebugInfo
                         File.WriteAllText( "test.ll", module.WriteToString( ) );
                         TargetDetails.TargetMachine.EmitToFile( module, "test.o", CodeGenFileType.ObjectFile );
                         TargetDetails.TargetMachine.EmitToFile( module, "test.s", CodeGenFileType.AssemblySource );
+                        Console.WriteLine( "Generated test.bc, test.ll, test.o, and test.s" );
                     }
                 }
             }

--- a/Samples/CodeGenWithDebugInfo/Program.cs
+++ b/Samples/CodeGenWithDebugInfo/Program.cs
@@ -331,7 +331,7 @@ namespace TestDebugInfo
             }
 
             var loadedDst = instBuilder.SetDebugLocation( 15, 6, copyFunc.DISubProgram )
-                                       .Load( dstAddr )
+                                       .Load( fooPtr, dstAddr )
                                        .Alignment( ptrAlign );
 
             instBuilder.SetDebugLocation( 15, 13, copyFunc.DISubProgram );

--- a/Samples/Kaleidoscope/Chapter2/Program.cs
+++ b/Samples/Kaleidoscope/Chapter2/Program.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Linq;
 using System.Reflection;
 using Kaleidoscope.Grammar;

--- a/Samples/Kaleidoscope/Chapter4/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter4/CodeGenerator.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Kaleidoscope.Grammar;
 using Kaleidoscope.Grammar.AST;
 using Kaleidoscope.Runtime;

--- a/Samples/Kaleidoscope/Chapter5/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter5/CodeGenerator.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Kaleidoscope.Grammar;
 using Kaleidoscope.Grammar.AST;
 using Kaleidoscope.Runtime;

--- a/Samples/Kaleidoscope/Chapter6/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter6/CodeGenerator.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Kaleidoscope.Grammar;
 using Kaleidoscope.Grammar.AST;
 using Kaleidoscope.Runtime;

--- a/Samples/Kaleidoscope/Chapter7.1/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter7.1/CodeGenerator.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Kaleidoscope.Grammar;
 using Kaleidoscope.Grammar.AST;
 using Kaleidoscope.Runtime;
@@ -221,7 +220,10 @@ namespace Kaleidoscope.Chapter71
         {
             var value = LookupVariable( reference.Name );
 
-            return InstructionBuilder.Load( value )
+            // since the Alloca is created as a non-opaque pointer it is OK to just use the
+            // ElementType. If full opaque pointer support was used, then the Lookup map
+            // would need to include the type of the value allocated.
+            return InstructionBuilder.Load( value.ElementType, value )
                                      .RegisterName( reference.Name );
         }
         #endregion
@@ -273,7 +275,11 @@ namespace Kaleidoscope.Chapter71
             // generate continue block
             function.BasicBlocks.Add( continueBlock );
             InstructionBuilder.PositionAtEnd( continueBlock );
-            return InstructionBuilder.Load( result )
+
+            // since the Alloca is created as a non-opaque pointer it is OK to just use the
+            // ElementType. If full opaque pointer support was used, then the Lookup map
+            // would need to include the type of the value allocated.
+            return InstructionBuilder.Load( result.ElementType, result )
                                      .RegisterName( "ifresult" );
         }
         #endregion
@@ -339,7 +345,10 @@ namespace Kaleidoscope.Chapter71
                     return null;
                 }
 
-                var curVar = InstructionBuilder.Load( allocaVar )
+                // since the Alloca is created as a non-opaque pointer it is OK to just use the
+                // ElementType. If full opaque pointer support was used, then the Lookup map
+                // would need to include the type of the value allocated.
+                var curVar = InstructionBuilder.Load( allocaVar.ElementType, allocaVar )
                                                .RegisterName( varName );
                 var nextVar = InstructionBuilder.FAdd( curVar, stepValue )
                                                 .RegisterName( "nextvar" );
@@ -427,7 +436,7 @@ namespace Kaleidoscope.Chapter71
 
         #region GetOrDeclareFunction
 
-        // Retrieves a Function" for a prototype from the current module if it exists,
+        // Retrieves a Function for a prototype from the current module if it exists,
         // otherwise declares the function and returns the newly declared function.
         private Function GetOrDeclareFunction( Prototype prototype )
         {

--- a/Samples/Kaleidoscope/Chapter7/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter7/CodeGenerator.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Kaleidoscope.Grammar;
 using Kaleidoscope.Grammar.AST;
 using Kaleidoscope.Runtime;
@@ -221,7 +220,10 @@ namespace Kaleidoscope.Chapter7
         {
             var value = LookupVariable( reference.Name );
 
-            return InstructionBuilder.Load( value )
+            // since the Alloca is created as a non-opaque pointer it is OK to just use the
+            // ElementType. If full opaque pointer support was used, then the Lookup map
+            // would need to include the type of the value allocated.
+            return InstructionBuilder.Load( value.ElementType, value )
                                      .RegisterName( reference.Name );
         }
         #endregion
@@ -273,7 +275,11 @@ namespace Kaleidoscope.Chapter7
             // generate continue block
             function.BasicBlocks.Add( continueBlock );
             InstructionBuilder.PositionAtEnd( continueBlock );
-            return InstructionBuilder.Load( result )
+
+            // since the Alloca is created as a non-opaque pointer it is OK to just use the
+            // ElementType. If full opaque pointer support was used, then the Lookup map
+            // would need to include the type of the value allocated.
+            return InstructionBuilder.Load( result.ElementType, result )
                                      .RegisterName( "ifresult" );
         }
         #endregion
@@ -339,7 +345,10 @@ namespace Kaleidoscope.Chapter7
                     return null;
                 }
 
-                var curVar = InstructionBuilder.Load( allocaVar )
+                // since the Alloca is created as a non-opaque pointer it is OK to just use the
+                // ElementType. If full opaque pointer support was used, then the Lookup map
+                // would need to include the type of the value allocated.
+                var curVar = InstructionBuilder.Load( allocaVar.ElementType, allocaVar )
                                                .RegisterName( varName );
                 var nextVar = InstructionBuilder.FAdd( curVar, stepValue )
                                                 .RegisterName( "nextvar" );

--- a/Samples/Kaleidoscope/Chapter8/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter8/CodeGenerator.cs
@@ -221,9 +221,12 @@ namespace Kaleidoscope.Chapter8
         #region VariableReferenceExpression
         public override Value Visit( VariableReferenceExpression reference )
         {
-            Alloca value = LookupVariable( reference.Name );
+            var value = LookupVariable( reference.Name );
 
-            return InstructionBuilder.Load( value )
+            // since the Alloca is created as a non-opaque pointer it is OK to just use the
+            // ElementType. If full opaque pointer support was used, then the Lookup map
+            // would need to include the type of the value allocated.
+            return InstructionBuilder.Load( value.ElementType, value )
                                      .RegisterName( reference.Name );
         }
         #endregion
@@ -275,7 +278,11 @@ namespace Kaleidoscope.Chapter8
             // generate continue block
             function.BasicBlocks.Add( continueBlock );
             InstructionBuilder.PositionAtEnd( continueBlock );
-            return InstructionBuilder.Load( result )
+
+            // since the Alloca is created as a non-opaque pointer it is OK to just use the
+            // ElementType. If full opaque pointer support was used, then the Lookup map
+            // would need to include the type of the value allocated.
+            return InstructionBuilder.Load( result.ElementType, result )
                                      .RegisterName( "ifresult" );
         }
         #endregion
@@ -305,8 +312,7 @@ namespace Kaleidoscope.Chapter8
             // store the value into allocated location
             InstructionBuilder.Store( startVal, allocaVar );
 
-            // Make the new basic block for the loop header, inserting after current
-            // block.
+            // Make the new basic block for the loop header.
             var loopBlock = function.AppendBasicBlock( "loop" );
 
             // Insert an explicit fall through from the current block to the loopBlock.
@@ -342,7 +348,10 @@ namespace Kaleidoscope.Chapter8
                     return null;
                 }
 
-                var curVar = InstructionBuilder.Load( allocaVar )
+                // since the Alloca is created as a non-opaque pointer it is OK to just use the
+                // ElementType. If full opaque pointer support was used, then the Lookup map
+                // would need to include the type of the value allocated.
+                var curVar = InstructionBuilder.Load( allocaVar.ElementType, allocaVar )
                                                .RegisterName( varName );
                 var nextVar = InstructionBuilder.FAdd( curVar, stepValue )
                                                 .RegisterName( "nextvar" );
@@ -352,6 +361,7 @@ namespace Kaleidoscope.Chapter8
                 endCondition = InstructionBuilder.Compare( RealPredicate.OrderedAndNotEqual, endCondition, Context.CreateConstant( 0.0 ) )
                                                  .RegisterName( "loopcond" );
 
+                // Create the "after loop" block and insert it.
                 var afterBlock = function.AppendBasicBlock( "afterloop" );
 
                 // Insert the conditional branch into the end of LoopEndBB.
@@ -430,7 +440,7 @@ namespace Kaleidoscope.Chapter8
 
         #region GetOrDeclareFunction
 
-        // Retrieves a Function" for a prototype from the current module if it exists,
+        // Retrieves a Function for a prototype from the current module if it exists,
         // otherwise declares the function and returns the newly declared function.
         private Function GetOrDeclareFunction( Prototype prototype )
         {

--- a/Samples/Kaleidoscope/Kaleidoscope.Parser/Kaleidoscope.Grammar.csproj
+++ b/Samples/Kaleidoscope/Kaleidoscope.Parser/Kaleidoscope.Grammar.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Antlr4" Version="4.6.5-beta001" />
+    <PackageReference Include="Antlr4" Version="4.6.6"/>
     <PackageReference Include="OpenSoftware.DgmlBuilder" Version="1.12.0" Condition="'$(TargetFramework)'=='net47'" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>

--- a/Samples/Kaleidoscope/Kaleidoscope.Runtime/Kaleidoscope.Runtime.csproj
+++ b/Samples/Kaleidoscope/Kaleidoscope.Runtime/Kaleidoscope.Runtime.csproj
@@ -8,7 +8,6 @@
       <ProjectReference Include="..\Kaleidoscope.Parser\Kaleidoscope.Grammar.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="System.IO.Pipelines" Version="4.5.1" />
-      <PackageReference Include="System.Reactive" Version="4.1.2" />
+      <PackageReference Include="System.Reactive" Version="4.1.5" />
     </ItemGroup>
 </Project>

--- a/buildutils.ps1
+++ b/buildutils.ps1
@@ -326,7 +326,7 @@ function Install-LlvmLibs($destPath, $llvmversion, $compiler, $compilerversion)
             }
             else
             {
-                throw "Release '$releaseName' not found!"
+                throw "Release 'v$releaseName' not found!"
             }
         }
 

--- a/src/Interop/Llvm.NET.Interop/llvm-c/Core.cs
+++ b/src/Interop/Llvm.NET.Interop/llvm-c/Core.cs
@@ -2585,7 +2585,7 @@ namespace Llvm.NET.Interop
 
         [SuppressUnmanagedCodeSecurity]
         [DllImport( LibraryPath, CallingConvention=global::System.Runtime.InteropServices.CallingConvention.Cdecl )]
-        public static extern LLVMValueRef LLVMConstGEP( LLVMValueRef ConstantVal, out LLVMValueRef ConstantIndices, uint NumIndices );
+        public static extern LLVMValueRef LLVMConstGEP( LLVMValueRef ConstantVal, [MarshalAs( UnmanagedType.LPArray, ArraySubType = UnmanagedType.SysInt )]LLVMValueRef[] ConstantIndices, uint NumIndices );
 
         [SuppressUnmanagedCodeSecurity]
         [DllImport( LibraryPath, CallingConvention=global::System.Runtime.InteropServices.CallingConvention.Cdecl )]
@@ -4430,11 +4430,11 @@ namespace Llvm.NET.Interop
 
         [SuppressUnmanagedCodeSecurity]
         [DllImport( LibraryPath, CallingConvention=global::System.Runtime.InteropServices.CallingConvention.Cdecl )]
-        public static extern LLVMValueRef LLVMBuildGEP2( LLVMBuilderRef B, LLVMTypeRef Ty, LLVMValueRef Pointer, out LLVMValueRef Indices, uint NumIndices, [MarshalAs( UnmanagedType.LPStr )]string Name );
+        public static extern LLVMValueRef LLVMBuildGEP2( LLVMBuilderRef B, LLVMTypeRef Ty, LLVMValueRef Pointer, [MarshalAs( UnmanagedType.LPArray, ArraySubType = UnmanagedType.SysInt )]LLVMValueRef[] Indices, uint NumIndices, [MarshalAs( UnmanagedType.LPStr )]string Name );
 
         [SuppressUnmanagedCodeSecurity]
         [DllImport( LibraryPath, CallingConvention=global::System.Runtime.InteropServices.CallingConvention.Cdecl )]
-        public static extern LLVMValueRef LLVMBuildInBoundsGEP2( LLVMBuilderRef B, LLVMTypeRef Ty, LLVMValueRef Pointer, out LLVMValueRef Indices, uint NumIndices, [MarshalAs( UnmanagedType.LPStr )]string Name );
+        public static extern LLVMValueRef LLVMBuildInBoundsGEP2( LLVMBuilderRef B, LLVMTypeRef Ty, LLVMValueRef Pointer, [MarshalAs( UnmanagedType.LPArray, ArraySubType = UnmanagedType.SysInt )]LLVMValueRef[] Indices, uint NumIndices, [MarshalAs( UnmanagedType.LPStr )]string Name );
 
         [SuppressUnmanagedCodeSecurity]
         [DllImport( LibraryPath, CallingConvention=global::System.Runtime.InteropServices.CallingConvention.Cdecl )]
@@ -4559,7 +4559,7 @@ namespace Llvm.NET.Interop
 
         [SuppressUnmanagedCodeSecurity]
         [DllImport( LibraryPath, CallingConvention=global::System.Runtime.InteropServices.CallingConvention.Cdecl )]
-        public static extern LLVMValueRef LLVMBuildCall2( LLVMBuilderRef _0, LLVMTypeRef _1, LLVMValueRef Fn, out LLVMValueRef Args, uint NumArgs, [MarshalAs( UnmanagedType.LPStr )]string Name );
+        public static extern LLVMValueRef LLVMBuildCall2( LLVMBuilderRef _0, LLVMTypeRef _1, LLVMValueRef Fn, [MarshalAs( UnmanagedType.LPArray, ArraySubType = UnmanagedType.SysInt )]LLVMValueRef[] Args, uint NumArgs, [MarshalAs( UnmanagedType.LPStr )]string Name );
 
         [SuppressUnmanagedCodeSecurity]
         [DllImport( LibraryPath, CallingConvention=global::System.Runtime.InteropServices.CallingConvention.Cdecl )]

--- a/src/Interop/LlvmBindingsGenerator/Program.cs
+++ b/src/Interop/LlvmBindingsGenerator/Program.cs
@@ -116,6 +116,10 @@ namespace LlvmBindingsGenerator
                     new ArrayMarshalInfo( "LLVMGetIntrinsicDeclaration", "ParamTypes", UnmanagedType.SysInt),
                     new ArrayMarshalInfo( "LLVMIntrinsicGetType", "ParamTypes", UnmanagedType.SysInt),
                     new ArrayMarshalInfo( "LLVMIntrinsicCopyOverloadedName", "ParamTypes", UnmanagedType.SysInt),
+                    new ArrayMarshalInfo( "LLVMBuildCall2", "Args", UnmanagedType.SysInt),
+                    new ArrayMarshalInfo( "LLVMBuildInBoundsGEP2", "Indices", UnmanagedType.SysInt ),
+                    new ArrayMarshalInfo( "LLVMConstGEP", "ConstantIndices", UnmanagedType.SysInt ),
+                    new ArrayMarshalInfo( "LLVMBuildGEP2", "Indices", UnmanagedType.SysInt ),
 
                     // Function return types
                     new StringMarshalInfo( "LLVMGetDiagInfoDescription", StringDisposal.DisposeMessage ),

--- a/src/Llvm.NET/Context.cs
+++ b/src/Llvm.NET/Context.cs
@@ -839,6 +839,11 @@ namespace Llvm.NET
 
         internal Context( LLVMContextRef contextRef )
         {
+            if( contextRef == LLVMContextRef.Zero )
+            {
+                throw new ArgumentNullException( nameof( contextRef ) );
+            }
+
             ContextHandle = contextRef;
             ContextCache.Add( this );
             ActiveHandler = new WrappedNativeCallback<LLVMDiagnosticHandler>( DiagnosticHandler );

--- a/src/Llvm.NET/DebugInfo/DebugStructType.cs
+++ b/src/Llvm.NET/DebugInfo/DebugStructType.cs
@@ -48,6 +48,9 @@ namespace Llvm.NET.DebugInfo
             DebugMembers = new ReadOnlyCollection<DebugMemberInfo>( debugElements as IList<DebugMemberInfo> ?? debugElements.ToList( ) );
 
             NativeType = module.Context.CreateStructType( nativeName, packed, debugElements.Select( e => e.DebugType ).ToArray( ) );
+
+            // create a temp opaque type to act as scope for members
+            // this is RAUW with the full struct once it is defined
             DIType = module.DIBuilder.CreateReplaceableCompositeType( Tag.StructureType
                                                                     , name
                                                                     , scope

--- a/src/Llvm.NET/DisAssembler.cs
+++ b/src/Llvm.NET/DisAssembler.cs
@@ -4,11 +4,6 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-using System;
-using System.Runtime.InteropServices;
-using Llvm.NET.Interop;
-
-using static Llvm.NET.Interop.NativeMethods;
 
 // warning CS0649: Field 'xxx' is never assigned to, and will always have its default value 0
 #pragma warning disable 649

--- a/src/Llvm.NET/Instructions/Alloca.cs
+++ b/src/Llvm.NET/Instructions/Alloca.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using Llvm.NET.Interop;
+using Llvm.NET.Types;
 
 namespace Llvm.NET.Instructions
 {
@@ -19,5 +20,13 @@ namespace Llvm.NET.Instructions
             : base( valueRef )
         {
         }
+
+        /// <summary>Gets the type of the alloca element</summary>
+        /// <remarks>
+        /// The <see cref="Llvm.NET.Values.Value.NativeType"/> of an <see cref="Alloca"/>
+        /// is always a pointer type, this provides the ElementType (e.g. the pointee type)
+        /// for the alloca.
+        /// </remarks>
+        public ITypeRef ElementType => ( ( IPointerType )NativeType ).ElementType;
     }
 }

--- a/src/Llvm.NET/Instructions/Predicates.cs
+++ b/src/Llvm.NET/Instructions/Predicates.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Llvm.NET.Interop;
-using static Llvm.NET.Interop.NativeMethods;
 
 namespace Llvm.NET.Instructions
 {

--- a/src/Llvm.NET/Properties/Resources.Designer.cs
+++ b/src/Llvm.NET/Properties/Resources.Designer.cs
@@ -270,6 +270,15 @@ namespace Llvm.NET.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot load a value for an opaque or unsized type.
+        /// </summary>
+        internal static string Cannot_load_a_value_for_an_opaque_or_unsized_type {
+            get {
+                return ResourceManager.GetString("Cannot_load_a_value_for_an_opaque_or_unsized_type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot mix types from different contexts.
         /// </summary>
         internal static string Cannot_mix_types_from_different_contexts {
@@ -801,6 +810,15 @@ namespace Llvm.NET.Properties {
         internal static string Name_cannot_be_null_or_empty {
             get {
                 return ResourceManager.GetString("Name_cannot_be_null_or_empty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Non-pointer type expected.
+        /// </summary>
+        internal static string Non_pointer_type_expected {
+            get {
+                return ResourceManager.GetString("Non_pointer_type_expected", resourceCulture);
             }
         }
         

--- a/src/Llvm.NET/Properties/Resources.resx
+++ b/src/Llvm.NET/Properties/Resources.resx
@@ -484,4 +484,10 @@ Types are:
   <data name="Alignment_only_allowed_on_memory_instructions" xml:space="preserve">
     <value>Alignment can only be set for instructions dealing with memory read/write (alloca, load, store)</value>
   </data>
+  <data name="Non_pointer_type_expected" xml:space="preserve">
+      <value>Non-pointer type expected</value>
+  </data>
+  <data name="Cannot_load_a_value_for_an_opaque_or_unsized_type" xml:space="preserve">
+      <value>Cannot load a value for an opaque or unsized type</value>
+  </data>
 </root>

--- a/src/Llvm.NET/Types/ITypeRef.cs
+++ b/src/Llvm.NET/Types/ITypeRef.cs
@@ -7,8 +7,6 @@ using Llvm.NET.Interop;
 using Llvm.NET.Values;
 using Ubiquity.ArgValidators;
 
-using static Llvm.NET.Interop.NativeMethods;
-
 // Interface+internal type matches file name
 #pragma warning disable SA1649
 

--- a/src/Llvm.NET/Values/ConstantExpression.cs
+++ b/src/Llvm.NET/Values/ConstantExpression.cs
@@ -72,7 +72,7 @@ namespace Llvm.NET.Values
         public static Constant GetElementPtr(Constant value, IEnumerable<Constant> args)
         {
             var llvmArgs = InstructionBuilder.GetValidatedGEPArgs(value.NativeType, value, args);
-            var handle = LLVMConstGEP( value.ValueHandle, out llvmArgs[0], (uint)llvmArgs.Length);
+            var handle = LLVMConstGEP( value.ValueHandle, llvmArgs, (uint)llvmArgs.Length);
             return FromHandle<Constant>(handle);
         }
 

--- a/src/Llvm.NET/Values/GlobalVariable.cs
+++ b/src/Llvm.NET/Values/GlobalVariable.cs
@@ -2,7 +2,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // </copyright>
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using Llvm.NET.DebugInfo;
 using Llvm.NET.Interop;

--- a/src/Llvm.NETTests/Llvm.NET.Tests.csproj
+++ b/src/Llvm.NETTests/Llvm.NET.Tests.csproj
@@ -10,8 +10,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-      <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-      <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+      <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+      <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
   </ItemGroup>
 </Project>

--- a/src/Llvm.NETTests/ModuleFixtures.cs
+++ b/src/Llvm.NETTests/ModuleFixtures.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using Llvm.NET;
 using Llvm.NET.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 


### PR DESCRIPTION
- Deprecated InstructionBuilder.Load() single arg form, in favor of overload that accepts a type param for opaque pointers.
- Updated Analyzers to latest version and cleaned up code to correspond with changes in rules.
- Updated ANTLR4 version for Kaleidoscope Grammar.
- Added additional array marshaling info to the bindings generator to account for In arrays on some missed APIs
- Added ElementType to Alloca Instruction to provide a simple property to get the allocated type.
- Fixed GEP arg checks to validate args and indexes for arbitrary depth.
- Added SkipDocs switch to BuildAll.ps1 to allow faster inner loop development when doc builds aren't relevant.