### PR TITLE
DocsUpdates

### DIFF
--- a/Samples/Kaleidoscope/Chapter3/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter3/CodeGenerator.cs
@@ -79,8 +79,10 @@ namespace Kaleidoscope.Chapter3
             {
             case BuiltInOperatorKind.Less:
                 {
-                    var tmp = InstructionBuilder.Compare( RealPredicate.UnorderedOrLessThan, binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) )
-                                                .RegisterName( "cmptmp" );
+                    var tmp = InstructionBuilder.Compare( RealPredicate.UnorderedOrLessThan
+                                                        , binaryOperator.Left.Accept( this )
+                                                        , binaryOperator.Right.Accept( this )
+                                                        ).RegisterName( "cmptmp" );
                     return InstructionBuilder.UIToFPCast( tmp, InstructionBuilder.Context.DoubleType )
                                              .RegisterName( "booltmp" );
                 }
@@ -88,21 +90,31 @@ namespace Kaleidoscope.Chapter3
             case BuiltInOperatorKind.Pow:
                 {
                     var pow = GetOrDeclareFunction( new Prototype( "llvm.pow.f64", "value", "power" ) );
-                    return InstructionBuilder.Call( pow, binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) )
-                                             .RegisterName( "powtmp" );
+                    return InstructionBuilder.Call( pow
+                                                  , binaryOperator.Left.Accept( this )
+                                                  , binaryOperator.Right.Accept( this )
+                                                  ).RegisterName( "powtmp" );
                 }
 
             case BuiltInOperatorKind.Add:
-                return InstructionBuilder.FAdd( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "addtmp" );
+                return InstructionBuilder.FAdd( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "addtmp" );
 
             case BuiltInOperatorKind.Subtract:
-                return InstructionBuilder.FSub( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "subtmp" );
+                return InstructionBuilder.FSub( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "subtmp" );
 
             case BuiltInOperatorKind.Multiply:
-                return InstructionBuilder.FMul( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "multmp" );
+                return InstructionBuilder.FMul( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "multmp" );
 
             case BuiltInOperatorKind.Divide:
-                return InstructionBuilder.FDiv( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "divtmp" );
+                return InstructionBuilder.FDiv( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "divtmp" );
 
             default:
                 throw new CodeGeneratorException( $"ICE: Invalid binary operator {binaryOperator.Op}" );

--- a/Samples/Kaleidoscope/Chapter4/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter4/CodeGenerator.cs
@@ -42,12 +42,14 @@ namespace Kaleidoscope.Chapter4
         }
         #endregion
 
+        #region Dispose
         public void Dispose( )
         {
             JIT.Dispose( );
             Module.Dispose( );
             Context.Dispose( );
         }
+        #endregion
 
         #region Generate
         public Value Generate( IAstNode ast, Action<CodeGeneratorException> codeGenerationErroHandler )
@@ -110,8 +112,10 @@ namespace Kaleidoscope.Chapter4
             {
             case BuiltInOperatorKind.Less:
                 {
-                    var tmp = InstructionBuilder.Compare( RealPredicate.UnorderedOrLessThan, binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) )
-                                                .RegisterName( "cmptmp" );
+                    var tmp = InstructionBuilder.Compare( RealPredicate.UnorderedOrLessThan
+                                                        , binaryOperator.Left.Accept( this )
+                                                        , binaryOperator.Right.Accept( this )
+                                                        ).RegisterName( "cmptmp" );
                     return InstructionBuilder.UIToFPCast( tmp, InstructionBuilder.Context.DoubleType )
                                              .RegisterName( "booltmp" );
                 }
@@ -119,21 +123,31 @@ namespace Kaleidoscope.Chapter4
             case BuiltInOperatorKind.Pow:
                 {
                     var pow = GetOrDeclareFunction( new Prototype( "llvm.pow.f64", "value", "power" ) );
-                    return InstructionBuilder.Call( pow, binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) )
-                                             .RegisterName( "powtmp" );
+                    return InstructionBuilder.Call( pow
+                                                  , binaryOperator.Left.Accept( this )
+                                                  , binaryOperator.Right.Accept( this )
+                                                  ).RegisterName( "powtmp" );
                 }
 
             case BuiltInOperatorKind.Add:
-                return InstructionBuilder.FAdd( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "addtmp" );
+                return InstructionBuilder.FAdd( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "addtmp" );
 
             case BuiltInOperatorKind.Subtract:
-                return InstructionBuilder.FSub( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "subtmp" );
+                return InstructionBuilder.FSub( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "subtmp" );
 
             case BuiltInOperatorKind.Multiply:
-                return InstructionBuilder.FMul( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "multmp" );
+                return InstructionBuilder.FMul( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "multmp" );
 
             case BuiltInOperatorKind.Divide:
-                return InstructionBuilder.FDiv( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "divtmp" );
+                return InstructionBuilder.FDiv( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "divtmp" );
 
             default:
                 throw new CodeGeneratorException( $"ICE: Invalid binary operator {binaryOperator.Op}" );
@@ -232,7 +246,7 @@ namespace Kaleidoscope.Chapter4
 
         #region GetOrDeclareFunction
 
-        // Retrieves a Function" for a prototype from the current module if it exists,
+        // Retrieves a Function for a prototype from the current module if it exists,
         // otherwise declares the function and returns the newly declared function.
         private IrFunction GetOrDeclareFunction( Prototype prototype )
         {
@@ -266,6 +280,6 @@ namespace Kaleidoscope.Chapter4
         private BitcodeModule Module;
         private readonly KaleidoscopeJIT JIT = new KaleidoscopeJIT( );
         private readonly Dictionary<string, ulong> FunctionModuleMap = new Dictionary<string, ulong>( );
-#endregion
+        #endregion
     }
 }

--- a/Samples/Kaleidoscope/Chapter6/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter6/CodeGenerator.cs
@@ -42,12 +42,14 @@ namespace Kaleidoscope.Chapter6
         }
         #endregion
 
+        #region Dispose
         public void Dispose( )
         {
             JIT.Dispose( );
             Module.Dispose( );
             Context.Dispose( );
         }
+        #endregion
 
         #region Generate
         public Value Generate( IAstNode ast, Action<CodeGeneratorException> codeGenerationErroHandler )
@@ -110,8 +112,10 @@ namespace Kaleidoscope.Chapter6
             {
             case BuiltInOperatorKind.Less:
                 {
-                    var tmp = InstructionBuilder.Compare( RealPredicate.UnorderedOrLessThan, binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) )
-                                                .RegisterName( "cmptmp" );
+                    var tmp = InstructionBuilder.Compare( RealPredicate.UnorderedOrLessThan
+                                                        , binaryOperator.Left.Accept( this )
+                                                        , binaryOperator.Right.Accept( this )
+                                                        ).RegisterName( "cmptmp" );
                     return InstructionBuilder.UIToFPCast( tmp, InstructionBuilder.Context.DoubleType )
                                              .RegisterName( "booltmp" );
                 }
@@ -119,21 +123,31 @@ namespace Kaleidoscope.Chapter6
             case BuiltInOperatorKind.Pow:
                 {
                     var pow = GetOrDeclareFunction( new Prototype( "llvm.pow.f64", "value", "power" ) );
-                    return InstructionBuilder.Call( pow, binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) )
-                                             .RegisterName( "powtmp" );
+                    return InstructionBuilder.Call( pow
+                                                  , binaryOperator.Left.Accept( this )
+                                                  , binaryOperator.Right.Accept( this )
+                                                  ).RegisterName( "powtmp" );
                 }
 
             case BuiltInOperatorKind.Add:
-                return InstructionBuilder.FAdd( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "addtmp" );
+                return InstructionBuilder.FAdd( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "addtmp" );
 
             case BuiltInOperatorKind.Subtract:
-                return InstructionBuilder.FSub( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "subtmp" );
+                return InstructionBuilder.FSub( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "subtmp" );
 
             case BuiltInOperatorKind.Multiply:
-                return InstructionBuilder.FMul( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "multmp" );
+                return InstructionBuilder.FMul( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "multmp" );
 
             case BuiltInOperatorKind.Divide:
-                return InstructionBuilder.FDiv( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "divtmp" );
+                return InstructionBuilder.FDiv( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "divtmp" );
 
             default:
                 throw new CodeGeneratorException( $"ICE: Invalid binary operator {binaryOperator.Op}" );
@@ -243,7 +257,7 @@ namespace Kaleidoscope.Chapter6
             InstructionBuilder.Branch( continueBlock );
 
             // capture the insert in case generating else adds new blocks
-            thenBlock = InstructionBuilder.InsertBlock;
+            var thenResultBlock = InstructionBuilder.InsertBlock;
 
             // generate else block
             function.BasicBlocks.Add( elseBlock );
@@ -255,7 +269,7 @@ namespace Kaleidoscope.Chapter6
             }
 
             InstructionBuilder.Branch( continueBlock );
-            elseBlock = InstructionBuilder.InsertBlock;
+            var elseResultBlock = InstructionBuilder.InsertBlock;
 
             // generate continue block
             function.BasicBlocks.Add( continueBlock );
@@ -263,8 +277,8 @@ namespace Kaleidoscope.Chapter6
             var phiNode = InstructionBuilder.PhiNode( function.Context.DoubleType )
                                             .RegisterName( "iftmp" );
 
-            phiNode.AddIncoming( thenValue, thenBlock );
-            phiNode.AddIncoming( elseValue, elseBlock );
+            phiNode.AddIncoming( thenValue, thenResultBlock );
+            phiNode.AddIncoming( elseValue, elseResultBlock );
             return phiNode;
         }
         #endregion
@@ -341,8 +355,10 @@ namespace Kaleidoscope.Chapter6
                 endCondition = InstructionBuilder.Compare( RealPredicate.OrderedAndNotEqual, endCondition, Context.CreateConstant( 0.0 ) )
                                                  .RegisterName( "loopcond" );
 
-                // Create the "after loop" block and insert it.
+                // capture loop end result block for loop variable PHI node
                 var loopEndBlock = InstructionBuilder.InsertBlock;
+
+                // Create the "after loop" block and insert it.
                 var afterBlock = function.AppendBasicBlock( "afterloop" );
 
                 // Insert the conditional branch into the end of LoopEndBB.
@@ -379,7 +395,7 @@ namespace Kaleidoscope.Chapter6
 
         #region GetOrDeclareFunction
 
-        // Retrieves a Function" for a prototype from the current module if it exists,
+        // Retrieves a Function for a prototype from the current module if it exists,
         // otherwise declares the function and returns the newly declared function.
         private IrFunction GetOrDeclareFunction( Prototype prototype )
         {

--- a/Samples/Kaleidoscope/Chapter7.1/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter7.1/CodeGenerator.cs
@@ -43,12 +43,14 @@ namespace Kaleidoscope.Chapter71
         }
         #endregion
 
+        #region Dispose
         public void Dispose( )
         {
             JIT.Dispose( );
             Module.Dispose( );
             Context.Dispose( );
         }
+        #endregion
 
         #region Generate
         public Value Generate( IAstNode ast, Action<CodeGeneratorException> codeGenerationErroHandler )
@@ -111,8 +113,10 @@ namespace Kaleidoscope.Chapter71
             {
             case BuiltInOperatorKind.Less:
                 {
-                    var tmp = InstructionBuilder.Compare( RealPredicate.UnorderedOrLessThan, binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) )
-                                                .RegisterName( "cmptmp" );
+                    var tmp = InstructionBuilder.Compare( RealPredicate.UnorderedOrLessThan
+                                                        , binaryOperator.Left.Accept( this )
+                                                        , binaryOperator.Right.Accept( this )
+                                                        ).RegisterName( "cmptmp" );
                     return InstructionBuilder.UIToFPCast( tmp, InstructionBuilder.Context.DoubleType )
                                              .RegisterName( "booltmp" );
                 }
@@ -120,21 +124,31 @@ namespace Kaleidoscope.Chapter71
             case BuiltInOperatorKind.Pow:
                 {
                     var pow = GetOrDeclareFunction( new Prototype( "llvm.pow.f64", "value", "power" ) );
-                    return InstructionBuilder.Call( pow, binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) )
-                                             .RegisterName( "powtmp" );
+                    return InstructionBuilder.Call( pow
+                                                  , binaryOperator.Left.Accept( this )
+                                                  , binaryOperator.Right.Accept( this )
+                                                  ).RegisterName( "powtmp" );
                 }
 
             case BuiltInOperatorKind.Add:
-                return InstructionBuilder.FAdd( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "addtmp" );
+                return InstructionBuilder.FAdd( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "addtmp" );
 
             case BuiltInOperatorKind.Subtract:
-                return InstructionBuilder.FSub( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "subtmp" );
+                return InstructionBuilder.FSub( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "subtmp" );
 
             case BuiltInOperatorKind.Multiply:
-                return InstructionBuilder.FMul( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "multmp" );
+                return InstructionBuilder.FMul( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "multmp" );
 
             case BuiltInOperatorKind.Divide:
-                return InstructionBuilder.FDiv( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "divtmp" );
+                return InstructionBuilder.FDiv( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "divtmp" );
 
             case BuiltInOperatorKind.Assign:
                 Alloca target = LookupVariable( ( ( VariableReferenceExpression )binaryOperator.Left ).Name );

--- a/Samples/Kaleidoscope/Chapter7/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter7/CodeGenerator.cs
@@ -42,12 +42,14 @@ namespace Kaleidoscope.Chapter7
         }
         #endregion
 
+        #region Dispose
         public void Dispose( )
         {
             JIT.Dispose( );
             Module.Dispose( );
             Context.Dispose( );
         }
+        #endregion
 
         #region Generate
         public Value Generate( IAstNode ast, Action<CodeGeneratorException> codeGenerationErroHandler )
@@ -110,8 +112,10 @@ namespace Kaleidoscope.Chapter7
             {
             case BuiltInOperatorKind.Less:
                 {
-                    var tmp = InstructionBuilder.Compare( RealPredicate.UnorderedOrLessThan, binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) )
-                                                .RegisterName( "cmptmp" );
+                    var tmp = InstructionBuilder.Compare( RealPredicate.UnorderedOrLessThan
+                                                        , binaryOperator.Left.Accept( this )
+                                                        , binaryOperator.Right.Accept( this )
+                                                        ).RegisterName( "cmptmp" );
                     return InstructionBuilder.UIToFPCast( tmp, InstructionBuilder.Context.DoubleType )
                                              .RegisterName( "booltmp" );
                 }
@@ -119,21 +123,31 @@ namespace Kaleidoscope.Chapter7
             case BuiltInOperatorKind.Pow:
                 {
                     var pow = GetOrDeclareFunction( new Prototype( "llvm.pow.f64", "value", "power" ) );
-                    return InstructionBuilder.Call( pow, binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) )
-                                             .RegisterName( "powtmp" );
+                    return InstructionBuilder.Call( pow
+                                                  , binaryOperator.Left.Accept( this )
+                                                  , binaryOperator.Right.Accept( this )
+                                                  ).RegisterName( "powtmp" );
                 }
 
             case BuiltInOperatorKind.Add:
-                return InstructionBuilder.FAdd( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "addtmp" );
+                return InstructionBuilder.FAdd( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "addtmp" );
 
             case BuiltInOperatorKind.Subtract:
-                return InstructionBuilder.FSub( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "subtmp" );
+                return InstructionBuilder.FSub( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "subtmp" );
 
             case BuiltInOperatorKind.Multiply:
-                return InstructionBuilder.FMul( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "multmp" );
+                return InstructionBuilder.FMul( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "multmp" );
 
             case BuiltInOperatorKind.Divide:
-                return InstructionBuilder.FDiv( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "divtmp" );
+                return InstructionBuilder.FDiv( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "divtmp" );
 
             case BuiltInOperatorKind.Assign:
                 Alloca target = LookupVariable( ( ( VariableReferenceExpression )binaryOperator.Left ).Name );

--- a/Samples/Kaleidoscope/Chapter8/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter8/CodeGenerator.cs
@@ -45,10 +45,12 @@ namespace Kaleidoscope.Chapter8
 
         public BitcodeModule Module { get; private set; }
 
+        #region Dispose
         public void Dispose( )
         {
             Context.Dispose( );
         }
+        #endregion
 
         #region Generate
         public Value Generate( IAstNode ast, Action<CodeGeneratorException> codeGenerationErroHandler )
@@ -105,8 +107,10 @@ namespace Kaleidoscope.Chapter8
             {
             case BuiltInOperatorKind.Less:
                 {
-                    var tmp = InstructionBuilder.Compare( RealPredicate.UnorderedOrLessThan, binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) )
-                                                .RegisterName( "cmptmp" );
+                    var tmp = InstructionBuilder.Compare( RealPredicate.UnorderedOrLessThan
+                                                        , binaryOperator.Left.Accept( this )
+                                                        , binaryOperator.Right.Accept( this )
+                                                        ).RegisterName( "cmptmp" );
                     return InstructionBuilder.UIToFPCast( tmp, InstructionBuilder.Context.DoubleType )
                                              .RegisterName( "booltmp" );
                 }
@@ -114,21 +118,31 @@ namespace Kaleidoscope.Chapter8
             case BuiltInOperatorKind.Pow:
                 {
                     var pow = GetOrDeclareFunction( new Prototype( "llvm.pow.f64", "value", "power" ) );
-                    return InstructionBuilder.Call( pow, binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) )
-                                             .RegisterName( "powtmp" );
+                    return InstructionBuilder.Call( pow
+                                                  , binaryOperator.Left.Accept( this )
+                                                  , binaryOperator.Right.Accept( this )
+                                                  ).RegisterName( "powtmp" );
                 }
 
             case BuiltInOperatorKind.Add:
-                return InstructionBuilder.FAdd( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "addtmp" );
+                return InstructionBuilder.FAdd( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "addtmp" );
 
             case BuiltInOperatorKind.Subtract:
-                return InstructionBuilder.FSub( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "subtmp" );
+                return InstructionBuilder.FSub( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "subtmp" );
 
             case BuiltInOperatorKind.Multiply:
-                return InstructionBuilder.FMul( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "multmp" );
+                return InstructionBuilder.FMul( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "multmp" );
 
             case BuiltInOperatorKind.Divide:
-                return InstructionBuilder.FDiv( binaryOperator.Left.Accept( this ), binaryOperator.Right.Accept( this ) ).RegisterName( "divtmp" );
+                return InstructionBuilder.FDiv( binaryOperator.Left.Accept( this )
+                                              , binaryOperator.Right.Accept( this )
+                                              ).RegisterName( "divtmp" );
 
             case BuiltInOperatorKind.Assign:
                 Alloca target = LookupVariable( ( ( VariableReferenceExpression )binaryOperator.Left ).Name );

--- a/Samples/Kaleidoscope/Chapter9/Program.cs
+++ b/Samples/Kaleidoscope/Chapter9/Program.cs
@@ -93,13 +93,13 @@ namespace Kaleidoscope.Chapter9
         // really simple command line handling, just loops through the input arguments
         private static (string SourceFilePath, int ExitCode) ProcessArgs( string[ ] args )
         {
-            bool waitforDebugger = false;
+            bool waitForDebugger = false;
             string sourceFilePath = string.Empty;
             foreach( string arg in args )
             {
                 if( string.Compare( arg, "waitfordebugger", StringComparison.OrdinalIgnoreCase ) == 0 )
                 {
-                    waitforDebugger = true;
+                    waitForDebugger = true;
                 }
                 else
                 {
@@ -111,7 +111,7 @@ namespace Kaleidoscope.Chapter9
                 }
             }
 
-            WaitForDebugger( waitforDebugger );
+            WaitForDebugger( waitForDebugger );
 
             if( string.IsNullOrWhiteSpace( sourceFilePath ) )
             {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,6 @@ environment:
   docspush_username: cibuild-telliam
   docspush_access_token:
     secure: QqWCIyFM6uBBbkW1jnlVGsMQWy+9aPY9rhD56oNT2L/0Cmw2bynROEsrUrOPpBrk
-  matrix:
-    - BuildMode: Source
-    - BuildMode: Docs
 
 skip_commits:
   files:
@@ -32,13 +29,13 @@ nuget:
   project_feed: true
 
 build_script:
-  - ps: .\BuildAll.ps1 -BuildMode $env:BuildMode
+  - ps: .\BuildAll.ps1 -BuildMode All
 
 deploy_script:
-  - ps: if($env:BuildMode -eq 'Docs') { .\Push-Docs.ps1 }
+  - ps: .\Push-Docs.ps1
 
 test_script:
-  - ps: if($env:BuildMode -eq 'Source') { .\Invoke-UnitTests.ps1; Set-Culture fr-FR; .\Invoke-UnitTests.ps1; }
+  - ps: .\Invoke-UnitTests.ps1; Set-Culture fr-FR; .\Invoke-UnitTests.ps1;
 
 artifacts:
   - path: .\BuildOutput\Nuget\*.nupkg

--- a/docfx/articles/InternalDetails/LlvmBindingsGenerator-Configuration.md
+++ b/docfx/articles/InternalDetails/LlvmBindingsGenerator-Configuration.md
@@ -10,7 +10,7 @@ generate correct .NET interop code. There are several tables of information
 used in the various passes.
 
 ## StatusReturningFunctions
-This table is a simple [SortedSet](xref:System.Collections.Generic.SortedSet{T}) of
+This table is a simple [SortedSet](xref:System.Collections.Generic.SortedSet`1) of
 strings. Each entry is the name of an LLVM function that semantically returns a status.
 The return type is transformed to an LLVMStatus to differentiate such types from a
 boolean or other integral values (in the case of a C Declaration that simply returns an
@@ -30,7 +30,7 @@ a message explaining what the alternative is, if there is one. This is used to c
 declaration with the Obsolete attribute in .NET. 
 >[!NOTE]
 >At present this table is only used to completely filter out the deprecated functions so they
->do not even appear in the generated output.
+>do not even appear in the generated output or EXPORTS.
 
 ## InternalFunctions
 This property contains a dictionary of functions that are considered internal or just completely
@@ -57,9 +57,9 @@ marshaling. The following is a summary of the handle types (for more details see
 
 #### Alias handles
 On occasion there are places where the LLVM-C APIs retrieve a handle to an object that is just
-an alias (e.g. not ultimately owned by the caller after the call completes). These are usually
-child objects returning a reference to the parent. In such cases the application should never
-dispose the handle as it doesn't own it.
+an alias (e.g. not ultimately owned by the caller after the call completes). These are usually,
+but not always, child objects returning a reference to the parent. In such cases the application
+should never dispose the handle as it doesn't own it.
 
 ### ContextHandleTemplate
 Contextual handles are those that are always references to objects owned by a parent container

--- a/docfx/articles/Samples/Kaleidoscope-ParseTreeVisitor.md
+++ b/docfx/articles/Samples/Kaleidoscope-ParseTreeVisitor.md
@@ -2,7 +2,8 @@
 The LLVM.NET Kaleidoscope tutorials all use ANTLR4 to parse the Kaleidoscope language When ANTLR processes the
 language grammar description to generate the lexer and parser it also generates a base "visitor" class for applying
 the [Visitor pattern](https://en.wikipedia.org/wiki/Visitor_pattern) to the parse tree. This is the primary mechanism
-for generating code in these examples. All of the CodeGenerator classes derive from the ANTLR generated base visitor class.
+for generating the [AST](Kaleidoscope-AST.md) for these examples. The AST transformation classes derive from the ANTLR
+generated base visitor class.
 
 There are only a few top level rules in the grammar to consider (although each has many sub rules).
 
@@ -12,9 +13,10 @@ The parse tree consist of a tree of nodes generated for each rule in the grammar
 build time when the antlr grammar file is parsed. The C# target for ANTLR4 will generate the rule classes with the
 partial keyword, allowing the application code to add application specific support to the rule classes, and thus to
 the parse tree. For Kaleidoscope, this is used to provide simpler access to the information parsed from the Kaleidoscope
-language input and effectively removes the need for an AST. (e.g. The parse tree is the AST so an intermediate transform
-isn't needed). For simplicity and clarity of understanding each of the extended partial classes are placed into their
-own source file.
+language input simplifying generation of the AST. For simplicity and clarity of understanding each of the extended partial
+classes are placed into their own source file.
 
-The code generation process involves walking the tree to produce the final output. Each chapter uses a different generator
-implementation but they are all implementations of a parse tree visitor.
+Generally speaking, the use of ANTLR and the ParseTree is a hidden internal implementation detail of the Llvm.NET
+Kaleidoscope tutorials. The actual code generation deals only with the AST so the parsing could be done with some
+other technology. (Though with all the functionality that ANTLR4 provides it would take a strong argument to justify
+something else)

--- a/docfx/articles/Samples/Kaleidoscope-ch2.md
+++ b/docfx/articles/Samples/Kaleidoscope-ch2.md
@@ -356,7 +356,7 @@ fibi(10);
 ```
 
 ## Parse Tree
-ANTLR produces a low level parse tree with nodes corresponding to each of the rules defined in teh grammar.
+ANTLR produces a low level parse tree with nodes corresponding to each of the rules defined in the grammar.
 In most cases this is extremely verbose and more details than is actually needed for generating code. (Though,
 it can be used as-is in some cases.) Typically code generation will walk the parse tree to provide a simpler
 Abstract Syntax Tree that represents the actual language concepts independent of the syntax of the language.
@@ -437,7 +437,7 @@ more scenarios and catch breaking issues quicker.)
 
 ### Special case for Chapter 2
 Chapter 2 sample code, while still following the general patterns used in all of the chapters, is a bit
-unique, it doesn't actually use Lllvm.NET at all. Instead, it is only focused on the language and parsing.
+unique, it doesn't actually use Lllvm.NET at all! Instead, it is only focused on the language and parsing.
 This helps in understanding the basic patterns of the code. Furthermore, this chapter serves as an aid in
 understanding the language itself. Of particular use is the ability to generate DGML and [blockdiag](http://blockdiag.com)
 representations of the parse tree for a given parse.

--- a/docfx/articles/Samples/Kaleidoscope-ch9.md
+++ b/docfx/articles/Samples/Kaleidoscope-ch9.md
@@ -41,10 +41,10 @@ Another important item for debug information is called the Compilation Unit. In 
 [DICompileUnit](xref:Llvm.NET.DebugInfo.DICompileUnit). The compile unit is the top level scope for
 storing debug information, there is only ever one per module and generally it represents the full source
 file that was used to create the module. Since the compile unit, like the builder is really tied to the
-module it is exposed as the [DIBuilder](xref:Llvm.NET.BitcodeModule.DIBuilder) property. However, unlike
-a builder it isn't something that a module can automatically construct without more information. Therefore,
-Llvm.NET provides overloads for the creation of a module that includes the additional data needed to create
-the DICompileUnit for you.
+module it is exposed as the [DICompileUnit](xref:Llvm.NET.BitcodeModule.DICompileUnit) property. However,
+unlike a builder it isn't something that a module can automatically construct without more information.
+Therefore, Llvm.NET provides overloads for the creation of a module that includes the additional data
+needed to create the DICompileUnit for you.
 
 The updated InitializeModuleAndPassManager() function looks like this:
 
@@ -54,7 +54,7 @@ There are a few points of interest here. First the compile unit is created for t
 however it is using the [SourceLanguage.C](xref:Llvm.NET.DebugInfo.SourceLanguage.C) value. This is
 because a debugger won't likely understand the Kaleidoscope language, runtime, or calling conventions.
 (We just invented it and only now setting up debugger support after all!) The good news is that the
-language follows the C language ABI in the code generation (generally a good idea unless you ave a really
+language follows the C language ABI in the code generation (generally a good idea unless you have a really
 good reason not to). Therefore, the C language is fairly accurate. This allows calling functions from the
 debugger and it will execute them.
 
@@ -68,15 +68,12 @@ is provided so that it becomes the root compile unit.
 > [Finish](xref:Llvm.NET.DebugInfo.DebugInfoBuilder.Finish(Llvm.NET.DebugInfo.DISubProgram))
 > method. (In Llvm.NET this method is called Finish() to avoid conflicts with the .NET runtime defined
 > Finalize() and to avoid confusion on the term as the idea of "finalization" has a very different meaning
-> in .NET then what happens here).
+> in .NET then what applies to the DIBuilder).
 
-The tutorial takes care of finishing the debug information in Main after the running the parsing loop to
-process all the input text for the source file.
+The tutorial takes care of finishing the debug information in the generator's Generate method after
+completing code generation for the module.
 
-```C#
-replLoop.Run( );
-generator.Module.DIBuilder.Finish( );
-```
+[!code-csharp[Generate](../../../Samples/Kaleidoscope/Chapter9/CodeGenerator.cs#Generate)]
 
 ## Functions
 With the basics of the DIBuilder and DICompile unit setup for the module it is time to focus on providing
@@ -92,7 +89,7 @@ intern the file definition so that it won't actually end up with duplicates.
 [!code-csharp[GetIrDeclareFunction](../../../Samples/Kaleidoscope/Chapter9/CodeGenerator.cs#GetOrDeclareFunction)]
 
 ## Debug Locations
-The parse tree contains full location information for each parsed node in the tree. This allows building
+The AST contains full location information for each parsed node from the parse tree. This allows building
 debug location information for each node fairly easily. The general idea is to set the location in the
 InstructionBuilder so that it is applied to all instructions emitted until it is changed. This saves on
 manually adding the location on every instruction.

--- a/docfx/articles/Samples/Kaleidoscope.md
+++ b/docfx/articles/Samples/Kaleidoscope.md
@@ -43,6 +43,29 @@ Kaleidoscope is a simple functional language with the following major features:
       Though, ANTLR4's flexibility made it fairly easy to do once fully understood. (more details in
       [Chapter 6](Kaleidoscope-ch6.md))
 
+### Expressions
+In Kaleidoscope, everything is an expression (e.g. everything has or returns a value even if the value
+is a constant 0.0). There are no statements and no "void" functions etc...
+
+#### Multi-line expressions
+There are a few different ways to represent an expression that is long enough to warrant splitting it across
+multiple lines when typing it out.
+
+##### Expression Continuation Marker
+One mechanism for handling multi-line expressions that is used in most shell scripting languages is a line
+continuation marker. In such cases a special character followed by a line-termination char or char sequence
+indicates that the expression continues on the next line (e.g. it isn't complete yet).
+
+##### Expression Complete Marker
+Another approach to handling long expressions spanning multiple lines is basically the opposite of line
+continuation, expression complete markers. This marker indicates the end of a potentially multi-line expression. (A variant
+of this might require a line termination following the marker as with the line continuation).
+
+##### Kaleidoscope Implementation
+The original LLVM C++ implementation chose the expression completion approach using a semicolon as the completion.
+(So it seems familiar like statements in other C like languages) Therefore, the LLVM.NET tutorial follows the same
+design. [Implementing the line continuation mechanism in Kaleidoscope is left as an exercise for the reader :wink:]
+
 ### Example
 The following example is a complete program in Kaleidoscope that will generate a textual representation
 of the classic Mandelbrot Set.

--- a/docfx/articles/Samples/index.md
+++ b/docfx/articles/Samples/index.md
@@ -3,3 +3,19 @@ Llvm.NET provides multiple samples to aid in understanding how to use the Llvm.N
 These samples are designed and intended to illustrate some aspect(s) of using Llvm.NET itself
 and are not generally considered production quality. 
 
+## Code Generation
+### [CodeGenerator With Debug Information](codegeneration.md)
+
+## Kaleidoscope
+### [Chapter 1 - Language Introduction](Kaleidoscope.md)
+### [Chapter 2 - Implementing the parser](Kaleidoscope-ch2.md)
+### [Chapter 3 - Generating LLVM IR](Kaleidoscope-ch3.md)
+### [Chapter 4 - JIT and Optimizer Support](Kaleidoscope-ch4.md)
+### [Chapter 5 - Control Flow](Kaleidoscope-ch5.md)
+### [Chapter 6 - User Defined Operators](Kaleidoscope-ch6.md)
+### [Chapter 7 - Mutable Variables](Kaleidoscope-ch7.md)
+### [Chapter 7.1 - Extreme Lazy JIT](Kaleidoscope-ch7.1.md)
+### [Chapter 8 - AOT Compilation](Kaleidoscope-ch8.md)
+### [Chapter 9 - Debug Information](Kaleidoscope-ch9.md)
+### [ParseTree Visitor](Kaleidoscope-ParseTreeVisitor.md)
+### [ParseTree Examples](Kaleidoscope-ParseTree-examples.md)

--- a/docfx/articles/Samples/toc.md
+++ b/docfx/articles/Samples/toc.md
@@ -1,6 +1,6 @@
-# Code Generation
+# [Code Generation](codegeneration.md)
 ## [CodeGenerator With Debug Information](codegeneration.md)
-# Kaleidoscope
+# [Kaleidoscope](Kaleidoscope.md)
 ## [Chapter 1 - Language Introduction](Kaleidoscope.md)
 ## [Chapter 2 - Implementing the parser](Kaleidoscope-ch2.md)
 ## [Chapter 3 - Generating LLVM IR](Kaleidoscope-ch3.md)

--- a/docfx/articles/index.md
+++ b/docfx/articles/index.md
@@ -7,3 +7,28 @@ using Lllvm.NET and how it maps to the underlying LLVM. The LLVM documentation i
 generally speaking, required reading to understand Llvm.NET. The topics here contain
 links to the official LLVM documentation to help in further understanding the
 functionality of the library.
+
+#### [Samples](Samples/index.md)
+##### Code Generation
+###### [CodeGenerator With Debug Information](Samples/codegeneration.md)
+##### Kaleidoscope
+###### [Chapter 1 - Language Introduction](Samples/Kaleidoscope.md)
+###### [Chapter 2 - Implementing the parser](Samples/Kaleidoscope-ch2.md)
+###### [Chapter 3 - Generating LLVM IR](Samples/Kaleidoscope-ch3.md)
+###### [Chapter 4 - JIT and Optimizer Support](Samples/Kaleidoscope-ch4.md)
+###### [Chapter 5 - Control Flow](Samples/Kaleidoscope-ch5.md)
+###### [Chapter 6 - User Defined Operators](Samples/Kaleidoscope-ch6.md)
+###### [Chapter 7 - Mutable Variables](Samples/Kaleidoscope-ch7.md)
+###### [Chapter 7.1 - Extreme Lazy JIT](Samples/Kaleidoscope-ch7.1.md)
+###### [Chapter 8 - AOT Compilation](Samples/Kaleidoscope-ch8.md)
+###### [Chapter 9 - Debug Information](Samples/Kaleidoscope-ch9.md)
+###### [ParseTree Visitor](Samples/Kaleidoscope-ParseTreeVisitor.md)
+###### [ParseTree Examples](Samples/Kaleidoscope-ParseTree-examples.md)
+
+#### [Internal Details](InternalDetails/index.md)
+##### LLVM-C API Handles
+###### [Wrapping LLVM-C Handles](InternalDetails/llvm-handles.md)
+###### [Interning LLVM-C Handles](InternalDetails/handleref-interning.md)
+##### Marshaling LLVM types
+###### [Marshaling Strings](InternalDetails/marshal-string.md)
+###### [Marshaling LLVMBool](InternalDetails/marshal-LLVMBool.md)

--- a/docfx/articles/toc.md
+++ b/docfx/articles/toc.md
@@ -12,8 +12,11 @@
 ### [Chapter 7.1 - Extreme Lazy JIT](Samples/Kaleidoscope-ch7.1.md)
 ### [Chapter 8 - AOT Compilation](Samples/Kaleidoscope-ch8.md)
 ### [Chapter 9 - Debug Information](Samples/Kaleidoscope-ch9.md)
-### [ParseTree Visitor](Samples/Kaleidoscope-ParseTreeVisitor.md)
-### [ParseTree Examples](Samples/Kaleidoscope-ParseTree-examples.md)
+### Additional Support
+#### [Kaleidoscope.Runtime](Samples/Kaleidoscope-Runtime.md)
+#### [Kaleidoscope AST](Samples/Kaleidoscope-AST.md)
+#### [ParseTree Visitor](Samples/Kaleidoscope-ParseTreeVisitor.md)
+#### [ParseTree Examples](Samples/Kaleidoscope-ParseTree-examples.md)
 
 # [Internal Details](InternalDetails/index.md)
 ## LLVM-C API Handles

--- a/src/Llvm.NET/ObjectFile/TargetObjectFile.cs
+++ b/src/Llvm.NET/ObjectFile/TargetObjectFile.cs
@@ -26,7 +26,7 @@ namespace Llvm.NET.ObjectFile
             buffer.Detach( );
         }
 
-        /// <summary>Gets the symbols in this <see cref="ObjFileRef"/></summary>
+        /// <summary>Gets the symbols in this <see cref="TargetObjectFile"/></summary>
         public IEnumerable<Symbol> Symbols
         {
             get
@@ -42,7 +42,7 @@ namespace Llvm.NET.ObjectFile
             }
         }
 
-        /// <summary>Gets the sections in this <see cref="ObjFileRef"/></summary>
+        /// <summary>Gets the sections in this <see cref="TargetObjectFile"/></summary>
         public IEnumerable<Section> Sections
         {
             get
@@ -58,7 +58,7 @@ namespace Llvm.NET.ObjectFile
             }
         }
 
-        /// <summary>Opens an <see cref="ObjectFile"/> from a path</summary>
+        /// <summary>Opens a <see cref="TargetObjectFile"/> from a path</summary>
         /// <param name="path">path to the object file binary</param>
         /// <returns>new object file</returns>
         /// <exception cref="System.IO.IOException">File IO failures</exception>


### PR DESCRIPTION
Fixes #97

* Clean up of docs to fix typos and updates to reflect changes made in code for latest C# language and runtime support along with general design improvements since originally written.
* Restored single job to build source and docs. The docs now build in about the same total time as the source and since jobs are a complete restart the binary interop lib doesn't exist and can't contribute when split.