### PR TITLE
Attempt to fix docs publish in GH Actions

### DIFF
--- a/Push-Docs.ps1
+++ b/Push-Docs.ps1
@@ -23,8 +23,11 @@ if(!($remoteUrl -like 'https://github.com/UbiquityDotNET/Llvm.NET*'))
 pushd .\BuildOutput\docs -ErrorAction Stop
 try
 {
+    # Best effort, on git commands as they can return non-zero even if nothing is wrong.
+    $ErrorActionPreference = 'Continue'
+
     Write-Information "pushing changes to git"
-    git push -q
+    git push
 }
 finally
 {

--- a/Set-PushCredentials.ps1
+++ b/Set-PushCredentials.ps1
@@ -4,9 +4,19 @@ Initialize-BuildEnvironment
 
 if( $IsAutomatedBuild -and !$IsPullRequestBuild )
 {
-    if(!$env:docspush_access_token -or !$env:docspush_email -or !$env:docspush_username)
+    if(!$env:docspush_access_token)
     {
-        throw "Env vars missing!"
+        Write-Error "Missing docspush_access_token"
+    }
+
+    if(!$env:docspush_email)
+    {
+        Write-Error "Missing docspush_email"
+    }
+
+    if(!$env:docspush_username)
+    {
+        Write-Error "Missing docspush_username"
     }
 
     # Best effort, on git commands as they can return non-zero even if nothing is wrong.


### PR DESCRIPTION
* Better error reporting of missing vars for setting creds
* disable error stop for docs push to try and figure out why it is failing with auth issues