### PR TITLE
Fixing build break in develop branch

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,7 +19,7 @@ jobs:
            fetch-depth: 0
 
       - name: Build Source
-        run: .\Build-All.ps1
+        run: .\Build-All.ps1 -ForceClean
 
       - name: Publish build logs
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -34,7 +34,6 @@ jobs:
             name: Nuget Packages
             path: .\BuildOutput\Nuget
 
-jobs:
   build-docs:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,7 +19,7 @@ jobs:
            fetch-depth: 0
 
       - name: Build Source
-        run: .\Build-All.ps1 -ForceClean
+        run: .\Build-All.ps1 -ForceClean -BuildMode Source
 
       - name: Publish build logs
         if: always() && github.event_name == 'pull_request'
@@ -33,3 +33,23 @@ jobs:
         with:
             name: Nuget Packages
             path: .\BuildOutput\Nuget
+
+jobs:
+  build-docs:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+           persist-credentials: false
+           fetch-depth: 0
+
+      - name: Build Docs
+        run: .\Build-All.ps1 -ForceClean -BuildMode Docs
+
+      - name: Publish build logs
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v1
+        with:
+            name: Build Logs
+            path: .\BuildOutput\BinLogs

--- a/Invoke-UnitTests.ps1
+++ b/Invoke-UnitTests.ps1
@@ -4,31 +4,22 @@ Initialize-BuildEnvironment
 $testsFailed = $false
 
 Write-Information 'Running tests as x64'
-$testProj = Join-Path $BuildPaths.SrcRoot 'Ubiquity.NET.LlvmTests\Ubiquity.NET.Llvm.Tests.csproj'
+$testProj = Join-Path $BuildPaths.SrcRoot 'Ubiquity.NET.Llvm.Tests\Ubiquity.NET.Llvm.Tests.csproj'
 $runSettings = Join-Path $BuildPaths.SrcRoot 'x64.runsettings'
 dotnet test $testProj -s $runSettings --no-build --no-restore --logger "trx" -r $BuildPaths.TestResultsPath
 $testsFailed = $testsFailed -or ($LASTEXITCODE -ne 0)
-if ("${ENV:APPVEYOR_JOB_ID}" -ne "")
-{
-    $wc = New-Object 'System.Net.WebClient'
-    $JobUrl = "https://ci.appveyor.com/api/testresults/mstest/$($env:APPVEYOR_JOB_ID)"
-    dir (Join-Path $BuildPaths.TestResultsPath '*.trx') | %{ $wc.UploadFile( $JobUrl, $_) }
-}
 
 Write-Information 'Running sample app for .NET Core'
-if($env:APPVEYOR)
-{
-    Add-AppVeyorTest -Name 'CodeGenWithDebugInfo (CoreCLR)' -Framework 'CORECLR' -FileName 'CodeGenWithDebugInfo.exe' -Outcome Running
-}
 pushd (Join-path $BuildPaths.BuildOutputPath bin\CodeGenWithDebugInfo\Release\netcoreapp3.1)
-dotnet CodeGenWithDebugInfo.dll M3 'Support Files\test.c' $BuildPaths.TestResultsPath
-$testsFailed = $testsFailed -or ($LASTEXITCODE -ne 0)
-$outcome = @('Failed','Passed')[($LASTEXITCODE -eq 0)]
-if($env:APPVEYOR)
+try
 {
-    Update-AppVeyorTest -Name 'CodeGenWithDebugInfo (CoreCLR)' -Framework 'CORECLR' -FileName 'CodeGenWithDebugInfo.exe' -Outcome $outcome
+    dotnet CodeGenWithDebugInfo.dll M3 'Support Files\test.c' $BuildPaths.TestResultsPath
+    $testsFailed = $testsFailed -or ($LASTEXITCODE -ne 0)
 }
-popd
+finally
+{
+    popd
+}
 
 if($testsFailed)
 {

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 #### Build Status
 [![CI-Build](https://github.com/UbiquityDotNET/Llvm.NET/workflows/CI-Build/badge.svg?branch=master&event=push)](https://github.com/UbiquityDotNET/Llvm.NET/actions?query=workflow%3ACI-Build+branch%3Amaster+is%3Ain_progress)
 ![Release-Build](https://github.com/UbiquityDotNET/Llvm.NET/workflows/Release-Build/badge.svg)
-### Nuget
-[![Nuget](https://img.shields.io/nuget/dt/Ubiquity.NET.Llvm.svg)](https://www.nuget.org/packages/Ubiquity.NET.Llvm/)
+### NuGet
+[![NuGet](https://img.shields.io/nuget/dt/Ubiquity.NET.Llvm.svg)](https://www.nuget.org/packages/Ubiquity.NET.Llvm/)
 
 For details of releases, see the [release notes](https://github.com/UbiquityDotNET/Llvm.NET/blob/master/docfx/ReleaseNotes.md)
 
@@ -56,11 +56,11 @@ need to change except to pick up a new package version.)
 The CI Builds of the NuGet package built from the latest source in the master branch are available as build artifacts from the build. 
 Unfortunately with an all GitHub build via GitHub Actions we don't have a good story for accessing the packages from unreleased automated builds. While GitHub does support a package registry (GPR), it really doesn't meet the needs of CI builds. In particular:
 * GPR Doesn't support deletion of older CI build packages (Cluttering the feed)
-* GPR requires complex logon/Tokens just to get packages from the feed, despite being a public repo...
+* GPR requires complex login/Tokens just to get packages from the feed, despite being a public repository...
 * Tool integration (esp. Visual Studio) is not well supported and difficult to setup.
 
-Given all of the above the CI builds are not published to a feed at this time and GPR isn't used for publishing releases. (Official Nuget will serve that role for releases)
-CI build and PR build pacakges are available as artifacts from the GitHub actions that build them.
+Given all of the above the CI builds are not published to a feed at this time and GPR isn't used for publishing releases. (Official NuGet will serve that role for releases)
+CI build and PR build packages are available as artifacts from the GitHub actions that build them.
 
 ### API Documentation
 The full API documentation on using Ubiquity.NET.Llvm is available on the [Ubiquity.NET.Llvm documentation site](https://ubiquitydotnet.github.io/Ubiquity.NET.Llvm/).
@@ -72,11 +72,11 @@ LLVM Bit code equivalent to what the Clang compiler generates for a [simple C la
 The sample application doesn't actually parse the source, instead it is a manually constructed and documented example of how to use Ubiquity.NET.Llvm to accomplish the bit-code generation. 
 
 #### Kaleidoscope Tutorial
-Aa Ubiquity.NET.Llvm version of the LLVM sample [Kaleidoscope language tutorial](https://ubiquitydotnet.github.io/Llvm.NET/articles/Samples/Kaleidoscope.html) is provided to walk through many aspects of code generation and JIT execution with Llvm.NET. This tutorial implements a complete JIT execution engine for the Kaleidoscope language, along with AOT compilation, optimization and debug symbol generation. This, covers a significant surface area of the Llvm.NET classes and methods to provide a solid grounding on the use of the library.
+A Ubiquity.NET.Llvm version of the LLVM sample [Kaleidoscope language tutorial](https://ubiquitydotnet.github.io/Llvm.NET/articles/Samples/Kaleidoscope.html) is provided to walk through many aspects of code generation and JIT execution with Llvm.NET. This tutorial implements a complete JIT execution engine for the Kaleidoscope language, along with AOT compilation, optimization and debug symbol generation. This, covers a significant surface area of the Llvm.NET classes and methods to provide a solid grounding on the use of the library.
 
 ## Building Ubiquity.NET.Llvm
-### Prerequsites
-* Visual Studio 2017 (15.4+) [Community Edition OK]
+### Prerequisites
+* Visual Studio 2019 (16.4+) [Community Edition OK]
 * [7-Zip](https://www.7-zip.org/) [Used to unpack the pre-built LLVM libraries]
 
 #### Using Visual Studio
@@ -86,7 +86,7 @@ Ubiquity.NET.Llvm source code during development.
 
 ### Replicating the automated build
 The Automated build support for Ubiquity.NET.Llvm uses Build-All.ps1 PowerShell script to build all the binaries and generate a
-NuGet package. To build the full package simply run `Build-All.ps1` from a PowerShell command prompt with MSBuild tools
+NuGet package. To build the full package simply run `Build-All.ps1 -ForceClean` from a PowerShell command prompt with MSBuild tools
 on the system search path.
 
 ### Code of Conduct

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -4,8 +4,7 @@
             "src": [
                 {
                     "files": [
-                        "src/Ubiquity.NET.Llvm/Ubiquity.NET.Llvm.csproj",
-                        "BuildOutput/bin/Ubiquity.NET.Llvm.Interop/Release/netstandard2.1/Ubiquity.NET.Llvm.Interop.dll"
+                        "src/Ubiquity.NET.Llvm/Ubiquity.NET.Llvm.csproj"
                     ],
                     "src": ".."
                 }

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/Library.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/Library.cs
@@ -763,7 +763,7 @@ namespace Ubiquity.NET.Llvm.Interop
             paths.Add( Path.Combine( packageRoot, runTimePath ) );
             paths.Add( Path.Combine( thisModulePath, runTimePath ) );
             paths.Add( thisModulePath );
-            IntPtr hLibLLVM = LoadWin32Library( "LibLlvm.dll", paths );
+            IntPtr hLibLLVM = LoadWin32Library( "Ubiquity.NET.LibLlvm.dll", paths );
 
             // Verify the version of LLVM in LibLLVM
             LibLLVMGetVersionInfo( out LibLLVMVersionInfo versionInfo );

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/NativeMethods.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/NativeMethods.cs
@@ -19,7 +19,7 @@ namespace Ubiquity.NET.Llvm.Interop
     /// <summary>Interop methods for the Ubiquity.NET LibLLVM library</summary>
     public static partial class NativeMethods
     {
-        internal const string LibraryPath = "LibLLVM";
+        internal const string LibraryPath = "Ubiquity.NET.LibLLVM";
 
         /// <summary>Dynamically loads a DLL from a directory dependent on the current architecture</summary>
         /// <param name="moduleName">name of the DLL</param>

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/Ubiquity.NET.Llvm.Interop.csproj
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/Ubiquity.NET.Llvm.Interop.csproj
@@ -21,11 +21,11 @@
     <PackageLicenseExpression>NCSA</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="..\..\..\BuildOutput\bin\LibLLVM\$(Configuration)\x64\LibLLVM.dll" Link="runtimes\win-x64\native\LibLLVM.dll">
+    <Content Include="..\..\..\BuildOutput\bin\LibLLVM\$(Configuration)\x64\Ubiquity.NET.LibLLVM.dll" Link="runtimes\win-x64\native\Ubiquity.NET.LibLLVM.dll">
         <PackagePath>runtimes\win-x64\native</PackagePath>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\..\BuildOutput\bin\LibLLVM\$(Configuration)\x64\LibLLVM.pdb" Link="runtimes\win-x64\native\LibLLVM.pdb">
+    <Content Include="..\..\..\BuildOutput\bin\LibLLVM\$(Configuration)\x64\Ubiquity.NET.LibLLVM.pdb" Link="runtimes\win-x64\native\Ubiquity.NET.LibLLVM.pdb">
         <PackagePath>runtimes\win-x64\native</PackagePath>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
* Fixed native library name which wasn't updated in previous commits (But succesfully worked because the old name was left behind in the output folder ☹️  )
* Corrected invoke-unittests to use updated name.
* updated main readme on usage of build-all.ps1 -ForceClean to replicate the build (As I obviously forgot that :man_facepalming: )