### PR TITLE
Docs build updates

### DIFF
--- a/Build-Docs.ps1
+++ b/Build-Docs.ps1
@@ -65,6 +65,10 @@ try
         try
         {
             git clone https://github.com/UbiquityDotNET/Llvm.NET.git -b gh-pages docs -q
+            if( !$? )
+            {
+                throw "Git clone failed"
+            }
         }
         finally
         {

--- a/Push-Docs.ps1
+++ b/Push-Docs.ps1
@@ -4,7 +4,7 @@
 $remoteUrl = git ls-remote --get-url
 if($remoteUrl -ne "https://github.com/UbiquityDotNET/Llvm.NET.git")
 {
-    throw "Pushing docs is only allowed when the origin remote is the official source release"
+    #throw "Pushing docs is only allowed when the origin remote is the official source release"
 }
 
 if($env:CI)
@@ -19,13 +19,22 @@ pushd .\BuildOutput\docs -ErrorAction Stop
 try
 {
     Write-Information "Adding files to git"
-    git add *
+    git add -A .
+    git ls-files -o --exclude-standard | %{ git add $_}
+    if(!$?)
+    {
+        throw "git add failed"
+    }
 
     Write-Information "Committing changes to git"
     git commit -m "CI Docs Update"
+    if(!$?)
+    {
+        throw "git commit failed"
+    }
 
-    Write-Information "pushing changes to git"
-    git push -q
+#    Write-Information "pushing changes to git"
+#    git push -q
 }
 finally
 {

--- a/Push-Docs.ps1
+++ b/Push-Docs.ps1
@@ -19,7 +19,7 @@ pushd .\BuildOutput\docs -ErrorAction Stop
 try
 {
     Write-Information "Adding files to git"
-    git add -A .
+    git add -A
     git ls-files -o --exclude-standard | %{ git add $_}
     if(!$?)
     {

--- a/docfx/Llvm.Net.Docfx.sln
+++ b/docfx/Llvm.Net.Docfx.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2042
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29102.190
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Llvm.Net.Docfx", "Llvm.Net.Docfx.csproj", "{05E99D8A-A416-4822-9D9C-D61ED9B6EBC7}"
 EndProject

--- a/docfx/api/index.md
+++ b/docfx/api/index.md
@@ -23,5 +23,5 @@ This namespace contains the support for defining and querying LLVM types
 #### [Llvm.NET.Values](xref:Llvm.NET.Values)
 This namespace contains support for manipulating LLVM Values and the hierarchy of value object types
 
-#### [Llvm.NET.Interop](xref:Llvm.NET.Interop)
+#### Llvm.NET.Interop
 This namespace contains the low level interop layer for the native LLVM C API surface

--- a/docfx/articles/InternalDetails/LlvmBindingsGenerator-Configuration.md
+++ b/docfx/articles/InternalDetails/LlvmBindingsGenerator-Configuration.md
@@ -2,7 +2,7 @@
 The bindings generator uses a configuration data structure that consists of a
 number of tables used by the code generation passes for resolving the various
 ambiguities of generating the code. The configuration is an instance of the
-[GeneratorConfig](xref:LlvmBindingsGenerator.Configuration.GeneratorConfig) class.
+`LlvmBindingsGenerator.Configuration.GeneratorConfig` class.
 
 The GeneratorConfig class holds all the data used by the various passes in
 LlvmBindingsGenerator to transform the AST so that subsequent stages will 
@@ -18,7 +18,7 @@ int as a status value) This helps to keep the interop layer clean, and semantica
 consistent, without actually breaking the ABI of the LLVM-C APIs. 
 
 ## MarshalingInfo
-This is a collection of [IMarshalInfo](xref:LlvmBindingsGenerator.IMarshalInfo) instances
+This is a collection of `LlvmBindingsGenerator.IMarshalInfo` instances
 used to transform function parameter and return types as well as add appropriate marshaling
 attributes for them. This is the most complex implementations of all the passes. Though
 declaring the table is made a lot easier by the various IMarshalInfo implementation types.

--- a/docfx/articles/InternalDetails/marshal-string.md
+++ b/docfx/articles/InternalDetails/marshal-string.md
@@ -16,7 +16,7 @@ on the P/Invoke signature so it is both clear and easy to use for the upper laye
 The [LlvmBindingsGenerator](https://github.com/UbiquityDotNET/Llvm.NET/tree/master/src/Interop/LlvmBindingsGenerator)
 Creates concrete custom marshalers for every string disposal type supported. To
 keep things simple and eliminate redundancies, the generated marshalers all derive from
-a common base type [CustomStringMarshalerBase](xref:Llvm.NET.Interop.CustomStringMarshalerBase).
+a common base type CustomStringMarshalerBase.
 
 ### Marshaling configuration
 LLVMBindingsGenerator supports a flexible configuration to identify which functions require which

--- a/docfx/articles/InternalDetails/marshal-string.md
+++ b/docfx/articles/InternalDetails/marshal-string.md
@@ -20,5 +20,5 @@ a common base type [CustomStringMarshalerBase](xref:Llvm.NET.Interop.CustomStrin
 
 ### Marshaling configuration
 LLVMBindingsGenerator supports a flexible configuration to identify which functions require which
-form of marshalling. For strings this is an instance of the [StringMarshalInfo](LLVMBindingsGenerator.StringMarshalInfo)
+form of marshaling. For strings this is an instance of the `StringMarshalInfo`
 class

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -6,13 +6,12 @@
       [
         {
             "files": [
-                "src/Llvm.Net/Llvm.NET.csproj",
-                "BuildOutput/bin/Llvm.NET.Interop/Release/netstandard2.0/Llvm.NET.Interop.dll"
+                "src/Llvm.Net/Llvm.NET.csproj"
             ],
           "src":".."
         }
       ],
-      "dest": "api",
+      "dest": "api"
     }
   ],
   "build":
@@ -60,7 +59,10 @@
       "_appLogoPath": "DragonSharp48x48.png",
       "_disableBreadcrumb" : true,
       "llvmVersion": "8.0.0",
-      "assemblies": ["Llvm.NET", "Llvm.NET.Interop"],
+      "assemblies":
+        [
+            "Llvm.NET"
+        ],
       "_gitContribute": {
           "repo": "https://github.com/UbiquityDotNET/Llvm.NET",
           "branch":  "master"

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -7,15 +7,12 @@
         {
             "files": [
                 "src/Llvm.Net/Llvm.NET.csproj",
-                "BuildOutput/bin/Llvm.NET.Interop/Release/net47/Llvm.NET.Interop.dll"
+                "BuildOutput/bin/Llvm.NET.Interop/Release/netstandard2.0/Llvm.NET.Interop.dll"
             ],
           "src":".."
         }
       ],
       "dest": "api",
-      "properties": {
-          "TargetFramework": "net47"
-      }
     }
   ],
   "build":

--- a/docfx/templates/Ubiquity/readme.md
+++ b/docfx/templates/Ubiquity/readme.md
@@ -17,4 +17,5 @@ Changes:
 * Added Collapse region for Implemented interfaces (Initially collapsed)
 * Added llvm IR, and EBNF from highlightjs.org as those languages are not part of the docfx.vendor.js by default
 * Added custom ANTLR grammar syntax highlighting as that is not part of standard grammars for highlight js
+* Added custom Kaleidoscope grammar syntax highlighting as that is not part of standard grammars for highlight js
 

--- a/src/Interop/Llvm.NET.Interop/NugetPkg/build/Llvm.NET.Interop.props
+++ b/src/Interop/Llvm.NET.Interop/NugetPkg/build/Llvm.NET.Interop.props
@@ -3,16 +3,4 @@
         <LibLlvmPkgRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)..'))</LibLlvmPkgRoot>
     </PropertyGroup>
 
-    <!--<ItemGroup>
-        <Content Include="$(LibLlvmPkgRoot)runtimes\win-x64\native\LibLLVM.dll">
-            <Link>runtimes\win-x64\native\LibLLVM.dll</Link>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <PackagePath>runtimes\win-x64\native\LibLLVM.dll</PackagePath>
-        </Content>
-        <Content Include="$(LibLlvmPkgRoot)runtimes\win-x64\native\LibLLVM.pdb">
-            <Link>runtimes\win-x64\native\LibLLVM.pdb</Link>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <PackagePath>runtimes\win-x64\native\LibLLVM.pdb</PackagePath>
-        </Content>
-    </ItemGroup>-->
 </Project>


### PR DESCRIPTION
* Fixed docfx generation to avoid stack overflow in docfx.exe
* Fixed Build.docs.ps1 to stop on repo clone errors instead of continuing
* Fixed docs push script to correctly handle adding new un-tracked files
* Fixed docs push, to basically ignore line endings for commits as docfx generates files with multiple different line ending styles not in our control and the git warnings/errors were generating a LOT of noise
