### PR TITLE
General support for accessing metadata on globals and instructions.

### DIFF
--- a/src/Interop/LibLLVM/EXPORTS.g.DEF
+++ b/src/Interop/LibLLVM/EXPORTS.g.DEF
@@ -93,8 +93,6 @@ LibLLVMRemoveGlobalFromParent
 LibLLVMGetValueKind
 LibLLVMGetAliasee
 LibLLVMGetArgumentIndex
-LibLLVMGlobalObjectGetComdat
-LibLLVMGlobalObjectSetComdat
 LibLLVMGlobalVariableAddDebugExpression
 LibLLVMFunctionAppendBasicBlock
 LibLLVMValueAsMetadataGetValue

--- a/src/Interop/LibLLVM/ValueBindings.cpp
+++ b/src/Interop/LibLLVM/ValueBindings.cpp
@@ -17,18 +17,6 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS( ValueCache, LibLLVMValueCacheRef );
 
 extern "C"
 {
-    LLVMComdatRef LibLLVMGlobalObjectGetComdat( LLVMValueRef Val )
-    {
-        auto pGlobalObj = dyn_cast< GlobalObject >( unwrap( Val ) );
-        return wrap( pGlobalObj->getComdat( ) );
-    }
-
-    void LibLLVMGlobalObjectSetComdat( LLVMValueRef Val, LLVMComdatRef comdatRef )
-    {
-        auto pGlobalObj = dyn_cast< GlobalObject >( unwrap( Val ) );
-        pGlobalObj->setComdat( unwrap( comdatRef ) );
-    }
-
     uint32_t LibLLVMGetArgumentIndex( LLVMValueRef valueRef )
     {
         auto pArgument = unwrap<Argument>( valueRef );

--- a/src/Interop/LibLLVM/include/libllvm-c/MetadataBindings.h
+++ b/src/Interop/LibLLVM/include/libllvm-c/MetadataBindings.h
@@ -9,13 +9,20 @@
 extern "C" {
 #endif
 
-    enum LibLLVMDwarfTag
+    typedef enum LibLLVMDwarfTag
     {
 #define HANDLE_DW_TAG(ID, NAME, VERSION, VENDOR)                 \
   LibLLVMDwarfTag##NAME = ID,
 #include "llvm/BinaryFormat/Dwarf.def"
 #undef HANDLE_DW_TAG
-    };
+    } LibLLVMDwarfTag;
+
+    typedef enum LibLLVMMetadataKind
+    {
+#define HANDLE_METADATA_LEAF(CLASS) LibLLVMMetadataKind_##CLASS,
+#include "llvm/IR/Metadata.def"
+#undef HANDLE_METADATA_LEAF
+    } LibLLVMMetadataKind;
 
     typedef struct LLVMOpaqueMDOperand* LibLLVMMDOperandRef;
 

--- a/src/Interop/LibLLVM/include/libllvm-c/ValueBindings.h
+++ b/src/Interop/LibLLVM/include/libllvm-c/ValueBindings.h
@@ -8,6 +8,11 @@
 extern "C" {
 #endif
 
+    // ordering matters, all distinct values are generated first, then any derived values (e.g. foo = bar + 1), to ensure the
+    // values match expectations of underlying C++ code and don't alter the sequencing as C++ numbers enum values without an
+    // initializer as automatic +1 of the previous value, thus sticking the derived values in at arbitrary locations in the
+    // declaration order would reset the values.
+
     typedef enum LibLLVMValueKind
     {
 #define HANDLE_VALUE(Name) Name##Kind,
@@ -35,9 +40,6 @@ extern "C" {
     LibLLVMValueKind LibLLVMGetValueKind( LLVMValueRef valueRef);
     LLVMValueRef LibLLVMGetAliasee( LLVMValueRef Val );
     uint32_t LibLLVMGetArgumentIndex( LLVMValueRef Val);
-
-    LLVMComdatRef LibLLVMGlobalObjectGetComdat( LLVMValueRef Val );
-    void LibLLVMGlobalObjectSetComdat( LLVMValueRef Val, LLVMComdatRef comdatRef );
 
     void LibLLVMGlobalVariableAddDebugExpression( LLVMValueRef /*GlobalVariable*/ globalVar, LLVMMetadataRef exp );
     void LibLLVMFunctionAppendBasicBlock( LLVMValueRef /*Function*/ function, LLVMBasicBlockRef block );

--- a/src/Llvm.NET/Metadata/LlvmMetadata.cs
+++ b/src/Llvm.NET/Metadata/LlvmMetadata.cs
@@ -10,16 +10,105 @@ using Llvm.NET.DebugInfo;
 using Llvm.NET.Interop;
 using Llvm.NET.Properties;
 
-// SA1515  Single-line comment should be preceded by blank line
-#pragma warning disable SA1515
-
-// SA1025  Code should not contain multiple whitespace characters in a row.
-#pragma warning disable SA1025
-
 using static Llvm.NET.Interop.NativeMethods;
 
 namespace Llvm.NET
 {
+    /// <summary>Enumeration to define metadata type kind</summary>
+    [SuppressMessage( "Design", "CA1027:Mark enums with FlagsAttribute", Justification = "It's not a flags enum, get over it...")]
+    public enum MetadataKind
+    {
+        /// <summary>Metadata string</summary>
+        MDString = LibLLVMMetadataKind.LibLLVMMetadataKind_MDString,
+
+        /// <summary>Constant Value as metadata</summary>
+        ConstantAsMetadata = LibLLVMMetadataKind.LibLLVMMetadataKind_ConstantAsMetadata,
+
+        /// <summary>Local value as metadata</summary>
+        LocalAsMetadata = LibLLVMMetadataKind.LibLLVMMetadataKind_LocalAsMetadata,
+
+        /// <summary>Distinct metadata place holder</summary>
+        DistinctMDOperandPlaceholder = LibLLVMMetadataKind.LibLLVMMetadataKind_DistinctMDOperandPlaceholder,
+
+        /// <summary>Metadata tuple</summary>
+        MDTuple = LibLLVMMetadataKind.LibLLVMMetadataKind_MDTuple,
+
+        /// <summary>Debug info location</summary>
+        DILocation = LibLLVMMetadataKind.LibLLVMMetadataKind_DILocation,
+
+        /// <summary>Debug info expression</summary>
+        DIExpression = LibLLVMMetadataKind.LibLLVMMetadataKind_DIExpression,
+
+        /// <summary>Debug info global variable expression</summary>
+        DIGlobalVariableExpression = LibLLVMMetadataKind.LibLLVMMetadataKind_DIGlobalVariableExpression,
+
+        /// <summary>Generic Debug info node</summary>
+        GenericDINode = LibLLVMMetadataKind.LibLLVMMetadataKind_GenericDINode,
+
+        /// <summary>Debug info sub range</summary>
+        DISubrange = LibLLVMMetadataKind.LibLLVMMetadataKind_DISubrange,
+
+        /// <summary>Debug info enumerator</summary>
+        DIEnumerator = LibLLVMMetadataKind.LibLLVMMetadataKind_DIEnumerator,
+
+        /// <summary>Debug info basic type</summary>
+        DIBasicType = LibLLVMMetadataKind.LibLLVMMetadataKind_DIBasicType,
+
+        /// <summary>Debug info derived type</summary>
+        DIDerivedType = LibLLVMMetadataKind.LibLLVMMetadataKind_DIDerivedType,
+
+        /// <summary>Debug info composite type</summary>
+        DICompositeType = LibLLVMMetadataKind.LibLLVMMetadataKind_DICompositeType,
+
+        /// <summary>Debug info subroutine type</summary>
+        DISubroutineType = LibLLVMMetadataKind.LibLLVMMetadataKind_DISubroutineType,
+
+        /// <summary>Debug info file reference</summary>
+        DIFile = LibLLVMMetadataKind.LibLLVMMetadataKind_DIFile,
+
+        /// <summary>Debug info Compilation Unit</summary>
+        DICompileUnit = LibLLVMMetadataKind.LibLLVMMetadataKind_DICompileUnit,
+
+        /// <summary>Debug info sub program</summary>
+        DISubprogram = LibLLVMMetadataKind.LibLLVMMetadataKind_DISubprogram,
+
+        /// <summary>Debug info lexical block</summary>
+        DILexicalBlock = LibLLVMMetadataKind.LibLLVMMetadataKind_DILexicalBlock,
+
+        /// <summary>Debug info lexical block file</summary>
+        DILexicalBlockFile = LibLLVMMetadataKind.LibLLVMMetadataKind_DILexicalBlockFile,
+
+        /// <summary>Debug info namespace</summary>
+        DINamespace = LibLLVMMetadataKind.LibLLVMMetadataKind_DINamespace,
+
+        /// <summary>Debug info fro a module</summary>
+        DIModule = LibLLVMMetadataKind.LibLLVMMetadataKind_DIModule,
+
+        /// <summary>Debug info for a template type parameter</summary>
+        DITemplateTypeParameter = LibLLVMMetadataKind.LibLLVMMetadataKind_DITemplateTypeParameter,
+
+        /// <summary>Debug info for a template value parameter</summary>
+        DITemplateValueParameter = LibLLVMMetadataKind.LibLLVMMetadataKind_DITemplateValueParameter,
+
+        /// <summary>Debug info for a global variable</summary>
+        DIGlobalVariable = LibLLVMMetadataKind.LibLLVMMetadataKind_DIGlobalVariable,
+
+        /// <summary>Debug info for a local variable</summary>
+        DILocalVariable = LibLLVMMetadataKind.LibLLVMMetadataKind_DILocalVariable,
+
+        /// <summary>Debug info for an Objective C style property</summary>
+        DIObjCProperty = LibLLVMMetadataKind.LibLLVMMetadataKind_DIObjCProperty,
+
+        /// <summary>Debug info for an imported entity</summary>
+        DIImportedEntity = LibLLVMMetadataKind.LibLLVMMetadataKind_DIImportedEntity,
+
+        /// <summary>Debug info for a macro</summary>
+        DIMacro = LibLLVMMetadataKind.LibLLVMMetadataKind_DIMacro,
+
+        /// <summary>Debug info for a macro file</summary>
+        DIMacroFile = LibLLVMMetadataKind.LibLLVMMetadataKind_DIMacroFile,
+    }
+
     /// <summary>Root of the LLVM Metadata hierarchy</summary>
     /// <remarks>In LLVM this is just "Metadata" however that name has the potential
     /// to conflict with the .NET runtime namespace of the same name, so the name
@@ -49,6 +138,9 @@ namespace Llvm.NET
         {
             return MetadataHandle == default ? string.Empty : LibLLVMMetadataAsString( MetadataHandle );
         }
+
+        /// <summary>Gets a value indicating this metadata's kind</summary>
+        public MetadataKind Kind => ( MetadataKind )LibLLVMGetMetadataID( MetadataHandle );
 
         internal LLVMMetadataRef MetadataHandle { get; /*protected*/ set; }
 
@@ -169,51 +261,6 @@ namespace Llvm.NET
                     throw new NotImplementedException( );
 #pragma warning restore RECS0083
                 }
-            }
-
-            /// <summary>Enumeration to define debug information metadata nodes</summary>
-            private enum MetadataKind : uint
-            {
-                MDString,                     // HANDLE_METADATA_LEAF(MDString)
-                                              // ValueAsMetadata,            // HANDLE_METADATA_BRANCH(ValueAsMetadata)
-                ConstantAsMetadata,           // HANDLE_METADATA_LEAF(ConstantAsMetadata)
-                LocalAsMetadata,              // HANDLE_METADATA_LEAF(LocalAsMetadata)
-                DistinctMDOperandPlaceholder, // HANDLE_METADATA_LEAF(DistinctMDOperandPlaceholder)
-                                              // MDNode,                     // HANDLE_MDNODE_BRANCH(MDNode)
-                MDTuple,                      // HANDLE_MDNODE_LEAF_UNIQUABLE(MDTuple)
-                DILocation,                   // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILocation)
-                DIExpression,                 // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIExpression)
-                DIGlobalVariableExpression,   // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIGlobalVariableExpression)
-                                              // DINode,                     // HANDLE_SPECIALIZED_MDNODE_BRANCH(DINode)
-                GenericDINode,                // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(GenericDINode)
-                DISubrange,                   // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DISubrange)
-                DIEnumerator,                 // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIEnumerator)
-                                              // DIScope,                    // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIScope)
-                                              // DIType,                     // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIType)
-                DIBasicType,                  // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIBasicType)
-                DIDerivedType,                // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIDerivedType)
-                DICompositeType,              // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DICompositeType)
-                DISubroutineType,             // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DISubroutineType)
-                DIFile,                       // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIFile)
-                DICompileUnit,                // HANDLE_SPECIALIZED_MDNODE_LEAF(DICompileUnit)
-                                              // DILocalScope,               // HANDLE_SPECIALIZED_MDNODE_BRANCH(DILocalScope)
-                DISubprogram,                 // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DISubprogram)
-                                              // DILexicalBlockBase,         // HANDLE_SPECIALIZED_MDNODE_BRANCH(DILexicalBlockBase)
-                DILexicalBlock,               // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILexicalBlock)
-                DILexicalBlockFile,           // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILexicalBlockFile)
-                DINamespace,                  // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DINamespace)
-                DIModule,                     // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIModule)
-                                              // DITemplateParameter,        // HANDLE_SPECIALIZED_MDNODE_BRANCH(DITemplateParameter)
-                DITemplateTypeParameter,      // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DITemplateTypeParameter)
-                DITemplateValueParameter,     // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DITemplateValueParameter)
-                                              // DIVariable,                 // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIVariable)
-                DIGlobalVariable,             // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIGlobalVariable)
-                DILocalVariable,              // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILocalVariable)
-                DIObjCProperty,               // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIObjCProperty)
-                DIImportedEntity,             // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIImportedEntity)
-                                              // DIMacroNode,                // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIMacroNode)
-                DIMacro,                      // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIMacro)
-                DIMacroFile                   // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIMacroFile)
             }
         }
 


### PR DESCRIPTION
- made MetadataKind enum public so it can be used as a key to add/remove metadata.
- Added interop LibLLVMMetadataKind enumeration to auto generate the backing enum for the object model MetadataKind. This ensures that any new entires inserted into the middle, don't silently invalidate a hand built object model enum. (Should be eliminating all of those in favor of this pattern)
removed some unused LibLLV Comdat functions