### PR TITLE
Minor updates

### DIFF
--- a/src/Interop/InteropTests/InteropTests.csproj
+++ b/src/Interop/InteropTests/InteropTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Microsoft.Build.CentralPackageVersions"/>
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" />
   <PropertyGroup>
-      <TargetFramework>net47</TargetFramework>
+      <TargetFrameworks>netcoreapp2.0;net47</TargetFrameworks>
       <IsPackable>false</IsPackable>
       <LangVersion>7.2</LangVersion>
   </PropertyGroup>
@@ -9,6 +9,8 @@
       <PackageReference Include="Microsoft.NET.Test.Sdk" />
       <PackageReference Include="MSTest.TestFramework" />
       <PackageReference Include="MSTest.TestAdapter" />
-      <PackageReference Include="Llvm.NET.Interop" VersionOverride="[8.0.0-*,9)" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Llvm.NET.Interop\Llvm.NET.Interop.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/MetadataBindings.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/MetadataBindings.xml
@@ -10,6 +10,69 @@
 ;; ==============================================================================
 -->
 <LibLlvmAPI>
+    <Enumeration name="LibLLVMDwarfAttributeEncoding">
+        <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding Enumeration</summary>
+        <Item name="DW_ATE_address">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_address Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_boolean">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_boolean Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_complex_float">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_complex_float Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_float">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_float Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_signed">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_signed Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_signed_char">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_signed_char Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_unsigned">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_unsigned Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_unsigned_char">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_unsigned_char Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_imaginary_float">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_imaginary_float Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_packed_decimal">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_packed_decimal Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_numeric_string">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_numeric_string Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_edited">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_edited Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_signed_fixed">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_signed_fixed Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_unsigned_fixed">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_unsigned_fixed Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_decimal_float">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_decimal_float Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_UTF">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_UTF Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_UCS">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_UCS Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_ASCII">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_ASCII Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_lo_user">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_lo_user Enumeration</summary>
+        </Item>
+        <Item name="DW_ATE_hi_user">
+            <summary>TODO: Provide summary for LibLLVMDwarfAttributeEncoding.DW_ATE_hi_user Enumeration</summary>
+        </Item>
+    </Enumeration>
     <Enumeration name="LibLLVMDwarfTag">
         <summary>Enumeration for DWARF debug information tags</summary>
         <remarks>For full details of the tags and their meanings see the <see href="http://dwarfstd.org/">DWARF</see> specifications</remarks>

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/OrcBindings.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/llvm-c/OrcBindings.xml
@@ -38,10 +38,6 @@
         <param name="MangledSymbol">TODO: Provide details of parameter MangledSymbol</param>
         <param name="Symbol">TODO: Provide details of parameter Symbol</param>
     </Function>
-    <Function name="LLVMOrcDisposeMangledSymbol">
-        <summary>TODO: Provide summary for Function LLVMOrcDisposeMangledSymbol</summary>
-        <param name="MangledSymbol">TODO: Provide details of parameter MangledSymbol</param>
-    </Function>
     <Function name="LLVMOrcCreateLazyCompileCallback">
         <summary>TODO: Provide summary for Function LLVMOrcCreateLazyCompileCallback</summary>
         <param name="JITStack">TODO: Provide details of parameter JITStack</param>

--- a/src/Interop/Llvm.NET.Interop/Llvm.NET.Interop.csproj
+++ b/src/Interop/Llvm.NET.Interop/Llvm.NET.Interop.csproj
@@ -50,6 +50,14 @@
   <ItemGroup>
       <PackageReference Include="Ubiquity.ArgValidators" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Update="..\..\..\BuildOutput\bin\LibLLVM\Debug\x64\LibLLVM.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Update="..\..\..\BuildOutput\bin\LibLLVM\Debug\x64\LibLLVM.pdb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <!--
     Version numbers are computed at build time after any declarative properties are evaluated
     so this is needed to update the NuSpec properties with the dynamically generated values

--- a/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/Driver.cs
+++ b/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/Driver.cs
@@ -207,7 +207,7 @@ namespace LlvmBindingsGenerator
                         string fullFilePathfile = Path.Combine( templateOutputPath, fileName );
                         File.WriteAllText( fullFilePathfile, template.Generate( ) );
 
-                        Diagnostics.Message( "Generated '{0}'", fileName );
+                        Diagnostics.Debug( "Generated '{0}'", fileName );
                     }
                     catch( System.IO.IOException ex )
                     {

--- a/src/Interop/LlvmBindingsGenerator/Program.cs
+++ b/src/Interop/LlvmBindingsGenerator/Program.cs
@@ -228,11 +228,12 @@ namespace LlvmBindingsGenerator
                 InternalFunctions =
                 {
                     /* Disposal methods used and generated in Handle wrappers directly*/
-                    { "LLVMDisposeMessage", false },
-                    { "LLVMDisposeErrorMessage", false },
-                    { "LLVMConsumeError", false },
+                    { "LLVMDisposeMessage", true },
+                    { "LLVMDisposeErrorMessage", true },
+                    { "LLVMConsumeError", true },
                     { "LLVMGetErrorMessage", true },
                     { "LLVMCreateMessage", true }, // Not relevant to managed projections
+                    { "LLVMOrcDisposeMangledSymbol", true },
                     /* Declared but not present in LibLLVM */
                     { "LLVMConstGEP2", true },         // declared in LLVM headers but never defined [Go, Figure!]
                     { "LLVMConstInBoundsGEP2", true }, // declared in LLVM headers but never defined [Go, Figure!]


### PR DESCRIPTION
- minor updates to interoptests
- moved "GENERATED xyz.ext" messages to a debug level to cut down on noise from generator (and speed it up a bit)
- fixed generation to ignore and not generate dispose functions that are used in string marshaling and interop handles