### PR TITLE
General cleanup

### DIFF
--- a/Build-Docs.ps1
+++ b/Build-Docs.ps1
@@ -72,11 +72,8 @@ try
         }
     }
 
-    Write-Information "Restoring Docs Project"
-    Invoke-MSBuild -Targets Restore -Project docfx\Llvm.NET.DocFX.csproj -Properties $msBuildProperties -LoggerArgs $msbuildLoggerArgs ($msbuildLoggerArgs + @("/bl:Llvm.NET-docfx-restore.binlog") )
-
-    Write-Information "Building Docs"
-    Invoke-MSBuild -Targets Build -Project docfx\Llvm.NET.DocFX.csproj -Properties $msBuildProperties -LoggerArgs $msbuildLoggerArgs ($msbuildLoggerArgs + @("/bl:Llvm.NET-docfx-build.binlog") )
+    Write-Information "Building Docs Project"
+    Invoke-MSBuild -Targets 'Restore;Build' -Project docfx\Llvm.NET.DocFX.csproj -Properties $msBuildProperties -LoggerArgs $msbuildLoggerArgs ($msbuildLoggerArgs + @("/bl:Llvm.NET-docfx.binlog") )
 }
 finally
 {

--- a/Build-Interop.ps1
+++ b/Build-Interop.ps1
@@ -86,7 +86,6 @@ try
                             LlvmVersion = $BuildInfo.LlvmVersion
                           }
 
-
     # Need to invoke NuGet directly for restore of vcxproj as /t:Restore target doesn't support packages.config
     # and PackageReference isn't supported for native projects... [Sigh...]
     Write-Information "Restoring NuGet Packages"
@@ -95,11 +94,10 @@ try
     Write-Information "Building LllvmBindingsGenerator"
     # manual restore needed so that the CppSharp libraries are available during the build phase as CppSharp NuGet package
     # is basically hostile to the newer SDK project format.
-    Invoke-MSBuild -Targets Restore -Project 'src\Interop\LlvmBindingsGenerator\LlvmBindingsGenerator.csproj' -Properties $msBuildProperties -LoggerArgs ($msbuildLoggerArgs + @("/bl:LlvmBindingsGenerator.binlog") )
-    Invoke-MSBuild -Targets Build -Project 'src\Interop\LlvmBindingsGenerator\LlvmBindingsGenerator.csproj' -Properties $msBuildProperties -LoggerArgs ($msbuildLoggerArgs + @("/bl:LlvmBindingsGenerator.binlog") )
+    Invoke-MSBuild -Targets 'Restore;Build' -Project 'src\Interop\LlvmBindingsGenerator\LlvmBindingsGenerator.csproj' -Properties $msBuildProperties -LoggerArgs ($msbuildLoggerArgs + @("/bl:LlvmBindingsGenerator.binlog") )
 
     Write-Information "Generating P/Invoke Binding code"
-    & "$($buildPaths.BuildOutputPath)\bin\LlvmBindingsGenerator\Release\net47\LlvmBindingsGenerator.exe" $buildPaths.LlvmLibsRoot (Join-Path $buildPaths.SrcRoot 'Interop\LibLLVM') (Join-Path $buildPaths.SrcRoot 'Interop\Llvm.NET.Interop') 
+    & "$($buildPaths.BuildOutputPath)\bin\LlvmBindingsGenerator\Release\net47\LlvmBindingsGenerator.exe" $buildPaths.LlvmLibsRoot (Join-Path $buildPaths.SrcRoot 'Interop\LibLLVM') (Join-Path $buildPaths.SrcRoot 'Interop\Llvm.NET.Interop')
     if($LASTEXITCODE -eq 0)
     {
         # now build the projects that consume generated output for the bindings

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -83,10 +83,7 @@ try
     .\Build-Interop.ps1 -BuildInfo $BuildInfo
 
     Write-Information "Restoring NuGet Packages for Llvm.NET"
-    Invoke-MSBuild -Targets Restore -Project src\Llvm.NET.sln -Properties $msBuildProperties -LoggerArgs $msbuildLoggerArgs ($msbuildLoggerArgs + @("/bl:Llvm.NET-restore.binlog") )
-
-    Write-Information "Building Llvm.NET"
-    Invoke-MSBuild -Targets Build -Project src\Llvm.NET.sln -Properties $msBuildProperties -LoggerArgs $msbuildLoggerArgs ($msbuildLoggerArgs + @("/bl:Llvm.NET-build.binlog") )
+    Invoke-MSBuild -Targets 'Restore;Build' -Project src\Llvm.NET.sln -Properties $msBuildProperties -LoggerArgs $msbuildLoggerArgs ($msbuildLoggerArgs + @("/bl:Llvm.NET-restore.binlog") )
 
     if(!$SkipDocs)
     {

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/AnalysisBindings.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/AnalysisBindings.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/AttributeBindings.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/AttributeBindings.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/ContextBindings.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/ContextBindings.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/DIBuilderBindings.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/DIBuilderBindings.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/IRBindings.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/IRBindings.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/MetadataBindings.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/MetadataBindings.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/ModuleBindings.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/ModuleBindings.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/PassManagerBindings.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/PassManagerBindings.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/TripleBindings.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/TripleBindings.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/ValueBindings.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/ValueBindings.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Analysis.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Analysis.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/BitReader.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/BitReader.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/BitWriter.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/BitWriter.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Comdat.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Comdat.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Core.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Core.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/DataTypes.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/DataTypes.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/DebugInfo.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/DebugInfo.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Disassembler.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Disassembler.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/DisassemblerTypes.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/DisassemblerTypes.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Error.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Error.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/ErrorHandling.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/ErrorHandling.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/ExecutionEngine.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/ExecutionEngine.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/IRReader.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/IRReader.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Initialization.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Initialization.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Linker.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Linker.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Object.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Object.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/OrcBindings.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/OrcBindings.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Support.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Support.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Target.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Target.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/TargetMachine.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/TargetMachine.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/AggressiveInstCombine.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/AggressiveInstCombine.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/Coroutines.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/Coroutines.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/IPO.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/IPO.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/InstCombine.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/InstCombine.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/PassManagerBuilder.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/PassManagerBuilder.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/Scalar.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/Scalar.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/Utils.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/Utils.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/Vectorize.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Transforms/Vectorize.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Types.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/Types.xml
@@ -4,7 +4,7 @@
 ;;     This file contains the Manually edited doc comments info that the
 ;;     generated code files refer to. This was originally cloned from the
 ;;     'GeneratedDocsFolder' and requires manual update and merging whenever
-;;     the API surface changes. The generated XML is not commited to the repository
+;;     the API surface changes. The generated XML is not committed to the repository
 ;;     but serves as a useful aid in building the docs for generated code files.
 ;; </usage>
 ;; ==============================================================================

--- a/src/Interop/Llvm.NET.Interop/DisposableObject.cs
+++ b/src/Interop/Llvm.NET.Interop/DisposableObject.cs
@@ -43,6 +43,8 @@ namespace Llvm.NET.Interop
         /// </remarks>
         protected abstract void Dispose( bool disposing );
 
+        // do not write directly to this field, it should only be done with interlocked calls in Dispose() to ensure correct behavior
+        [SuppressMessage( "StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Indicates the field should never be directly written to" )]
         private int IsDisposed_;
     }
 }

--- a/src/Interop/Llvm.NET.Interop/Llvm.NET.Interop.csproj
+++ b/src/Interop/Llvm.NET.Interop/Llvm.NET.Interop.csproj
@@ -11,7 +11,10 @@
     <MinClientVersion>4.0</MinClientVersion>
     <Authors>.NET Foundation,LLVM.org,Ubiquity.NET</Authors>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Description>.NET Low Level Interop Bindings for Ubiquity.LibLLVM</Description>
+    <Description>
+    .NET Low Level Interop Bindings for Ubiquity.LibLLVM. Direct use of this low level API is discouraged, instead you should
+    use the Llvm.NET package, which provides a full C# object model projection of the LLVM APIs on top of this library.
+    </Description>
     <PackageTags>LLVM,Compiler,JIT,Ubiquity.NET</PackageTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <RepositoryType>git</RepositoryType>

--- a/src/Interop/LlvmBindingsGenerator/Configuration/LlvmBindingsGenerator-Configuration.md
+++ b/src/Interop/LlvmBindingsGenerator/Configuration/LlvmBindingsGenerator-Configuration.md
@@ -1,1 +1,0 @@
-﻿# Markdown file

--- a/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/Driver.cs
+++ b/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/Driver.cs
@@ -50,8 +50,6 @@ namespace LlvmBindingsGenerator
 
         public BindingContext Context { get; private set; }
 
-        public bool HasCompilationErrors { get; set; }
-
         public ITypePrinter TypePrinter
         {
             get => InternalTypePrinter;

--- a/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/TargetedAttribute.cs
+++ b/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/TargetedAttribute.cs
@@ -48,13 +48,6 @@ namespace LlvmBindingsGenerator.CppSharpExtensions
             Value = string.Join( ", ", args );
         }
 
-        public TargetedAttribute( AttributeTarget target, CppSharp.AST.Attribute other )
-        {
-            Type = other.Type;
-            Value = other.Value;
-            Target = target;
-        }
-
         public void AddParameter( string param )
         {
             Value = $"{Value}, {param}";

--- a/src/Interop/LlvmBindingsGenerator/IntPtrTypeMap.cs
+++ b/src/Interop/LlvmBindingsGenerator/IntPtrTypeMap.cs
@@ -11,6 +11,10 @@ using CppSharp.Types;
 
 namespace LlvmBindingsGenerator
 {
+    // DO NOT apply the TypeMap attribute here as that triggers auto inclusion in the
+    // TypeMapDataBase and these must be constructed at run time to provide the correct name
+
+    /// <summary>Custom type map entry for pointer typedefs to System.IntPtr</summary>
     internal class IntPtrTypeMap
         : TypeMap
     {

--- a/src/Interop/LlvmBindingsGenerator/LibLLVMTypePrinter.cs
+++ b/src/Interop/LlvmBindingsGenerator/LibLLVMTypePrinter.cs
@@ -11,6 +11,21 @@ using Ubiquity.ArgValidators;
 
 namespace LlvmBindingsGenerator
 {
+    /// <summary>Specialized type printer for Llvm.NET.Interop</summary>
+    /// <remarks>
+    /// <para>Unfortunately <see cref="CppSharp.AST.Type.ToString"/> will fail with a null
+    /// reference if there isn't a type printer delegate assigned. E.g. it has no
+    /// internal ability to convert the type to a string. Instead, it assumes that the
+    /// original source type is irrelevant and that the application is going to generate
+    /// code. Furthermore it assumes that the code generation will use ToString() to
+    /// get the final output generated code type name. Generally speaking that's a bad
+    /// design. It means that display of the type in a debugger doesn't work and you can't
+    /// see what you are dealing with easily. With the very surprising consequence of calls
+    /// to the ToString() method in code generating a null reference exception if the
+    /// delegate isn't set up.</para>
+    /// <para>This type serves as an extension to the default <see cref="CSharpTypePrinter"/>
+    /// that handles the specific needs of the Llvm.NET.Interop code generation.</para>
+    /// </remarks>
     internal class LibLLVMTypePrinter
         : CSharpTypePrinter
     {

--- a/src/Interop/LlvmBindingsGenerator/MarshalingInfo/IMarshalInfo.cs
+++ b/src/Interop/LlvmBindingsGenerator/MarshalingInfo/IMarshalInfo.cs
@@ -8,18 +8,32 @@ using System.Collections.Generic;
 
 namespace LlvmBindingsGenerator
 {
+    /// <summary>Interface for marshaling information for function parameters and return</summary>
     internal interface IMarshalInfo
     {
+        /// <summary>Gets the name of the function this info applies to</summary>
         string FunctionName { get; }
 
+        /// <summary>Gets the parameter name this info applies to</summary>
         string ParameterName { get; }
 
+        /// <summary>Gets or sets the parameter index this info applies to</summary>
+        /// <remarks>
+        /// This is ordinarily <see cref="MarshalingInfoMap.UnresolvedParamIndex"/> at
+        /// time of construction. Later, during the AddMarshalingAttributesPass the
+        /// index is resolved from the function signature.
+        /// </remarks>
         uint ParameterIndex { get; set; }
 
+        /// <summary>Gets the semantics for the parameter</summary>
         ParamSemantics Semantics { get; }
 
+        /// <summary>Gets a collection of the attributes required for marshaling the parameter or return</summary>
         IEnumerable<CppSharp.AST.Attribute> Attributes { get; }
 
+        /// <summary>Transforms the declared type of a parameter or return into the required interop type</summary>
+        /// <param name="type">QUalified type of the parameter or function return</param>
+        /// <returns>Transformed type for subsequent passes and code generation to use</returns>
         CppSharp.AST.QualifiedType TransformType( CppSharp.AST.QualifiedType type );
     }
 }

--- a/src/Interop/LlvmBindingsGenerator/MarshalingInfo/PrimitiveTypeMarshalInfo.cs
+++ b/src/Interop/LlvmBindingsGenerator/MarshalingInfo/PrimitiveTypeMarshalInfo.cs
@@ -5,13 +5,11 @@
 // -----------------------------------------------------------------------
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using CppSharp.AST;
 
 namespace LlvmBindingsGenerator
 {
-    [SuppressMessage( "Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Can be used in configuration" )]
     internal class PrimitiveTypeMarshalInfo
         : MarshalInfoBase
     {

--- a/src/Interop/LlvmBindingsGenerator/Passes/AddMissingParameterNamesPass.cs
+++ b/src/Interop/LlvmBindingsGenerator/Passes/AddMissingParameterNamesPass.cs
@@ -50,10 +50,5 @@ namespace LlvmBindingsGenerator.Passes
 
             return false;
         }
-
-        public override bool VisitFunctionType( FunctionType function, TypeQualifiers quals )
-        {
-            return base.VisitFunctionType( function, quals );
-        }
     }
 }

--- a/src/Interop/LlvmBindingsGenerator/Passes/FixInconsistentLLVMHandleDeclarations.cs
+++ b/src/Interop/LlvmBindingsGenerator/Passes/FixInconsistentLLVMHandleDeclarations.cs
@@ -13,7 +13,7 @@ namespace LlvmBindingsGenerator.Passes
     /// <summary>Fix inconsistencies in type defs for handles in LLVM</summary>
     /// <remarks>
     /// <para>
-    /// The cannonical pattern is 'typedef struct LLVMOpaqueGoodFoo* LLVMGoodFooRef',
+    /// The canonical pattern is 'typedef struct LLVMOpaqueGoodFoo* LLVMGoodFooRef',
     /// which is used directly as a parameter like: 'void LLVMGoodFooDoSomething(LLVMGoodFooRef foo)'.
     /// Unfortunately not all of the opaque typedefs, follow this pattern. Instead, they
     /// do the declare the typedef without the pointer 'typedef struct LLVMOpaqueBadFoo LLVMBadFoo'.
@@ -23,7 +23,7 @@ namespace LlvmBindingsGenerator.Passes
     /// proper managed type (Like a smart pointer or RAII pattern). Since a handle is not as easily
     /// detected and these variances need special handling. Rather than spreading such handling
     /// throughout the transform passes, this handles it all in one place to transform the AST into
-    /// the cannonical form.
+    /// the canonical form.
     /// </para>
     /// </remarks>
     internal class FixInconsistentLLVMHandleDeclarations

--- a/src/Interop/LlvmBindingsGenerator/Program.cs
+++ b/src/Interop/LlvmBindingsGenerator/Program.cs
@@ -182,6 +182,7 @@ namespace LlvmBindingsGenerator
                     new StringMarshalInfo("LLVMGetDefaultTargetTriple", StringDisposal.DisposeMessage),
                     new StringMarshalInfo("LLVMGetHostCPUName", StringDisposal.DisposeMessage),
                     new StringMarshalInfo("LLVMGetHostCPUFeatures", StringDisposal.DisposeMessage),
+                    new PrimitiveTypeMarshalInfo("LLVMHasMetadata", CppSharp.AST.PrimitiveType.Bool),
                 },
                 /* Functions that are deprecated in LLVM and should be marked obsolte in generation (or by default ommitted completely)*/
                 DeprecatedFunctionToMessageMap = new Dictionary<string, string>

--- a/src/Interop/LlvmBindingsGenerator/Templates/HandleTemplateMap.cs
+++ b/src/Interop/LlvmBindingsGenerator/Templates/HandleTemplateMap.cs
@@ -25,8 +25,6 @@ namespace LlvmBindingsGenerator.Templates
             return true;
         }
 
-        public IEnumerable<string> HandleTypeNames => from item in this select item.HandleName;
-
         public IEnumerable<string> DisposeFunctionNames
             => from item in this
                let ght = item as GlobalHandleTemplate

--- a/src/Interop/LlvmBindingsGenerator/Templates/StringMarshalerTemplate.cs
+++ b/src/Interop/LlvmBindingsGenerator/Templates/StringMarshalerTemplate.cs
@@ -11,11 +11,6 @@ namespace LlvmBindingsGenerator.Templates
     internal partial class StringMarshalerTemplate
         : ICodeGenTemplate
     {
-        public StringMarshalerTemplate( string name )
-            : this( name, string.Empty)
-        {
-        }
-
         public StringMarshalerTemplate( string name, string disposeFunctionName)
         {
             Name = name;

--- a/src/Interop/LlvmBindingsGenerator/Templates/T4/ExternalDocXmlTemplate.cs
+++ b/src/Interop/LlvmBindingsGenerator/Templates/T4/ExternalDocXmlTemplate.cs
@@ -44,7 +44,7 @@ namespace LlvmBindingsGenerator.Templates
 ;; </auto-generated>
 ;; <usage>
 ;;     This file contains the bare bones skeleton doc comments info that the
-;;     generated code files refer to. If the orginal source contained comments,
+;;     generated code files refer to. If the original source contained comments,
 ;;     those comments are generated here as the ""remarks"" element to aid in
 ;;     completing the docs. This always generated file is created with a .g.xml
 ;;     extension, however the generated C# code includes the form with the "".g""

--- a/src/Interop/LlvmBindingsGenerator/Templates/T4/ExternalDocXmlTemplate.tt
+++ b/src/Interop/LlvmBindingsGenerator/Templates/T4/ExternalDocXmlTemplate.tt
@@ -14,7 +14,7 @@
 ;; </auto-generated>
 ;; <usage>
 ;;     This file contains the bare bones skeleton doc comments info that the
-;;     generated code files refer to. If the orginal source contained comments,
+;;     generated code files refer to. If the original source contained comments,
 ;;     those comments are generated here as the "remarks" element to aid in
 ;;     completing the docs. This always generated file is created with a .g.xml
 ;;     extension, however the generated C# code includes the form with the ".g"

--- a/src/Interop/LlvmBindingsGenerator/Templates/T4/GlobalHandleTemplate.cs
+++ b/src/Interop/LlvmBindingsGenerator/Templates/T4/GlobalHandleTemplate.cs
@@ -148,7 +148,7 @@ if(NeedsAlias){
     /// <summary>Alias handle for an LLVM object</summary>
     ///<remarks>
     /// Sometimes a global object is exposed via a child that maintains a reference to the parent.
-    /// In such cases, the handle isn't owned by the App (it's an alias) and therfore should not be
+    /// In such cases, the handle isn't owned by the App (it's an alias) and therefore should not be
     /// disposed or destroyed. This handle type takes care of that in a type safe manner and does not
     /// perform any automatic cleanup.
     ///</remarks>

--- a/src/Interop/LlvmBindingsGenerator/Templates/T4/GlobalHandleTemplate.tt
+++ b/src/Interop/LlvmBindingsGenerator/Templates/T4/GlobalHandleTemplate.tt
@@ -67,7 +67,7 @@ namespace Llvm.NET.Interop
     /// <summary>Alias handle for an LLVM object</summary>
     ///<remarks>
     /// Sometimes a global object is exposed via a child that maintains a reference to the parent.
-    /// In such cases, the handle isn't owned by the App (it's an alias) and therfore should not be
+    /// In such cases, the handle isn't owned by the App (it's an alias) and therefore should not be
     /// disposed or destroyed. This handle type takes care of that in a type safe manner and does not
     /// perform any automatic cleanup.
     ///</remarks>

--- a/src/Interop/LlvmBindingsGenerator/Templates/TemplateCodeGenerator.cs
+++ b/src/Interop/LlvmBindingsGenerator/Templates/TemplateCodeGenerator.cs
@@ -5,21 +5,12 @@
 // -----------------------------------------------------------------------
 
 using System.Collections.Generic;
-using CppSharp.AST;
 
 namespace LlvmBindingsGenerator.Templates
 {
     internal class TemplateCodeGenerator
         : ICodeGenerator
     {
-        public TemplateCodeGenerator( TranslationUnit unit, IEnumerable<ICodeGenTemplate> templates )
-            : this( unit.IsValid,
-                    unit.FileNameWithoutExtension,
-                    unit.IncludePath == null ? string.Empty : unit.FileRelativeDirectory,
-                    templates )
-        {
-        }
-
         public TemplateCodeGenerator(
             bool isValid,
             string fileNameWithoutExtension,


### PR DESCRIPTION
- Fixed typos in API docs XML files
- Fixed some analyzer warnings
- added verbiage to interop NuGet package description to indicate direct use is discouraged
- removed empty mark-down file
 - removed redundant/unused code
- fixed comment typos in generator templates
- Fixed return type of LLVMHasMetadata function
- Simplified build scripts by combining multiple targets for a single build command. This should also shave a bit of time off the build since msbuild is invoked only once