### PR TITLE
Moved binlogs to a distinct directory and updated docs push

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -23,12 +23,11 @@ jobs:
         run: .\Build-All.ps1
 
       - name: Publish build logs
-        if: always() #&& github.event_name == 'pull_request'
-        run: dir .\BuildOutput\Nuget
-#        uses: actions/upload-artifact@v1
-#        with:
-#            name: Build Logs
-#            path: .\BuildOutput\*.binlog
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v1
+        with:
+            name: Build Logs
+            path: .\BuildOutput\BinLogs
 
       - name: Publish Artifacts
         uses: actions/upload-artifact@v1
@@ -40,4 +39,4 @@ jobs:
         if: success() && github.event_name == 'push'
         env:
           docspush_access_token: ${{secrets.docspush_access_token}}
-        run: .\Publish-Docs.ps1
+        run: .\Push-Docs.ps1

--- a/Build-All.ps1
+++ b/Build-All.ps1
@@ -73,8 +73,7 @@ try
 
     if( $env:APPVEYOR_PULL_REQUEST_NUMBER )
     {
-        $binLogs = join-path $buildPaths.BuildOutputPath '*.binlog'
-        Get-ChildItem  -Filter *.binlog (Join-Path $buildPaths.BuildOutputPath '*.binlog') | %{ Push-AppveyorArtifact $_.FullName }
+        Get-ChildItem  -Filter *.binlog $buildPaths.BinLogsPath | %{ Push-AppveyorArtifact $_.FullName }
     }
     dir $buildPaths.BuildOutputPath
 }

--- a/Build-Docs.ps1
+++ b/Build-Docs.ps1
@@ -76,8 +76,8 @@ try
         }
     }
 
-    $docfxRestoreBinLogPath = Join-Path $buildPaths.BuildOutputPath Llvm.NET-docfx-Build.restore.binlog
-    $docfxBinLogPath = Join-Path $buildPaths.BuildOutputPath Llvm.NET-docfx-Build.binlog
+    $docfxRestoreBinLogPath = Join-Path $buildPaths.BinLogsPath Llvm.NET-docfx-Build.restore.binlog
+    $docfxBinLogPath = Join-Path $buildPaths.BinLogsPath Llvm.NET-docfx-Build.binlog
 
     # DocFX.console build support is peculiar and a bit fragile, It requires a separate restore path or it won't do anything for the build target.
     Write-Information "Restoring Docs Project"

--- a/Build-Interop.ps1
+++ b/Build-Interop.ps1
@@ -107,8 +107,8 @@ try
         Invoke-MSBuild -Targets 'Build' -Project 'src\Interop\LibLLVM\LibLLVM.vcxproj' -Properties $msBuildProperties -LoggerArgs ($msbuildLoggerArgs + @("/bl:LibLLVM.binlog") )
 
         Write-Information "Building Lllvm.NET.Interop"
-        $interopRestoreBinLogPath = Join-Path $buildPaths.BuildOutputPath Llvm.NET.Interop-restore.binlog
-        $interopBinLog = Join-Path $buildPaths.BuildOutputPath Llvm.NET.Interop.binlog
+        $interopRestoreBinLogPath = Join-Path $buildPaths.BinLogsPath Llvm.NET.Interop-restore.binlog
+        $interopBinLog = Join-Path $buildPaths.BinLogsPath Llvm.NET.Interop.binlog
         Invoke-MSBuild -Targets 'Restore' -Project 'src\Interop\Llvm.NET.Interop\Llvm.NET.Interop.csproj' -Properties $msBuildProperties -LoggerArgs ($msbuildLoggerArgs + @("/bl:$InteropRestoreBinLogPath") )
         Invoke-MSBuild -Targets 'Build' -Project 'src\Interop\Llvm.NET.Interop\Llvm.NET.Interop.csproj' -Properties $msBuildProperties -LoggerArgs ($msbuildLoggerArgs + @("/bl:$interopBinLog") )
     }

--- a/Build-Source.ps1
+++ b/Build-Source.ps1
@@ -78,7 +78,7 @@ try
 
     .\Build-Interop.ps1 -BuildInfo $BuildInfo
 
-    $buildLogPath = Join-Path $buildPaths.BuildOutputPath Llvm.NET.binlog
+    $buildLogPath = Join-Path $buildPaths.BinLogsPath Llvm.NET.binlog
     Write-Information "Restoring NuGet Packages for Llvm.NET"
     Invoke-MSBuild -Targets 'Restore;Build' -Project src\Llvm.NET.sln -Properties $msBuildProperties -LoggerArgs ($msbuildLoggerArgs + @("/bl:$buildLogPath") )
 }

--- a/Push-Docs.ps1
+++ b/Push-Docs.ps1
@@ -11,17 +11,21 @@ if($remoteUrl -ne "https://github.com/UbiquityDotNET/Llvm.NET.git")
     throw "Pushing docs is only allowed when the origin remote is the official source release"
 }
 
-if($env:IsAutmoatedBuild -and ($env:IsPullRequestBuild -ieq 'false'))
+$canPush = $env:IsAutmoatedBuild -and ($env:IsPullRequestBuild -ieq 'false')
+if(!$canPush)
 {
-    git config --global credential.helper store
-    Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:docspush_access_token):x-oauth-basic@github.com`n"
-    git config --global user.email "$env:docspush_email"
-    git config --global user.name "$env:docspush_username"
+    Write-Information "Skipping Docs PUSH as this is not an official build"
+    return;
 }
 
 pushd .\BuildOutput\docs -ErrorAction Stop
 try
 {
+    git config --global credential.helper store
+    Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:docspush_access_token):x-oauth-basic@github.com`n"
+    git config --global user.email "$env:docspush_email"
+    git config --global user.name "$env:docspush_username"
+
     Write-Information "Adding files to git"
     git add -A
     git ls-files -o --exclude-standard | %{ git add $_}
@@ -37,8 +41,8 @@ try
         throw "git commit failed"
     }
 
-#    Write-Information "pushing changes to git"
-#    git push -q
+    Write-Information "pushing changes to git"
+    git push -q
 }
 finally
 {

--- a/buildutils.ps1
+++ b/buildutils.ps1
@@ -220,6 +220,7 @@ function Get-BuildPaths([string]$repoRoot)
     $buildPaths.BuildExtensionsRoot = ([IO.Path]::Combine( $repoRoot, 'BuildExtensions') )
     $buildPaths.GenerateVersionProj = ([IO.Path]::Combine( $buildPaths.BuildExtensionsRoot, 'CommonVersion.csproj') )
     $buildPaths.DocsOutput = ([IO.Path]::Combine( $buildPaths.BuildOutputPath, 'docs') )
+    $buildPaths.BinLogsPath = Normalize-Path (Join-Path $buildPaths.BuildOutputPath 'BinLogs')
     return $buildPaths
 }
 


### PR DESCRIPTION
Due to a lack of [WildCard](https://github.com/actions/upload-artifact/issues/11) support in the upload-artifact action the only way to get the files uploaded is to use a seperate folder for the logs. :(

Modified Push-Docs to actually push and to simply bail out under unsupported conditions.