### PR TITLE
Split credentials set to allow for more detailed logs of push failures

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -36,10 +36,11 @@ jobs:
             path: .\BuildOutput\Nuget
 
       - name: Set Docs Push Credentials
-        if: success() && github.event_name == 'push'
+        if: github.event_name == 'push'
         env:
           docspush_access_token: ${{secrets.docspush_access_token}}
         run: .\Set-PushCredentials.ps1
 
       - name: Publish Docs
+        if: github.event_name == 'push'
         run: .\Push-Docs.ps1

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -35,8 +35,11 @@ jobs:
             name: Nuget Packages
             path: .\BuildOutput\Nuget
 
-      - name: Publish Docs
+      - name: Set Docs Push Credentials
         if: success() && github.event_name == 'push'
         env:
           docspush_access_token: ${{secrets.docspush_access_token}}
+        run: .\Set-PushCredentials.ps1
+
+      - name: Publish Docs
         run: .\Push-Docs.ps1

--- a/Build-All.ps1
+++ b/Build-All.ps1
@@ -58,6 +58,7 @@ try
     # AppVeyor specific artifact push. (Should be part of YML so scripts are build infra neutral...)
     if( $env:APPVEYOR_PULL_REQUEST_NUMBER )
     {
+        Write-Information "Uploading BINLOG artifacts"
         Get-ChildItem  -Filter *.binlog $buildPaths.BinLogsPath | %{ Push-AppveyorArtifact $_.FullName }
     }
 }
@@ -66,3 +67,5 @@ finally
     popd
     $env:Path = $oldPath
 }
+
+Write-Information "Build finished"

--- a/Build-All.ps1
+++ b/Build-All.ps1
@@ -39,6 +39,11 @@ try
     md $buildPaths.NuGetOutputPath -ErrorAction SilentlyContinue| Out-Null
 
     $BuildInfo = Get-BuildInformation $buildPaths
+    if($env:APPVEYOR)
+    {
+        Write-Information "Updating APPVEYOR version: $($BuildInfo.FullBuildNumber)"
+        Update-AppVeyorBuild -Version "$($BuildInfo.FullBuildNumber) [$([DateTime]::Now)]"
+    }
 
     if($BuildSource)
     {

--- a/Build-Docs.ps1
+++ b/Build-Docs.ps1
@@ -77,6 +77,7 @@ try
 
             Write-Information "Committing changes to git"
             git commit --allow-empty -m "CI Docs Update"
+            Write-Information "git commit exit code: $LASTEXITCODE"
             if($LASTEXITCODE -ne 0)
             {
                 throw "git commit failed: Exit code $LASTEXITCODE"

--- a/Build-Docs.ps1
+++ b/Build-Docs.ps1
@@ -67,21 +67,15 @@ try
         pushd $buildPaths.DocsOutput
         try
         {
+            # Best effort, on git commands as they can return non-zero even if
+            # nothing is wrong.
+            $ErrorActionPreference = Continue
             Write-Information "Adding files to git"
             git add -A
             git ls-files -o --exclude-standard | %{ git add $_}
-            if($LASTEXITCODE -ne 0)
-            {
-                throw "git add failed"
-            }
 
             Write-Information "Committing changes to git"
             git commit --allow-empty -m "CI Docs Update"
-            Write-Information "git commit exit code: $LASTEXITCODE"
-            if($LASTEXITCODE -ne 0)
-            {
-                throw "git commit failed: Exit code $LASTEXITCODE"
-            }
         }
         finally
         {

--- a/Build-Docs.ps1
+++ b/Build-Docs.ps1
@@ -70,16 +70,16 @@ try
             Write-Information "Adding files to git"
             git add -A
             git ls-files -o --exclude-standard | %{ git add $_}
-            if(!$?)
+            if($LASTEXITCODE -ne 0)
             {
                 throw "git add failed"
             }
 
             Write-Information "Committing changes to git"
-            git commit -m "CI Docs Update"
-            if(!$?)
+            git commit --allow-empty -m "CI Docs Update"
+            if($LASTEXITCODE -ne 0)
             {
-                throw "git commit failed"
+                throw "git commit failed: Exit code $LASTEXITCODE"
             }
         }
         finally

--- a/Build-Docs.ps1
+++ b/Build-Docs.ps1
@@ -87,6 +87,8 @@ try
             popd
         }
     }
+
+    Write-Information "Finished building docs"
 }
 finally
 {

--- a/Build-Interop.ps1
+++ b/Build-Interop.ps1
@@ -51,10 +51,6 @@ try
     if(!$BuildInfo)
     {
         $BuildInfo = Get-BuildInformation $buildPaths
-        if($env:APPVEYOR)
-        {
-            Update-AppVeyorBuild -Version $BuildInfo.FullBuildNumber
-        }
     }
 
     $msBuildProperties = @{ Configuration = $Configuration

--- a/Build-Source.ps1
+++ b/Build-Source.ps1
@@ -23,12 +23,6 @@ try
         $BuildInfo = Get-BuildInformation $buildPaths
     }
 
-    if($env:APPVEYOR)
-    {
-        Write-Information "Updating APPVEYOR version: $($BuildInfo.FullBuildNumber)"
-        Update-AppVeyorBuild -Version "$($BuildInfo.FullBuildNumber) [$([DateTime]::Now)]"
-    }
-
     $packProperties = @{ version=$($BuildInfo.PackageVersion)
                          llvmversion=$($BuildInfo.LlvmVersion)
                          buildbinoutput=(normalize-path (Join-path $($buildPaths.BuildOutputPath) 'bin'))

--- a/Invoke-UnitTests.ps1
+++ b/Invoke-UnitTests.ps1
@@ -31,15 +31,24 @@ if($env:APPVEYOR)
 {
     Add-AppVeyorTest -Name 'CodeGenWithDebugInfo (CoreCLR)' -Framework 'CORECLR' -FileName 'CodeGenWithDebugInfo.exe' -Outcome Running
 }
+
 pushd (Join-path $buildPaths.BuildOutputPath bin\CodeGenWithDebugInfo\Release\netcoreapp3.1)
-dotnet CodeGenWithDebugInfo.dll M3 'Support Files\test.c' $buildPaths.TestResultsPath
-$testsFailed = $testsFailed -or ($LASTEXITCODE -ne 0)
-$outcome = @('Passed','Failed')[($LASTEXITCODE -eq 0)]
-if($env:APPVEYOR)
+try
 {
-    Update-AppVeyorTest -Name 'CodeGenWithDebugInfo (CoreCLR)' -Framework 'CORECLR' -FileName 'CodeGenWithDebugInfo.exe' -Outcome $outcome
+    dotnet CodeGenWithDebugInfo.dll M3 'Support Files\test.c' $buildPaths.TestResultsPath
+    $testsFailed = $testsFailed -or ($LASTEXITCODE -ne 0)
+    $outcome = @('Failed','Passed')[($LASTEXITCODE -eq 0)]
+
+    Write-Information "CodeGenWithDebugInfo (CoreCLR) - $outcome"
+    if($env:APPVEYOR)
+    {
+        Update-AppVeyorTest -Name 'CodeGenWithDebugInfo (CoreCLR)' -Framework 'CORECLR' -FileName 'CodeGenWithDebugInfo.exe' -Outcome $outcome
+    }
 }
-popd
+finally
+{
+    popd
+}
 
 if($testsFailed)
 {

--- a/Push-Docs.ps1
+++ b/Push-Docs.ps1
@@ -4,7 +4,7 @@ Initialize-BuildEnvironment
 
 Write-Information "Preparing to PUSH updated docs to GitHub IO"
 
-$canPush = $env:IsAutomatedBuild -and ($env:IsPullRequestBuild -ieq 'false')
+$canPush = $IsAutomatedBuild -and !$IsPullRequestBuild
 if(!$canPush)
 {
     Write-Information "Skipping Docs PUSH as this is not an official build"
@@ -15,10 +15,7 @@ if(!$canPush)
 # This ensures that the links to source in the generated docs will have the correct URLs
 # (e.g. docs pushed to the official repository MUST not have links to source in some private fork)
 $remoteUrl = git ls-remote --get-url
-
-Write-Information "Remote URL: $remoteUrl"
-
-if($remoteUrl -ne "https://github.com/UbiquityDotNET/Llvm.NET")
+if($remoteUrl -ine "https://github.com/UbiquityDotNET/Llvm.NET.git")
 {
     throw "Pushing docs is only allowed when the origin remote is the official source release current remote is '$remoteUrl'"
 }
@@ -26,26 +23,6 @@ if($remoteUrl -ne "https://github.com/UbiquityDotNET/Llvm.NET")
 pushd .\BuildOutput\docs -ErrorAction Stop
 try
 {
-    git config --global credential.helper store
-    Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:docspush_access_token):x-oauth-basic@github.com`n"
-    git config --global user.email "$env:docspush_email"
-    git config --global user.name "$env:docspush_username"
-
-    Write-Information "Adding files to git"
-    git add -A
-    git ls-files -o --exclude-standard | %{ git add $_}
-    if(!$?)
-    {
-        throw "git add failed"
-    }
-
-    Write-Information "Committing changes to git"
-    git commit -m "CI Docs Update"
-    if(!$?)
-    {
-        throw "git commit failed"
-    }
-
     Write-Information "pushing changes to git"
     git push -q
 }

--- a/Push-Docs.ps1
+++ b/Push-Docs.ps1
@@ -15,7 +15,7 @@ if(!$canPush)
 # This ensures that the links to source in the generated docs will have the correct URLs
 # (e.g. docs pushed to the official repository MUST not have links to source in some private fork)
 $remoteUrl = git ls-remote --get-url
-if($remoteUrl -ine "https://github.com/UbiquityDotNET/Llvm.NET.git")
+if(!($remoteUrl -like 'https://github.com/UbiquityDotNET/Llvm.NET*'))
 {
     throw "Pushing docs is only allowed when the origin remote is the official source release current remote is '$remoteUrl'"
 }

--- a/Set-PushCredentials.ps1
+++ b/Set-PushCredentials.ps1
@@ -1,0 +1,11 @@
+. .\buildutils.ps1
+
+Initialize-BuildEnvironment
+
+if( $IsAutomatedBuild -and !$IsPullRequestBuild )
+{
+    git config --global credential.helper store
+    Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:docspush_access_token):x-oauth-basic@github.com`n"
+    git config --global user.email "$env:docspush_email"
+    git config --global user.name "$env:docspush_username"
+}

--- a/buildutils.ps1
+++ b/buildutils.ps1
@@ -372,6 +372,8 @@ function Initialize-BuildEnvironment
     $env:IsReleaseBuild = $global:IsReleaseBuild
 
     Write-Information (dir env:Is* | Format-Table -Property Name, value | Out-String)
+    Write-Information (dir env:GITHUB* | Format-Table -Property Name, value | Out-String)
+    Write-Information (dir env:APPVEYOR* | Format-Table -Property Name, value | Out-String)
 
     $msbuild = Find-MSBuild
     if( !$msbuild )

--- a/buildutils.ps1
+++ b/buildutils.ps1
@@ -345,24 +345,26 @@ function Initialize-BuildEnvironment
     [cmdletbinding()]
     Param()
 
-    $global:IsAutomatedBuild = [System.Convert]::ToBoolean($env:IsAutomatedBuild)
-    $global:IsPullRequestBuild = [System.Convert]::ToBoolean($env:IsPullRequestBuild)
-    $global:IsReleaseBuild = [System.Convert]::ToBoolean($env:IsReleaseBuild)
-
     # IsAutomatedBuild is the top level gate (e.g. if it is false, all the others must be false)
-    $global:IsAutomatedBuild = $IsAutomatedBuild `
+    $global:IsAutomatedBuild = [System.Convert]::ToBoolean($env:IsAutomatedBuild) `
                                -or $env:CI `
                                -or $env:APPVEYOR `
                                -or $env:GITHUB_ACTIONS
 
-    $global:IsPullRequestBuild = $IsAutomatedBuild `
-                                 -and ( $IsPullRequestBuild `
-                                        -or ( ($env:GITHUB_ACTIONS -and $env:GITHUB_BASE_REF) `
-                                              -or $env:APPVEYOR_PULL_REQUEST_NUMBER ) )
+    # IsPullRequestBuild indicates an automated buddy build and should not be trusted
+    $global:IsPullRequestBuild = [System.Convert]::ToBoolean($env:IsPullRequestBuild)
+    if(!$IsPullRequestBuild -and $IsAutomatedBuild)
+    {
+        $IsPullRequestBuild = ($env:GITHUB_ACTIONS -and $env:GITHUB_BASE_REF) `
+                              -or $env:APPVEYOR_PULL_REQUEST_NUMBER
+    }
 
-    # TODO: Determine how to detect release tag builds with GITHUB ACTIONS
-    $global:IsReleaseBuild = $IsAutomatedBuild `
-                             -and ($IsReleaseBuildBuild -or ($env:APPVEYOR_REPO_TAG -and !$IsPullRequestBuild ) )
+    $global:IsReleaseBuild = [System.Convert]::ToBoolean($env:IsReleaseBuild)
+    if(!$IsReleaseBuild -and $IsAutomatedBuild -and !$IsPullRequestBuild)
+    {
+        # TODO: Determine how to detect release tag builds with GITHUB ACTIONS
+        $IsReleaseBuild = $env:APPVEYOR_REPO_TAG
+    }
 
     # set/reset environment vars for non-script tools (i.e. msbuild.exe)
     # Script code should ALWAYS use the globals as they don't require conversion to bool

--- a/buildutils.ps1
+++ b/buildutils.ps1
@@ -355,8 +355,7 @@ function Initialize-BuildEnvironment
     $global:IsPullRequestBuild = [System.Convert]::ToBoolean($env:IsPullRequestBuild)
     if(!$IsPullRequestBuild -and $IsAutomatedBuild)
     {
-        $IsPullRequestBuild = ($env:GITHUB_ACTIONS -and $env:GITHUB_BASE_REF) `
-                              -or $env:APPVEYOR_PULL_REQUEST_NUMBER
+        $IsPullRequestBuild = $env:GITHUB_BASE_REF -or $env:APPVEYOR_PULL_REQUEST_NUMBER
     }
 
     $global:IsReleaseBuild = [System.Convert]::ToBoolean($env:IsReleaseBuild)

--- a/buildutils.ps1
+++ b/buildutils.ps1
@@ -345,6 +345,27 @@ function Initialize-BuildEnvironment
     [cmdletbinding()]
     Param()
 
+    # IsAutomatedBuild is the top level gate (e.g. if it is false, all the others must be false)
+    $global:IsAutomatedBuild = [System.Convert]::ToBoolean($env:IsAutomatedBuild) `
+                                -or $env:CI `
+                                -or $env:APPVEYOR `
+                                -or $env:GITHUB_ACTIONS
+
+    $global:IsPullRequestBuild = [System.Convert]::ToBoolean($env:IsPullRequestBuild) `
+                                 -and $IsAutomatedBuild `
+                                 -and ( ($env:GITHUB_ACTIONS -and $env:GITHUB_BASE_REF) -or $env:APPVEYOR_PULL_REQUEST_NUMBER)
+
+    # TODO: Determine how to detect release tag builds with GITHUB ACTIONS
+    $global:IsReleaseBuild = [System.Convert]::ToBoolean($env:IsReleaseBuild) `
+                             -and $IsAutomatedBuild `
+                             -and ($env:APPVEYOR_REPO_TAG -and !$IsPullRequestBuild)
+
+    # set/reset environment vars for non-script tools (i.e. msbuild.exe)
+    # Script code should ALWAYS use the globals as they don't require conversion to bool
+    $env:IsAutomatedBuild = $global:IsAutomatedBuild
+    $env:IsPullRequestBuild = $global:IsPullRequestBuild
+    $env:IsReleaseBuild = $global:IsReleaseBuild
+
     $msbuild = Find-MSBuild
     if( !$msbuild )
     {
@@ -356,34 +377,10 @@ function Initialize-BuildEnvironment
         $env:Path = "$env:Path;$($msbuild.BinPath)"
     }
 
-    $isAutomatedBuild = $env:CI -or ($env:IsAutomatedBuild -and [System.Convert]::ToBoolean($env:IsAutomatedBuild)) -or $env:APPVEYOR -or $env:GITHUB_ACTIONS
-    if($isAutomatedBuild)
+    # for an automated build, get the ISO-8601 formatted time stamp of the HEAD commit
+    if($IsAutomatedBuild -and !$env:BuildTime)
     {
-        $env:IsAutomatedBuild = 'true'
-        $env:IsPullRequestBuild = 'false'
-        $env:IsReleaseBuild = 'false'
-        if(($env:GITHUB_ACTIONS -and $env:GITHUB_BASE_REF) -or $env:APPVEYOR_PULL_REQUEST_NUMBER)
-        {
-            $env:IsPullRequestBuild = 'true'
-        }
-
-        # for an automated build, get the ISO-8601 formatted time stamp of the HEAD commit
-        if($isAutomatedBuild -and !$env:BuildTime)
-        {
-            $env:BuildTime = (git show -s --format=%cI)
-        }
-
-        # TODO: Determine how to detect release tag builds with GITHUB ACTIONS
-        if($env:APPVEYOR_REPO_TAG -and !$env:APPVEYOR_PULL_REQUEST_NUMBER)
-        {
-            $env:IsReleaseBuild = 'true'
-        }
-    }
-    else
-    {
-        $env:IsAutomatedBuild = 'false'
-        $env:IsPullRequestBuild = 'false'
-        $env:IsReleaseBuild = 'false'
+        $env:BuildTime = (git show -s --format=%cI)
     }
 
     Write-Verbose "MSBUILD:`n$($msbuild | Format-Table -AutoSize | Out-String)"

--- a/buildutils.ps1
+++ b/buildutils.ps1
@@ -371,10 +371,6 @@ function Initialize-BuildEnvironment
     $env:IsPullRequestBuild = $global:IsPullRequestBuild
     $env:IsReleaseBuild = $global:IsReleaseBuild
 
-    Write-Information (dir env:Is* | Format-Table -Property Name, value | Out-String)
-    Write-Information (dir env:GITHUB* | Format-Table -Property Name, value | Out-String)
-    Write-Information (dir env:APPVEYOR* | Format-Table -Property Name, value | Out-String)
-
     $msbuild = Find-MSBuild
     if( !$msbuild )
     {

--- a/buildutils.ps1
+++ b/buildutils.ps1
@@ -353,16 +353,16 @@ function Initialize-BuildEnvironment
 
     # IsPullRequestBuild indicates an automated buddy build and should not be trusted
     $global:IsPullRequestBuild = [System.Convert]::ToBoolean($env:IsPullRequestBuild)
-    if(!$IsPullRequestBuild -and $IsAutomatedBuild)
+    if(!$global:IsPullRequestBuild -and $global:IsAutomatedBuild)
     {
-        $IsPullRequestBuild = $env:GITHUB_BASE_REF -or $env:APPVEYOR_PULL_REQUEST_NUMBER
+        $global:IsPullRequestBuild = $env:GITHUB_BASE_REF -or $env:APPVEYOR_PULL_REQUEST_NUMBER
     }
 
     $global:IsReleaseBuild = [System.Convert]::ToBoolean($env:IsReleaseBuild)
-    if(!$IsReleaseBuild -and $IsAutomatedBuild -and !$IsPullRequestBuild)
+    if(!$global:IsReleaseBuild -and $global:IsAutomatedBuild -and !$global:IsPullRequestBuild)
     {
         # TODO: Determine how to detect release tag builds with GITHUB ACTIONS
-        $IsReleaseBuild = $env:APPVEYOR_REPO_TAG
+        $global:IsReleaseBuild = $env:APPVEYOR_REPO_TAG
     }
 
     # set/reset environment vars for non-script tools (i.e. msbuild.exe)
@@ -387,7 +387,7 @@ function Initialize-BuildEnvironment
     }
 
     # for an automated build, get the ISO-8601 formatted time stamp of the HEAD commit
-    if($IsAutomatedBuild -and !$env:BuildTime)
+    if($global:IsAutomatedBuild -and !$env:BuildTime)
     {
         $env:BuildTime = (git show -s --format=%cI)
     }


### PR DESCRIPTION
- Cleaned up use of Is* env vars, logic for them is cleaner and cast+assigned to global script vars. Script code now uses only the proper bool global values instead of the env string values.