### PR TITLE
Adding support for eager compilation to OrcJit on Windows

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -13,7 +13,7 @@
         <PackageReference Update="MSTest.TestFramework" Version="1.4.0" />
         <PackageReference Update="MSTest.TestAdapter" Version="1.4.0" />
         <PackageReference Update="System.Memory" Version="4.5.3" />
-        <PackageReference Update="CppSharp" Version="0.9.0" />
+        <PackageReference Update="CppSharp" Version="0.10.0" />
         <PackageReference Update="Antlr4" Version="4.6.6"/>
         <PackageReference Update="OpenSoftware.DgmlBuilder" Version="1.13.0" Condition="'$(TargetFramework)'=='net47'" />
         <PackageReference Update="System.Collections.Immutable" Version="1.5.0" />

--- a/Samples/CodeGenWithDebugInfo/Program.cs
+++ b/Samples/CodeGenWithDebugInfo/Program.cs
@@ -164,23 +164,24 @@ namespace TestDebugInfo
                             using( var modForOpt = module.Clone( ) )
                             {
                                 // NOTE:
-                                // The ordering of passes can matter depending on the pass and passes may be added more than once
+                                // The ordering of passes can matter depending on the pass, and passes may be added more than once
                                 // the caller has full control of ordering, this is just a sample of effectively randomly picked
                                 // passes and not necessarily a reflection of any particular use case.
-                                var pm = new ModulePassManager( )
-                                         .AddAlwaysInlinerPass( )
-                                         .AddAggressiveDCEPass( )
-                                         .AddArgumentPromotionPass( )
-                                         .AddBasicAliasAnalysisPass( )
-                                         .AddBitTrackingDCEPass( )
-                                         .AddCFGSimplificationPass( )
-                                         .AddConstantMergePass( )
-                                         .AddConstantPropagationPass( )
-                                         .AddFunctionInliningPass( )
-                                         .AddGlobalOptimizerPass( )
-                                         .AddInstructionCombiningPass( );
-
-                                pm.Run( modForOpt );
+                                using( var pm = new ModulePassManager( ) )
+                                {
+                                    pm.AddAlwaysInlinerPass( )
+                                      .AddAggressiveDCEPass( )
+                                      .AddArgumentPromotionPass( )
+                                      .AddBasicAliasAnalysisPass( )
+                                      .AddBitTrackingDCEPass( )
+                                      .AddCFGSimplificationPass( )
+                                      .AddConstantMergePass( )
+                                      .AddConstantPropagationPass( )
+                                      .AddFunctionInliningPass( )
+                                      .AddGlobalOptimizerPass( )
+                                      .AddInstructionCombiningPass( )
+                                      .Run( modForOpt );
+                                }
                             }
                         }
 

--- a/Samples/Kaleidoscope/Chapter4/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter4/CodeGenerator.cs
@@ -12,6 +12,7 @@ using Kaleidoscope.Grammar.AST;
 using Kaleidoscope.Runtime;
 using Llvm.NET;
 using Llvm.NET.Instructions;
+using Llvm.NET.JIT;
 using Llvm.NET.Transforms;
 using Llvm.NET.Values;
 
@@ -46,7 +47,8 @@ namespace Kaleidoscope.Chapter4
         public void Dispose( )
         {
             JIT.Dispose( );
-            Module.Dispose( );
+            Module?.Dispose( );
+            FunctionPassManager?.Dispose( );
             Context.Dispose( );
         }
         #endregion
@@ -65,30 +67,37 @@ namespace Kaleidoscope.Chapter4
 
                 InitializeModuleAndPassManager( );
 
-                // Destroy any previously generated module for this function.
-                // This allows re-definition as the new module will provide the
-                // implementation. This is needed, otherwise both the MCJIT
-                // and OrcJit engines will resolve to the original module, despite
-                // claims to the contrary in the official tutorial text. (Though,
-                // to be fair it may have been true in the original JIT and might
-                // still be true for the interpreter)
-                if( FunctionModuleMap.Remove( definition.Name, out ulong handle ) )
-                {
-                    JIT.RemoveModule( handle );
-                }
-
                 var function = ( IrFunction )definition.Accept( this );
-                ulong jitHandle = JIT.AddModule( function.ParentModule );
+
                 if( definition.IsAnonymous )
                 {
-                    var nativeFunc = JIT.GetFunctionDelegate<KaleidoscopeJIT.CallbackHandler0>( function.Name );
+                    // eagerly compile modules for anonymous functions as calling the function is the guaranteed next step
+                    ulong jitHandle = JIT.AddEagerlyCompiledModule( Module );
+                    var nativeFunc = JIT.GetFunctionDelegate<KaleidoscopeJIT.CallbackHandler0>( definition.Name );
                     var retVal = Context.CreateConstant( nativeFunc( ) );
                     JIT.RemoveModule( jitHandle );
                     return retVal;
                 }
+                else
+                {
+                    // Destroy any previously generated module for this function.
+                    // This allows re-definition as the new module will provide the
+                    // implementation. This is needed, otherwise both the MCJIT
+                    // and OrcJit engines will resolve to the original module, despite
+                    // claims to the contrary in the official tutorial text. (Though,
+                    // to be fair it may have been true in the original JIT and might
+                    // still be true for the interpreter)
+                    if( FunctionModuleMap.Remove( definition.Name, out ulong handle ) )
+                    {
+                        JIT.RemoveModule( handle );
+                    }
 
-                FunctionModuleMap.Add( function.Name, jitHandle );
-                return function;
+                    // Unknown if any future input will call the function so add it for lazy compilation.
+                    // Native code is generated for the module automatically only when required.
+                    ulong jitHandle = JIT.AddLazyCompiledModule( Module );
+                    FunctionModuleMap.Add( definition.Name, jitHandle );
+                    return function;
+                }
             }
             catch( CodeGeneratorException ex ) when( codeGenerationErroHandler != null )
             {

--- a/Samples/Kaleidoscope/Chapter6/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter6/CodeGenerator.cs
@@ -12,6 +12,7 @@ using Kaleidoscope.Grammar.AST;
 using Kaleidoscope.Runtime;
 using Llvm.NET;
 using Llvm.NET.Instructions;
+using Llvm.NET.JIT;
 using Llvm.NET.Transforms;
 using Llvm.NET.Values;
 
@@ -46,7 +47,8 @@ namespace Kaleidoscope.Chapter6
         public void Dispose( )
         {
             JIT.Dispose( );
-            Module.Dispose( );
+            Module?.Dispose( );
+            FunctionPassManager?.Dispose( );
             Context.Dispose( );
         }
         #endregion
@@ -65,30 +67,37 @@ namespace Kaleidoscope.Chapter6
 
                 InitializeModuleAndPassManager( );
 
-                // Destroy any previously generated module for this function.
-                // This allows re-definition as the new module will provide the
-                // implementation. This is needed, otherwise both the MCJIT
-                // and OrcJit engines will resolve to the original module, despite
-                // claims to the contrary in the official tutorial text. (Though,
-                // to be fair it may have been true in the original JIT and might
-                // still be true for the interpreter)
-                if( FunctionModuleMap.Remove( definition.Name, out ulong handle ) )
-                {
-                    JIT.RemoveModule( handle );
-                }
-
                 var function = ( IrFunction )definition.Accept( this );
-                ulong jitHandle = JIT.AddModule( function.ParentModule );
+
                 if( definition.IsAnonymous )
                 {
-                    var nativeFunc = JIT.GetFunctionDelegate<KaleidoscopeJIT.CallbackHandler0>( function.Name );
+                    // eagerly compile modules for anonymous functions as calling the function is the guaranteed next step
+                    ulong jitHandle = JIT.AddEagerlyCompiledModule( Module );
+                    var nativeFunc = JIT.GetFunctionDelegate<KaleidoscopeJIT.CallbackHandler0>( definition.Name );
                     var retVal = Context.CreateConstant( nativeFunc( ) );
                     JIT.RemoveModule( jitHandle );
                     return retVal;
                 }
+                else
+                {
+                    // Destroy any previously generated module for this function.
+                    // This allows re-definition as the new module will provide the
+                    // implementation. This is needed, otherwise both the MCJIT
+                    // and OrcJit engines will resolve to the original module, despite
+                    // claims to the contrary in the official tutorial text. (Though,
+                    // to be fair it may have been true in the original JIT and might
+                    // still be true for the interpreter)
+                    if( FunctionModuleMap.Remove( definition.Name, out ulong handle ) )
+                    {
+                        JIT.RemoveModule( handle );
+                    }
 
-                FunctionModuleMap.Add( function.Name, jitHandle );
-                return function;
+                    // Unknown if any future input will call the function so add it for lazy compilation.
+                    // Native code is generated for the module automatically only when required.
+                    ulong jitHandle = JIT.AddLazyCompiledModule( Module );
+                    FunctionModuleMap.Add( definition.Name, jitHandle );
+                    return function;
+                }
             }
             catch( CodeGeneratorException ex ) when( codeGenerationErroHandler != null )
             {
@@ -246,7 +255,7 @@ namespace Kaleidoscope.Chapter6
             var continueBlock = function.AppendBasicBlock( "ifcont" );
             InstructionBuilder.Branch( condBool, thenBlock, elseBlock );
 
-            // generate then block
+            // generate then block instructions
             InstructionBuilder.PositionAtEnd( thenBlock );
             var thenValue = conditionalExpression.ThenExpression.Accept( this );
             if( thenValue == null )
@@ -260,7 +269,6 @@ namespace Kaleidoscope.Chapter6
             var thenResultBlock = InstructionBuilder.InsertBlock;
 
             // generate else block
-            function.BasicBlocks.Add( elseBlock );
             InstructionBuilder.PositionAtEnd( elseBlock );
             var elseValue = conditionalExpression.ElseExpression.Accept( this );
             if( elseValue == null )
@@ -272,13 +280,11 @@ namespace Kaleidoscope.Chapter6
             var elseResultBlock = InstructionBuilder.InsertBlock;
 
             // generate continue block
-            function.BasicBlocks.Add( continueBlock );
             InstructionBuilder.PositionAtEnd( continueBlock );
             var phiNode = InstructionBuilder.PhiNode( function.Context.DoubleType )
-                                            .RegisterName( "iftmp" );
+                                            .RegisterName( "ifresult" );
 
-            phiNode.AddIncoming( thenValue, thenResultBlock );
-            phiNode.AddIncoming( elseValue, elseResultBlock );
+            phiNode.AddIncoming(( thenValue, thenResultBlock ),( elseValue, elseResultBlock ));
             return phiNode;
         }
         #endregion

--- a/Samples/Kaleidoscope/Chapter7/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter7/CodeGenerator.cs
@@ -12,6 +12,7 @@ using Kaleidoscope.Grammar.AST;
 using Kaleidoscope.Runtime;
 using Llvm.NET;
 using Llvm.NET.Instructions;
+using Llvm.NET.JIT;
 using Llvm.NET.Transforms;
 using Llvm.NET.Values;
 
@@ -46,7 +47,8 @@ namespace Kaleidoscope.Chapter7
         public void Dispose( )
         {
             JIT.Dispose( );
-            Module.Dispose( );
+            Module?.Dispose( );
+            FunctionPassManager?.Dispose( );
             Context.Dispose( );
         }
         #endregion
@@ -65,30 +67,37 @@ namespace Kaleidoscope.Chapter7
 
                 InitializeModuleAndPassManager( );
 
-                // Destroy any previously generated module for this function.
-                // This allows re-definition as the new module will provide the
-                // implementation. This is needed, otherwise both the MCJIT
-                // and OrcJit engines will resolve to the original module, despite
-                // claims to the contrary in the official tutorial text. (Though,
-                // to be fair it may have been true in the original JIT and might
-                // still be true for the interpreter)
-                if( FunctionModuleMap.Remove( definition.Name, out ulong handle ) )
-                {
-                    JIT.RemoveModule( handle );
-                }
-
                 var function = ( IrFunction )definition.Accept( this );
-                ulong jitHandle = JIT.AddModule( function.ParentModule );
+
                 if( definition.IsAnonymous )
                 {
-                    var nativeFunc = JIT.GetFunctionDelegate<KaleidoscopeJIT.CallbackHandler0>( function.Name );
+                    // eagerly compile modules for anonymous functions as calling the function is the guaranteed next step
+                    ulong jitHandle = JIT.AddEagerlyCompiledModule( Module );
+                    var nativeFunc = JIT.GetFunctionDelegate<KaleidoscopeJIT.CallbackHandler0>( definition.Name );
                     var retVal = Context.CreateConstant( nativeFunc( ) );
                     JIT.RemoveModule( jitHandle );
                     return retVal;
                 }
+                else
+                {
+                    // Destroy any previously generated module for this function.
+                    // This allows re-definition as the new module will provide the
+                    // implementation. This is needed, otherwise both the MCJIT
+                    // and OrcJit engines will resolve to the original module, despite
+                    // claims to the contrary in the official tutorial text. (Though,
+                    // to be fair it may have been true in the original JIT and might
+                    // still be true for the interpreter)
+                    if( FunctionModuleMap.Remove( definition.Name, out ulong handle ) )
+                    {
+                        JIT.RemoveModule( handle );
+                    }
 
-                FunctionModuleMap.Add( function.Name, jitHandle );
-                return function;
+                    // Unknown if any future input will call the function so add it for lazy compilation.
+                    // Native code is generated for the module automatically only when required.
+                    ulong jitHandle = JIT.AddLazyCompiledModule( Module );
+                    FunctionModuleMap.Add( definition.Name, jitHandle );
+                    return function;
+                }
             }
             catch( CodeGeneratorException ex ) when( codeGenerationErroHandler != null )
             {
@@ -264,7 +273,7 @@ namespace Kaleidoscope.Chapter7
             var continueBlock = function.AppendBasicBlock( "ifcont" );
             InstructionBuilder.Branch( condBool, thenBlock, elseBlock );
 
-            // generate then block
+            // generate then block instructions
             InstructionBuilder.PositionAtEnd( thenBlock );
             var thenValue = conditionalExpression.ThenExpression.Accept( this );
             if( thenValue == null )
@@ -276,7 +285,6 @@ namespace Kaleidoscope.Chapter7
             InstructionBuilder.Branch( continueBlock );
 
             // generate else block
-            function.BasicBlocks.Add( elseBlock );
             InstructionBuilder.PositionAtEnd( elseBlock );
             var elseValue = conditionalExpression.ElseExpression.Accept( this );
             if( elseValue == null )
@@ -288,7 +296,6 @@ namespace Kaleidoscope.Chapter7
             InstructionBuilder.Branch( continueBlock );
 
             // generate continue block
-            function.BasicBlocks.Add( continueBlock );
             InstructionBuilder.PositionAtEnd( continueBlock );
 
             // since the Alloca is created as a non-opaque pointer it is OK to just use the
@@ -434,8 +441,8 @@ namespace Kaleidoscope.Chapter7
         {
             Module = Context.CreateBitcodeModule( );
             Module.Layout = JIT.TargetMachine.TargetData;
-            FunctionPassManager = new FunctionPassManager( Module )
-                                      .AddPromoteMemoryToRegisterPass( );
+            FunctionPassManager = new FunctionPassManager( Module );
+            FunctionPassManager.AddPromoteMemoryToRegisterPass( );
 
             if( !DisableOptimizations )
             {

--- a/Samples/Kaleidoscope/Chapter8/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter8/CodeGenerator.cs
@@ -48,6 +48,7 @@ namespace Kaleidoscope.Chapter8
         #region Dispose
         public void Dispose( )
         {
+            FunctionPassManager?.Dispose( );
             Context.Dispose( );
         }
         #endregion
@@ -268,7 +269,7 @@ namespace Kaleidoscope.Chapter8
             var continueBlock = function.AppendBasicBlock( "ifcont" );
             InstructionBuilder.Branch( condBool, thenBlock, elseBlock );
 
-            // generate then block
+            // generate then block instructions
             InstructionBuilder.PositionAtEnd( thenBlock );
             var thenValue = conditionalExpression.ThenExpression.Accept( this );
             if( thenValue == null )
@@ -280,7 +281,6 @@ namespace Kaleidoscope.Chapter8
             InstructionBuilder.Branch( continueBlock );
 
             // generate else block
-            function.BasicBlocks.Add( elseBlock );
             InstructionBuilder.PositionAtEnd( elseBlock );
             var elseValue = conditionalExpression.ElseExpression.Accept( this );
             if( elseValue == null )
@@ -292,7 +292,6 @@ namespace Kaleidoscope.Chapter8
             InstructionBuilder.Branch( continueBlock );
 
             // generate continue block
-            function.BasicBlocks.Add( continueBlock );
             InstructionBuilder.PositionAtEnd( continueBlock );
 
             // since the Alloca is created as a non-opaque pointer it is OK to just use the
@@ -439,8 +438,8 @@ namespace Kaleidoscope.Chapter8
             Module = Context.CreateBitcodeModule( );
             Module.TargetTriple = TargetMachine.Triple;
             Module.Layout = TargetMachine.TargetData;
-            FunctionPassManager = new FunctionPassManager( Module )
-                                      .AddPromoteMemoryToRegisterPass( );
+            FunctionPassManager = new FunctionPassManager( Module );
+            FunctionPassManager.AddPromoteMemoryToRegisterPass( );
 
             if( !DisableOptimizations )
             {

--- a/Samples/Kaleidoscope/Chapter9/CodeGenerator.cs
+++ b/Samples/Kaleidoscope/Chapter9/CodeGenerator.cs
@@ -50,6 +50,7 @@ namespace Kaleidoscope.Chapter9
         #region Dispose
         public void Dispose( )
         {
+            FunctionPassManager?.Dispose( );
             Context.Dispose( );
         }
         #endregion
@@ -290,7 +291,7 @@ namespace Kaleidoscope.Chapter9
             var continueBlock = function.AppendBasicBlock( "ifcont" );
             InstructionBuilder.Branch( condBool, thenBlock, elseBlock );
 
-            // generate then block
+            // generate then block instructions
             InstructionBuilder.PositionAtEnd( thenBlock );
             var thenValue = conditionalExpression.ThenExpression.Accept( this );
             if( thenValue == null )
@@ -302,7 +303,6 @@ namespace Kaleidoscope.Chapter9
             InstructionBuilder.Branch( continueBlock );
 
             // generate else block
-            function.BasicBlocks.Add( elseBlock );
             InstructionBuilder.PositionAtEnd( elseBlock );
             var elseValue = conditionalExpression.ElseExpression.Accept( this );
             if( elseValue == null )
@@ -314,7 +314,6 @@ namespace Kaleidoscope.Chapter9
             InstructionBuilder.Branch( continueBlock );
 
             // generate continue block
-            function.BasicBlocks.Add( continueBlock );
             InstructionBuilder.PositionAtEnd( continueBlock );
 
             // since the Alloca is created as a non-opaque pointer it is OK to just use the
@@ -467,8 +466,8 @@ namespace Kaleidoscope.Chapter9
             Module.Layout = TargetMachine.TargetData;
             DoubleType = new DebugBasicType( Context.DoubleType, Module, "double", DiTypeKind.Float );
 
-            FunctionPassManager = new FunctionPassManager( Module )
-                                      .AddPromoteMemoryToRegisterPass( );
+            FunctionPassManager = new FunctionPassManager( Module );
+            FunctionPassManager.AddPromoteMemoryToRegisterPass( );
 
             if( !DisableOptimizations )
             {

--- a/Samples/Kaleidoscope/mandel.kls
+++ b/Samples/Kaleidoscope/mandel.kls
@@ -65,12 +65,3 @@ def mandel(realstart imagstart realmag imagmag)
   mandelhelp(realstart, realstart+realmag*78, realmag, imagstart, imagstart+imagmag*40, imagmag);
 
 mandel(-2.3, -1.3, 0.05, 0.07);
-
-#test loops
-extern putchard(char);
-def printstar(n)
-  for i = 1, i < n, 1.0 in
-    putchard(42);  # ASCII 42 = '*'
-
-# print 100 '*' characters
-printstar(100);

--- a/docfx/ReleaseNotes.md
+++ b/docfx/ReleaseNotes.md
@@ -1,0 +1,60 @@
+# LLVM 8.0 Support
+## Llvm.NET.Interop (New library)
+Llvm.NET 8.0 adds a new library (Llvm.NET.Interop)  that contains the raw P/Invoke
+APIs and support needed to inter-operate with the native library. The NuGet package
+for the interop library includes the native code binaries as they are tightly coupled.
+This package contains the native LibLLVM.dll and the P/Invoke interop support layers.
+Llvm.NET uses this library to define a clean projection of LLVM for .NET consumers.
+This will, hopefully, allow for future development and enhancement of the Llvm.NET
+object model without changing the underlying P/Invoke layers. (e.g.
+the Llvm.NET.Interop can "snap" to LLVM versions, but the LLvm.NET model can have
+multiple incremental releases) This isn't a hard/fast rule as it is possible that
+getting new functionality in the object model requires new custom extensions. At
+this point in time both libraries are built together and share build numbers.
+Though, that may change in the future. 
+
+### Auto-generated P/Invoke
+LLVM-C API now includes most of the debug APIs so, significantly fewer custom
+extensions are needed (That's a good thing!). To try and keep things simpler this
+moves the interop back to using code generation for the bulk of the P/Invoke interop.
+However, unlike the first use of generation, the [LLVMBindingsGenerator](https://github.com/UbiquityDotNET/Llvm.NET/tree/master/src/Interop/LlvmBindingsGenerator)
+is much more targeted and includes specialized handling to prevent the need for
+additional "by-hand" tweaking of the generated code, such as:
+
+1. Marshaling of strings with the many ways to dispose (or not) a returned string
+2. LLVMBool vs LLVMStatus
+3. "smart ref" handle types, including aliases that should not be released by
+   client code.
+
+The generated code is combined with some fixed support classes to create a new
+Llvm.NET.Interop Library and NuGet Package. 
+
+## New features
+* ObjectFile Support
+  * LLvm.NET.ObjectFile namespace contains support for processing object files using LLVM
+* Eager compilation JIT
+  * The OrcJIT now supports eager and lazy compilation for Windows platforms
+* Full initialization for all the latests supported targets
+  * Including - BPF, Lanai, WebAssembly, MSP430, NVPTX, AMDGPU, Hexagon, and XCore
+* Added accessors to allow retrieval/addition of metadata on instructions
+
+# Breaking Changes
+This is a Major release and, as such, can, and does, have breaking changes including:
+
+1. New namespace for some classes (Llvm.NET.Interop)
+2. StaticState class is renamed to Llvm.NET.Interop.Library as it is fundamentally 
+   part of the low level interop (and "StaticState" was always a bad name)
+3. Instructions no longer have a SetDebugLocation, instead that is provided via a new
+   fluent method on the InstructionBuilder since the normal use is to set the location
+   on the builder and then generate a sequence of IR instructions for a given expression
+   in code. 
+4. Legacy JIT engine support is dropped. ORCJit is the only supported JIT engine
+5. Context.CreateBasicBlock() now only creates detached blocks, if append to a function
+   is desired, there is a method on Function to create and append a new block.
+6. PassManager, ModulePassManager, and FunctionPassManager are IDisposable to help apps
+   ensure that a function pass manager, which is bound to a module, is destroyed before
+   the module it is bound to.
+7. Shared references for BitC
+7. BitCodeModule is now Disposable backed by a safe handle, this allows for detaching and
+   invalidating the underlying LLVMModuleRef when the module is provided to the JIT 
+

--- a/docfx/articles/ReleaseNotes.md
+++ b/docfx/articles/ReleaseNotes.md
@@ -1,0 +1,65 @@
+# LLVM 8.0 Support
+## Llvm.NET.Interop (New library)
+Llvm.NET 8.0 adds a new library (Llvm.NET.Interop)  that contains the raw P/Invoke
+APIs and support needed to inter-operate with the native library. The NuGet package
+for the interop library includes the native code binaries as they are tightly coupled.
+This package contains the native LibLLVM.dll and the P/Invoke interop support layers.
+Llvm.NET uses this library to define a clean projection of LLVM for .NET consumers.
+This will, hopefully, allow for future development and enhancement of the Llvm.NET
+object model without changing the underlying P/Invoke layers. (e.g.
+the Llvm.NET.Interop can "snap" to LLVM versions, but the LLvm.NET model can have
+multiple incremental releases) This isn't a hard/fast rule as it is possible that
+getting new functionality in the object model requires new custom extensions. At
+this point in time both libraries are built together and share build numbers.
+Though, that may change in the future. 
+
+### Auto-generated P/Invoke
+LLVM-C API now includes most of the debug APIs so, significantly fewer custom
+extensions are needed (That's a good thing!). To try and keep things simpler this
+moves the interop back to using code generation for the bulk of the P/Invoke interop.
+However, unlike the first use of generation, the [LLVMBindingsGenerator](https://github.com/UbiquityDotNET/Llvm.NET/tree/master/src/Interop/LlvmBindingsGenerator)
+is much more targeted and includes specialized handling to prevent the need for
+additional "by-hand" tweaking of the generated code, such as:
+
+1. Marshaling of strings with the many ways to dispose (or not) a returned string
+2. LLVMBool vs LLVMStatus
+3. "smart ref" handle types, including aliases that should not be released by
+   client code.
+
+The generated code is combined with some fixed support classes to create a new
+Llvm.NET.Interop Library and NuGet Package. 
+
+## New features
+* ObjectFile Support
+  * LLvm.NET.ObjectFile namespace contains support for processing object files using LLVM
+* Eager compilation JIT
+  * The OrcJIT now supports eager and lazy compilation for Windows platforms
+* Full initialization for all the latests supported targets
+  * Including - BPF, Lanai, WebAssembly, MSP430, NVPTX, AMDGPU, Hexagon, and XCore
+* Added accessors to allow retrieval/addition of metadata on instructions
+
+# Breaking Changes
+This is a Major release and, as such, can, and does, have breaking changes. It is generally
+anticipated that these are minor issues but do require changes in source:
+
+1. New namespace for some classes (Llvm.NET.Interop)
+1. StaticState class is renamed to Llvm.NET.Interop.Library as it is fundamentally 
+   part of the low level interop (and "StaticState" was always a bad name)
+1. Instructions no longer have a SetDebugLocation, instead that is provided via a new
+   fluent method on the InstructionBuilder since the normal use is to set the location
+   on the builder and then generate a sequence of IR instructions for a given expression
+   in code. 
+1. Legacy JIT engine support is dropped. ORCJit is the only supported JIT engine
+1. Context.CreateBasicBlock() now only creates detached blocks, if append to a function
+   is desired, there is a method on Function to create and append a new block.
+1. Renamed Function to IrFunction to keep from colliding with language keyword
+1. Renamed Select instruction to SelectInstruction to keep from colliding with
+   language keywords.
+1. PassManager, ModulePassManager, and FunctionPassManager are IDisposable to help apps
+   ensure that a function pass manager, which is bound to a module, is destroyed before
+   the module it is bound to.
+1. Shared references for modules and BitcodeModule.MakeShared have been removed.
+   This was created for the OrcJit in LLVM 6, but removed in LLVM 7  
+1. BitCodeModule is now Disposable backed by a safe handle, this allows for detaching and
+   invalidating the underlying LLVMModuleRef when the module is provided to the JIT 
+

--- a/docfx/articles/Samples/Kaleidoscope-ch4.md
+++ b/docfx/articles/Samples/Kaleidoscope-ch4.md
@@ -192,12 +192,21 @@ Dispose() method on the JIT engine.
 
 #### Generate Method
 To actually execute the code the generated modules are added to the JIT. If the function is an 
-anonymous top level expression a delegate is retrieved from the JIT to allow calling the compiled
-function directly. The delegate is then called to get the result. Once an anonymous function produces
+anonymous top level expression, it is eagerly compiled and a delegate is retrieved from the JIT
+to allow calling the compiled function directly. The delegate is then called to get the result. Once an anonymous function produces
 a value, it is no longer used so is removed from the JIT and the result value returned. For other functions
 the module is added to the JIT and the function is returned.
 
-[!code-csharp[Dispose](../../../Samples/Kaleidoscope/Chapter4/CodeGenerator.cs#Generate)]
+For named function definitions, the module is lazy added to the JIT as it isn't known if/when the functions
+is called. The JIT engine will compile modules lazy added into native code on first use. (Though if the
+function is never used, then creating the IR module was wasted. ([Chapter 7.1](Kaleidoscope-ch7.1.md) has a
+solution for even that extra overhead - truly lazy JIT). Since Kaleidoscope is generally a dynamic language
+it is possible and reasonable for the user to re-define a function (to fix an error, or provide a completely
+different implementation all together). Therefore, any named functions are removed from the JIT, if they
+existed, before adding in the new definition. Otherwise the JIT resolver would still resolve to the previously
+compiled instance.
+
+[!code-csharp[Generate](../../../Samples/Kaleidoscope/Chapter4/CodeGenerator.cs#Generate)]
 
 Keeping all the JIT interaction in the generate method isolates the rest of the generation from any
 awareness of the JIT. This will help when adding truly lazy JIT compilation in [Chapter 7.1](Kaleidoscope-ch7.1.md)

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -21,4 +21,12 @@ For more details see the full [API documentation](api/index.md)
   3. Leverage existing LLVM-C APIs underneath whenever possible
      1. Extend only when needed with custom wrappers
   4. FxCop/Code Analysis Clean
-  
+
+## Features
+* LLVM Cross target code generation from .NET code
+* JIT engine support for creating dynamic domain specific language
+  runtimes with full lazy JIT support. (See [Kaleidoscope language tutorial](articles/Samples/Kaleidoscope.md) for more details)
+* Ahead of time compilation with support for Link time optimization
+* Object model that reflects the underlying LLVM classes
+
+[Release Notes](ReleaseNotes.md)

--- a/docfx/toc.yml
+++ b/docfx/toc.yml
@@ -9,4 +9,4 @@
 - name: LLVM.org
   href: http://LLVM.org
 - name: LLVM Docs
-  href: http://releases.llvm.org/6.0.1/docs/index.html
+  href: http://releases.llvm.org/8.0.0/docs/index.html

--- a/src/Interop/InteropTests/OrcJitTests.cs
+++ b/src/Interop/InteropTests/OrcJitTests.cs
@@ -59,13 +59,13 @@ namespace InteropTests
         private static void AddAndExecuteTestModule( LLVMOrcJITStackRef orcJit, LLVMContextRef context, LLVMTargetMachineRef machine, int expectedResult )
         {
             LLVMModuleRef module = CreateModule( context, machine, expectedResult );
-            LLVMErrorRef err = LLVMOrcAddLazilyCompiledIR( orcJit, out ulong jitHandle, module, SymbolResolver, IntPtr.Zero );
+            LLVMErrorRef err = LLVMOrcAddEagerlyCompiledIR( orcJit, out ulong jitHandle, module, SymbolResolver, IntPtr.Zero );
             Assert.IsTrue( err.IsInvalid );
 
             // ORC now owns the module, so it must never be released
-            module = LLVMModuleRef.Zero;
+            module.SetHandleAsInvalid();
             LLVMOrcGetMangledSymbol( orcJit, out string mangledName, "main" );
-            err = LLVMOrcGetSymbolAddress( orcJit, out ulong funcAddress, mangledName );
+            err = LibLLVMOrcGetSymbolAddress( orcJit, out ulong funcAddress, mangledName, false );
             Assert.IsTrue( err.IsInvalid );
             Assert.AreNotEqual( 0ul, funcAddress );
             var callableMain = Marshal.GetDelegateForFunctionPointer<TestMain>( ( IntPtr )funcAddress );

--- a/src/Interop/LibLLVM/LibLLVM.vcxproj
+++ b/src/Interop/LibLLVM/LibLLVM.vcxproj
@@ -189,6 +189,7 @@
     <ClCompile Include="include\libllvm-c\ObjectFileBindings.cpp" />
     <ClCompile Include="InlinedExports.cpp" />
     <ClCompile Include="IRBindings.cpp" />
+    <ClCompile Include="LibLlvmOrcJitBindings.cpp" />
     <ClCompile Include="MetadataBindings.cpp" />
     <ClCompile Include="PassManagerBindings.cpp" />
     <ClCompile Include="ModuleBindings.cpp" />
@@ -213,6 +214,7 @@
     <ClInclude Include="include\libllvm-c\MetadataBindings.h" />
     <ClInclude Include="include\libllvm-c\ModuleBindings.h" />
     <ClInclude Include="include\libllvm-c\ObjectFileBindings.h" />
+    <ClInclude Include="include\libllvm-c\LibLlvmOrcJitBindings.h" />
     <ClInclude Include="include\libllvm-c\PassManagerBindings.h" />
     <ClInclude Include="include\libllvm-c\TripleBindings.h" />
     <ClInclude Include="include\libllvm-c\ValueBindings.h" />

--- a/src/Interop/LibLLVM/LibLLVM.vcxproj.filters
+++ b/src/Interop/LibLLVM/LibLLVM.vcxproj.filters
@@ -58,6 +58,9 @@
     <ClCompile Include="include\libllvm-c\ObjectFileBindings.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="LibLlvmOrcJitBindings.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Resource.rc">
@@ -111,6 +114,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\libllvm-c\ObjectFileBindings.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\libllvm-c\LibLlvmOrcJitBindings.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/Interop/LibLLVM/LibLlvmOrcJitBindings.cpp
+++ b/src/Interop/LibLLVM/LibLlvmOrcJitBindings.cpp
@@ -1,0 +1,42 @@
+#include "libllvm-c\LibLlvmOrcJitBindings.h"
+#include "OrcCBindingsStack.h"
+
+using namespace llvm;
+
+extern "C"
+{
+    LLVMErrorRef LibLLVMOrcGetSymbolAddress( LLVMOrcJITStackRef JITStack,
+                                             LLVMOrcTargetAddress* RetAddr,
+                                             const char* SymbolName,
+                                             LLVMBool ExportedSymbolsOnly )
+    {
+        OrcCBindingsStack& J = *unwrap( JITStack );
+        if ( auto Addr = J.findSymbolAddress( SymbolName, !!ExportedSymbolsOnly ) )
+        {
+            *RetAddr = *Addr;
+            return LLVMErrorSuccess;
+        }
+        else
+        {
+            return wrap( Addr.takeError( ) );
+        }
+    }
+
+    LLVMErrorRef LibLLVMOrcGetSymbolAddressIn( LLVMOrcJITStackRef JITStack,
+                                               LLVMOrcTargetAddress* RetAddr,
+                                               LLVMOrcModuleHandle H,
+                                               const char* SymbolName,
+                                               LLVMBool ExportedSymbolsOnly )
+    {
+        OrcCBindingsStack& J = *unwrap( JITStack );
+        if ( auto Addr = J.findSymbolAddressIn( H, SymbolName, !!ExportedSymbolsOnly ) )
+        {
+            *RetAddr = *Addr;
+            return LLVMErrorSuccess;
+        }
+        else
+        {
+            return wrap( Addr.takeError( ) );
+        }
+    }
+}

--- a/src/Interop/LibLLVM/include/libllvm-c/LibLlvmOrcJitBindings.h
+++ b/src/Interop/LibLLVM/include/libllvm-c/LibLlvmOrcJitBindings.h
@@ -1,0 +1,26 @@
+#ifndef _LIBLLVM_ORCJIT_BINDINGS_H_
+#define _LIBLLVM_ORCJIT_BINDINGS_H_
+
+#include <llvm-c/Core.h>
+#include "llvm-c/OrcBindings.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    LLVMErrorRef LibLLVMOrcGetSymbolAddress( LLVMOrcJITStackRef JITStack,
+                                             LLVMOrcTargetAddress* RetAddr,
+                                             const char* SymbolName,
+                                             LLVMBool ExportedSymbolsOnly );
+
+    LLVMErrorRef LibLLVMOrcGetSymbolAddressIn( LLVMOrcJITStackRef JITStack,
+                                               LLVMOrcTargetAddress* RetAddr,
+                                               LLVMOrcModuleHandle H,
+                                               const char* SymbolName,
+                                               LLVMBool ExportedSymbolsOnly );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/LibLlvmOrcJitBindings.xml
+++ b/src/Interop/Llvm.NET.Interop/ApiDocs/libllvm-c/LibLlvmOrcJitBindings.xml
@@ -1,0 +1,42 @@
+<!--
+;; ==============================================================================
+;; <usage>
+;;     This file contains the Manually edited doc comments info that the
+;;     generated code files refer to. This was originally cloned from the
+;;     'GeneratedDocsFolder' and requires manual update and merging whenever
+;;     the API surface changes. The generated XML is not committed to the repository
+;;     but serves as a useful aid in building the docs for generated code files.
+;; </usage>
+;; ==============================================================================
+-->
+<LibLlvmAPI>
+    <Function name="LibLLVMOrcGetSymbolAddress">
+        <summary>Extended method to get a symbol address from the OrcJit</summary>
+        <param name="JITStack">OrcJit to get the symbol from</param>
+        <param name="RetAddr">Symbol address</param>
+        <param name="SymbolName">Name of the symbol to find</param>
+        <param name="ExportedSymbolsOnly">flag to indicate if search includes only exported symbols</param>
+        <returns>error information</returns>
+        <remarks>
+            This function differs from <see cref="LLVMOrcGetSymbolAddress"/> only in the inclusion of the
+            <paramref name="ExportedSymbolsOnly"/> parameter. This is required when running on Windows
+            based platforms as the object file created by the JIT doesn't have the functions marked as
+            exported, so it won't see the symbol unless ExportedSymbolsOnly is <see langword="false"/>.
+        </remarks>
+    </Function>
+    <Function name="LibLLVMOrcGetSymbolAddressIn">
+        <summary>Extended method to get a symbol address in a specific module from the OrcJit</summary>
+        <param name="JITStack">OrcJit to get the symbol from</param>
+        <param name="RetAddr">Symbol address</param>
+        <param name="H">Handle for the module to search in</param>
+        <param name="SymbolName">Name of the symbol to find</param>
+        <param name="ExportedSymbolsOnly">flag to indicate if search includes only exported symbols</param>
+        <returns>error information</returns>
+        <remarks>
+            This function differs from <see cref="LLVMOrcGetSymbolAddressIn"/> only in the inclusion of the
+            <paramref name="ExportedSymbolsOnly"/> parameter. This is required when running on Windows
+            based platforms as the object file created by the JIT doesn't have the functions marked as
+            exported, so it won't see the symbol unless ExportedSymbolsOnly is <see langword="false"/>.
+        </remarks>
+    </Function>
+</LibLlvmAPI>

--- a/src/Interop/LlvmBindingsGenerator/Program.cs
+++ b/src/Interop/LlvmBindingsGenerator/Program.cs
@@ -317,7 +317,7 @@ namespace LlvmBindingsGenerator
                 {
                     new GlobalHandleTemplate( "LLVMMemoryBufferRef","LLVMDisposeMemoryBuffer" ),
                     new GlobalHandleTemplate( "LLVMContextRef" , "LLVMContextDispose", needsAlias: true ),
-                    new ContextHandleTemplate( "LLVMModuleRef" ),
+                    new GlobalHandleTemplate( "LLVMModuleRef", "LLVMDisposeModule", needsAlias: true ),
                     new ContextHandleTemplate( "LLVMTypeRef" ),
                     new ContextHandleTemplate( "LLVMValueRef" ),
                     new ContextHandleTemplate( "LLVMBasicBlockRef" ),
@@ -379,6 +379,8 @@ namespace LlvmBindingsGenerator
                     "LibLLVMGetNodeContext",
                     "LLVMGetModuleContext",
                     "LLVMGetGlobalContext",
+                    "LLVMGetGlobalParent",
+                    "LibLLVMNamedMetadataGetParentModule",
                     "LLVMGetExecutionEngineTargetMachine",
                     "LLVMGetExecutionEngineTargetData",
                 }

--- a/src/Llvm.NET/BitcodeModule.cs
+++ b/src/Llvm.NET/BitcodeModule.cs
@@ -311,7 +311,7 @@ namespace Llvm.NET
             }
 
             Context.RemoveModule( otherModule );
-            otherModule.ModuleHandle = LLVMModuleRef.Zero;
+            otherModule.Detach().SetHandleAsInvalid();
         }
 
         /// <summary>Verifies a bit-code module</summary>

--- a/src/Llvm.NET/HandleInterningMap.cs
+++ b/src/Llvm.NET/HandleInterningMap.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -15,7 +16,7 @@ namespace Llvm.NET
     {
         public Context Context { get; }
 
-        public TMappedType GetOrCreateItem( THandle handle )
+        public TMappedType GetOrCreateItem( THandle handle, Action<THandle> foundHandleRelease = null )
         {
             if( EqualityComparer<THandle>.Default.Equals( handle, default ) )
             {
@@ -24,11 +25,13 @@ namespace Llvm.NET
 
             if( HandleMap.TryGetValue( handle, out TMappedType retVal ) )
             {
+                foundHandleRelease?.Invoke( handle );
                 return retVal;
             }
 
             retVal = ItemFactory( handle );
             HandleMap.Add( handle, retVal );
+
             return retVal;
         }
 

--- a/src/Llvm.NET/IHandleInterning.cs
+++ b/src/Llvm.NET/IHandleInterning.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 
 // Internal types don't require XML docs, despite settings in stylecop.json the analyzer still
@@ -12,12 +13,12 @@ using System.Collections.Generic;
 
 namespace Llvm.NET
 {
-    internal interface IHandleInterning<in THandle, out TMappedType>
+    internal interface IHandleInterning<THandle, TMappedType>
         : IEnumerable<TMappedType>
     {
         Context Context { get; }
 
-        TMappedType GetOrCreateItem( THandle handle );
+        TMappedType GetOrCreateItem( THandle handle, Action<THandle> foundHandleRelease = null );
 
         void Remove( THandle handle );
 

--- a/src/Llvm.NET/Properties/Resources.Designer.cs
+++ b/src/Llvm.NET/Properties/Resources.Designer.cs
@@ -205,12 +205,30 @@ namespace Llvm.NET.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Basic block already exists in the function.
+        /// </summary>
+        internal static string Block_already_exists_in_function {
+            get {
+                return ResourceManager.GetString("Block_already_exists_in_function", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Call site argument type mismatch for function {0} at index {1}; argType={2}; signatureType={3}.
         /// </summary>
         internal static string Call_site_argument_type_mismatch_for_function_0_at_index_1_argType_equals_2_signatureType_equals_3 {
             get {
                 return ResourceManager.GetString("Call_site_argument_type_mismatch_for_function_0_at_index_1_argType_equals_2_signa" +
                         "tureType_equals_3", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot add a block belonging to a different function.
+        /// </summary>
+        internal static string Cannot_add_a_block_belonging_to_a_different_function {
+            get {
+                return ResourceManager.GetString("Cannot_add_a_block_belonging_to_a_different_function", resourceCulture);
             }
         }
         

--- a/src/Llvm.NET/Properties/Resources.resx
+++ b/src/Llvm.NET/Properties/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -485,9 +485,15 @@ Types are:
     <value>Alignment can only be set for instructions dealing with memory read/write (alloca, load, store)</value>
   </data>
   <data name="Non_pointer_type_expected" xml:space="preserve">
-      <value>Non-pointer type expected</value>
+    <value>Non-pointer type expected</value>
   </data>
   <data name="Cannot_load_a_value_for_an_opaque_or_unsized_type" xml:space="preserve">
-      <value>Cannot load a value for an opaque or unsized type</value>
+    <value>Cannot load a value for an opaque or unsized type</value>
+  </data>
+  <data name="Cannot_add_a_block_belonging_to_a_different_function" xml:space="preserve">
+    <value>Cannot add a block belonging to a different function</value>
+  </data>
+  <data name="Block_already_exists_in_function" xml:space="preserve">
+    <value>Basic block already exists in the function</value>
   </data>
 </root>

--- a/src/Llvm.NET/Transforms/PassManager.cs
+++ b/src/Llvm.NET/Transforms/PassManager.cs
@@ -12,6 +12,7 @@ namespace Llvm.NET.Transforms
 {
     /// <summary>Common base class for pass managers</summary>
     public class PassManager
+        : DisposableObject
     {
         internal PassManager( LLVMPassManagerRef handle )
         {
@@ -19,5 +20,11 @@ namespace Llvm.NET.Transforms
         }
 
         internal LLVMPassManagerRef Handle { get; }
+
+        /// <inheritdoc/>
+        protected override void Dispose( bool disposing )
+        {
+            Handle.Dispose();
+        }
     }
 }

--- a/src/Llvm.NET/Values/BasicBlockCollection.cs
+++ b/src/Llvm.NET/Values/BasicBlockCollection.cs
@@ -9,6 +9,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Llvm.NET.Interop;
+using Llvm.NET.Properties;
 using Ubiquity.ArgValidators;
 
 using static Llvm.NET.Interop.NativeMethods;
@@ -19,7 +20,7 @@ namespace Llvm.NET.Values
         : ICollection<BasicBlock>
     {
         /// <summary>Gets a count of the blocks in the collection</summary>
-        public int Count => checked((int)LLVMCountBasicBlocks( ContainingFunction.ValueHandle ));
+        public int Count => checked(( int )LLVMCountBasicBlocks( ContainingFunction.ValueHandle ));
 
         /// <summary>Add a block to the underlying function</summary>
         /// <param name="item"><see cref="BasicBlock"/> to add to the function</param>
@@ -29,7 +30,18 @@ namespace Llvm.NET.Values
         public void Add( BasicBlock item )
         {
             item.ValidateNotNull( nameof( item ) );
-            LibLLVMFunctionAppendBasicBlock( ContainingFunction.ValueHandle, item.BlockHandle );
+
+            if( item.ContainingFunction == null )
+            {
+                LibLLVMFunctionAppendBasicBlock( ContainingFunction.ValueHandle, item.BlockHandle );
+            }
+
+            if( item.ContainingFunction != ContainingFunction )
+            {
+                throw new ArgumentException( Resources.Cannot_add_a_block_belonging_to_a_different_function, nameof( item ) );
+            }
+
+            throw new ArgumentException( Resources.Block_already_exists_in_function, nameof( item ) );
         }
 
         /// <inheritdoc/>
@@ -68,7 +80,7 @@ namespace Llvm.NET.Values
                 throw new ArgumentOutOfRangeException( nameof( arrayIndex ) );
             }
 
-            foreach(var block in this)
+            foreach( var block in this )
             {
                 array[ arrayIndex++ ] = block;
             }

--- a/src/Llvm.NET/Values/ValueCache.cs
+++ b/src/Llvm.NET/Values/ValueCache.cs
@@ -18,17 +18,19 @@ using static Llvm.NET.Interop.NativeMethods;
 
 namespace Llvm.NET.Values
 {
+    [SuppressMessage( "Maintainability", "CA1506:Avoid excessive class coupling", Justification = "Interop projection factory" )]
     internal class ValueCache
         : DisposableObject
         , IHandleInterning<LLVMValueRef, Value>
     {
         public Context Context { get; }
 
-        public Value GetOrCreateItem( LLVMValueRef valueRef )
+        public Value GetOrCreateItem( LLVMValueRef valueRef, Action<LLVMValueRef> foundHandleRelease = null )
         {
             IntPtr managedHandlePtr = LibLLVMValueCacheLookup( Handle, valueRef );
             if( managedHandlePtr != IntPtr.Zero )
             {
+                foundHandleRelease?.Invoke( valueRef );
                 return (Value)GCHandle.FromIntPtr( managedHandlePtr ).Target;
             }
 

--- a/src/Llvm.NETTests/ModuleFixtures.cs
+++ b/src/Llvm.NETTests/ModuleFixtures.cs
@@ -20,6 +20,8 @@ namespace Llvm.NETTests
         [AssemblyInitialize]
         public static void AssemblyInitialize( TestContext ctx )
         {
+            TestContext = ctx;
+            TestContext.WriteLine( "Initializing LLVM" );
             if( ctx == null )
             {
                 throw new ArgumentNullException( nameof( ctx ) );
@@ -30,8 +32,13 @@ namespace Llvm.NETTests
         }
 
         [AssemblyCleanup]
-        public static void AssemblyCleanup( ) => LlvmInit.Dispose( );
+        public static void AssemblyCleanup( )
+        {
+            TestContext.WriteLine( "Shutting down LLVM" );
+            LlvmInit.Dispose( );
+        }
 
+        private static TestContext TestContext;
         private static IDisposable LlvmInit;
     }
 }

--- a/src/Llvm.NETTests/ModuleFixtures.cs
+++ b/src/Llvm.NETTests/ModuleFixtures.cs
@@ -20,8 +20,6 @@ namespace Llvm.NETTests
         [AssemblyInitialize]
         public static void AssemblyInitialize( TestContext ctx )
         {
-            TestContext = ctx;
-            TestContext.WriteLine( "Initializing LLVM" );
             if( ctx == null )
             {
                 throw new ArgumentNullException( nameof( ctx ) );
@@ -34,11 +32,9 @@ namespace Llvm.NETTests
         [AssemblyCleanup]
         public static void AssemblyCleanup( )
         {
-            TestContext.WriteLine( "Shutting down LLVM" );
             LlvmInit.Dispose( );
         }
 
-        private static TestContext TestContext;
         private static IDisposable LlvmInit;
     }
 }

--- a/src/Llvm.NETTests/OrcJitTests.cs
+++ b/src/Llvm.NETTests/OrcJitTests.cs
@@ -1,0 +1,80 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="OrcJitTests.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Llvm.NET.Instructions;
+using Llvm.NET.Interop;
+using Llvm.NET.JIT;
+using Llvm.NET.Values;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Llvm.NET.Tests
+{
+    [TestClass]
+    public class OrcJitTests
+    {
+        [TestMethod]
+        public void TestEagerIRCompilation()
+        {
+            Library.RegisterNative( );
+            using(var ctx = new Context())
+            {
+                var nativeTriple = Triple.HostTriple;
+                var target = Target.FromTriple( nativeTriple );
+                var machine = target.CreateTargetMachine( nativeTriple );
+                using( var orcJit = new OrcJit(machine))
+                {
+                    using( var lazyModule = CreateModule( ctx, machine, 10101010, "lazy1", "lazy1" ) )
+                    {
+                        orcJit.AddLazyCompiledModule( lazyModule );
+                    }
+
+                    using( var lazyModule = CreateModule( ctx, machine, 20202020, "lazy2", "lazy2" ) )
+                    {
+                        orcJit.AddLazyCompiledModule( lazyModule );
+                    }
+
+                    // try several different modules with the same function name replacing the previous
+                    using( var module = CreateModule(ctx, orcJit.TargetMachine, 42 ) )
+                    {
+                        AddAndExecuteTestModule(orcJit, module, 42 );
+                    }
+
+                    using( var module = CreateModule( ctx, orcJit.TargetMachine, 12345678 ) )
+                    {
+                        AddAndExecuteTestModule( orcJit, module, 12345678 );
+                    }
+
+                    using( var module = CreateModule( ctx, orcJit.TargetMachine, 87654321 ) )
+                    {
+                        AddAndExecuteTestModule( orcJit, module, 87654321 );
+                    }
+                }
+            }
+        }
+
+        private void AddAndExecuteTestModule( OrcJit orcJit, BitcodeModule module, int magicNumber )
+        {
+            ulong orcHandle = orcJit.AddEagerlyCompiledModule( module );
+            var main = orcJit.GetFunctionDelegate<TestMain>("main");
+            Assert.IsNotNull( main );
+            Assert.AreEqual( magicNumber, main( ) );
+            orcJit.RemoveModule( orcHandle );
+        }
+
+        private static BitcodeModule CreateModule(Context ctx, TargetMachine machine, int magicNumber, string modulename ="test", string functionname="main")
+        {
+            var module = ctx.CreateBitcodeModule(modulename);
+            module.Layout = machine.TargetData;
+            IrFunction main = module.AddFunction( functionname, ctx.GetFunctionType( ctx.Int32Type ) );
+            BasicBlock entryBlock = main.AppendBasicBlock("entry");
+            var bldr = new InstructionBuilder(entryBlock);
+            bldr.Return( ctx.CreateConstant( magicNumber ) );
+            return module;
+        }
+
+        private delegate int TestMain( );
+    }
+}


### PR DESCRIPTION
- moved BitcodeModule to a global handle so that it can be invalidated when provided to the JIT, since OrcJit ownership transfer model was changed from a shared_ptr internally, the ownership semantics are an explicit transfer (e.g. move). Therefore invalidating the handle is important.
- Fixed latent bug in code generation for conditionals that would crash on cleanup. LLVM JIT will crash with a verifiable, but malformed module that has extraneous blocks added to a function
- Added Release notes