### PR TITLE
Splitting out docs build to a distinct AppVeyopr Job

### DIFF
--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -62,7 +62,7 @@ try
         if($env:APPVEYOR)
         {
             Write-Information "Updating APPVEYOR version: $($BuildInfo.FullBuildNumber)"
-            Update-AppVeyorBuild -Version $BuildInfo.FullBuildNumber
+            Update-AppVeyorBuild -Version "$($BuildInfo.FullBuildNumber) [$([DateTime]::Now())]"
         }
 
         $packProperties = @{ version=$($BuildInfo.PackageVersion)

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -62,7 +62,7 @@ try
         if($env:APPVEYOR)
         {
             Write-Information "Updating APPVEYOR version: $($BuildInfo.FullBuildNumber)"
-            Update-AppVeyorBuild -Version "$($BuildInfo.FullBuildNumber) [$([DateTime]::Now())]"
+            Update-AppVeyorBuild -Version "$($BuildInfo.FullBuildNumber) [$([DateTime]::Now)]"
         }
 
         $packProperties = @{ version=$($BuildInfo.PackageVersion)

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -2,7 +2,8 @@ Param(
     [string]$Configuration="Release",
     [switch]$AllowVsPreReleases,
     [switch]$NoClean,
-    [switch]$SkipDocs
+    [ValidateSet('All','Source','Docs')]
+    [System.String]$BuildMode = 'All'
 )
 
 . .\buildutils.ps1
@@ -12,6 +13,15 @@ pushd $PSScriptRoot
 $oldPath = $env:Path
 $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
+$BuildSource = $false
+$BuildDocs = $false;
+switch($BuildMode)
+{
+'All' { $BuildSource = $true; $BuildDocs = $true; }
+'Source' { $BuildSource = $true }
+'Docs' { $BuildDocs = $true }
+}
+
 try
 {
     $msbuild = Find-MSBuild -AllowVsPrereleases:$AllowVsPreReleases
@@ -38,55 +48,58 @@ try
     Write-Information "Build Paths:"
     Write-Information ($buildPaths | Format-Table | Out-String)
 
-    if( (Test-Path -PathType Container $buildPaths.BuildOutputPath) -and !$NoClean )
+    if($BuildSource)
     {
-        Write-Information "Cleaning output folder from previous builds"
-        rd -Recurse -Force -Path $buildPaths.BuildOutputPath
+        if( (Test-Path -PathType Container $buildPaths.BuildOutputPath) -and !$NoClean )
+        {
+            Write-Information "Cleaning output folder from previous builds"
+            rd -Recurse -Force -Path $buildPaths.BuildOutputPath
+        }
+
+        md $buildPaths.NuGetOutputPath -ErrorAction SilentlyContinue| Out-Null
+
+        $BuildInfo = Get-BuildInformation $buildPaths
+        if($env:APPVEYOR)
+        {
+            Write-Information "Updating APPVEYOR version: $($BuildInfo.FullBuildNumber)"
+            Update-AppVeyorBuild -Version $BuildInfo.FullBuildNumber
+        }
+
+        $packProperties = @{ version=$($BuildInfo.PackageVersion)
+                             llvmversion=$($BuildInfo.LlvmVersion)
+                             buildbinoutput=(normalize-path (Join-path $($buildPaths.BuildOutputPath) 'bin'))
+                             configuration=$Configuration
+                           }
+
+        $msBuildProperties = @{ Configuration = $Configuration
+                                FullBuildNumber = $BuildInfo.FullBuildNumber
+                                PackageVersion = $BuildInfo.PackageVersion
+                                FileVersionMajor = $BuildInfo.FileVersionMajor
+                                FileVersionMinor = $BuildInfo.FileVersionMinor
+                                FileVersionBuild = $BuildInfo.FileVersionBuild
+                                FileVersionRevision = $BuildInfo.FileVersionRevision
+                                FileVersion = $BuildInfo.FileVersion
+                                LlvmVersion = $BuildInfo.LlvmVersion
+                              }
+
+        Write-Information "Build Parameters:"
+        Write-Information ($BuildInfo | Format-Table | Out-String)
+
+        # Download and unpack the LLVM libs if not already present, this doesn't use NuGet as the NuGet compression
+        # is insufficient to keep the size reasonable enough to support posting to public galleries. Additionally, the
+        # support for native lib projects in NuGet is tenuous at best. Due to various compiler version dependencies
+        # and incompatibilities libs are generally not something published in a package. However, since the build time
+        # for the libraries exceeds the time allowed for most hosted build services these must be pre-built for the
+        # automated builds.
+        Install-LlvmLibs $buildPaths.LlvmLibsRoot "8.0.0" "msvc" "15.9"
+
+        .\Build-Interop.ps1 -BuildInfo $BuildInfo
+
+        Write-Information "Restoring NuGet Packages for Llvm.NET"
+        Invoke-MSBuild -Targets 'Restore;Build' -Project src\Llvm.NET.sln -Properties $msBuildProperties -LoggerArgs ($msbuildLoggerArgs + @("/bl:Llvm.NET.binlog") )
     }
 
-    md $buildPaths.NuGetOutputPath -ErrorAction SilentlyContinue| Out-Null
-
-    $BuildInfo = Get-BuildInformation $buildPaths
-    if($env:APPVEYOR)
-    {
-        Write-Information "Updating APPVEYOR version: $($BuildInfo.FullBuildNumber)"
-        Update-AppVeyorBuild -Version $BuildInfo.FullBuildNumber
-    }
-
-    $packProperties = @{ version=$($BuildInfo.PackageVersion)
-                         llvmversion=$($BuildInfo.LlvmVersion)
-                         buildbinoutput=(normalize-path (Join-path $($buildPaths.BuildOutputPath) 'bin'))
-                         configuration=$Configuration
-                       }
-
-    $msBuildProperties = @{ Configuration = $Configuration
-                            FullBuildNumber = $BuildInfo.FullBuildNumber
-                            PackageVersion = $BuildInfo.PackageVersion
-                            FileVersionMajor = $BuildInfo.FileVersionMajor
-                            FileVersionMinor = $BuildInfo.FileVersionMinor
-                            FileVersionBuild = $BuildInfo.FileVersionBuild
-                            FileVersionRevision = $BuildInfo.FileVersionRevision
-                            FileVersion = $BuildInfo.FileVersion
-                            LlvmVersion = $BuildInfo.LlvmVersion
-                          }
-
-    Write-Information "Build Parameters:"
-    Write-Information ($BuildInfo | Format-Table | Out-String)
-
-    # Download and unpack the LLVM libs if not already present, this doesn't use NuGet as the NuGet compression
-    # is insufficient to keep the size reasonable enough to support posting to public galleries. Additionally, the
-    # support for native lib projects in NuGet is tenuous at best. Due to various compiler version dependencies
-    # and incompatibilities libs are generally not something published in a package. However, since the build time
-    # for the libraries exceeds the time allowed for most hosted build services these must be pre-built for the
-    # automated builds.
-    Install-LlvmLibs $buildPaths.LlvmLibsRoot "8.0.0" "msvc" "15.9"
-
-    .\Build-Interop.ps1 -BuildInfo $BuildInfo
-
-    Write-Information "Restoring NuGet Packages for Llvm.NET"
-    Invoke-MSBuild -Targets 'Restore;Build' -Project src\Llvm.NET.sln -Properties $msBuildProperties -LoggerArgs ($msbuildLoggerArgs + @("/bl:Llvm.NET.binlog") )
-
-    if(!$SkipDocs)
+    if($BuildDocs)
     {
         .\Build-Docs.ps1 -BuildInfo $BuildInfo
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,8 +38,7 @@ deploy_script:
   - ps: .\Push-Docs.ps1
 
 test_script:
-  - ps: .\Invoke-UnitTests.ps1
-  - ps: Set-Culture fr-FR; .\Invoke-UnitTests.ps1
+  - ps: if($env:BuildMode -eq 'Source') { .\Invoke-UnitTests.ps1; Set-Culture fr-FR; .\Invoke-UnitTests.ps1; }
 
 artifacts:
   - path: .\BuildOutput\Nuget\*.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,9 @@ environment:
   docspush_username: cibuild-telliam
   docspush_access_token:
     secure: QqWCIyFM6uBBbkW1jnlVGsMQWy+9aPY9rhD56oNT2L/0Cmw2bynROEsrUrOPpBrk
+  matrix:
+    - BuildMode: Source
+    - BuildMode: Docs
 
 skip_commits:
   files:
@@ -40,8 +43,3 @@ test_script:
 
 artifacts:
   - path: .\BuildOutput\Nuget\*.nupkg
-
-environment:
-  matrix:
-    - BuildMode: Source
-    - BuildMode: Docs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ nuget:
   project_feed: true
 
 build_script:
-  - ps: .\BuildAll.ps1
+  - ps: .\BuildAll.ps1 -BuildMode $env:BuildMode
 
 deploy_script:
   - ps: .\Push-Docs.ps1
@@ -40,4 +40,8 @@ test_script:
 
 artifacts:
   - path: .\BuildOutput\Nuget\*.nupkg
-  
+
+environment:
+  matrix:
+    - BuildMode: Source
+    - BuildMode: Docs


### PR DESCRIPTION
Building source and docs as a single job is is taking too long to complete and timing out the builds on AppVeyor. Unfortunately, the DocFx tooling is snail pace slow.