### PR TITLE
Fixes #184

### DIFF
--- a/docfx/current/ReleaseNotes.md
+++ b/docfx/current/ReleaseNotes.md
@@ -63,6 +63,16 @@ Some APIs had inconsistent, misspelled or confusing names and were updated.
 |---------------------------|--------------------------------|---------------|
 | BitcodeModule.AddFunction | BitcodeModule.CreateFunction() | The Create vs Add between debug info and raw native was always confusing |
 
+### Altered Behavior
+#### Context.CreateStructType()
+As part of resolving [bug #184](https://github.com/UbiquityDotNET/Llvm.NET/issues/184) the CreateStructType
+methods were re-evaluated and found lacking in functionality (the bug) and clarity. The docs were misleading
+and the implementations overly restrictive in some cases. Thus these have been re-worked to make it more clear
+when a Sized vs. Opaque structure type is created, in particular, for **ALL** overloads taking a 'packed' parameter
+a sized type is created, even if the size is 0 because no members are provided. This allows creation of named or 
+anonymous empty structs, used in many languages. To create a named opaque type then the overload with just the
+name is used. This isn't expected to impact many consumers, other than the tests, but it is a breaking change.
+
 ### Removed redundant APIs
 LLVM has made additional APIs available in the standard LLVM-C library that are either identical to or functionality equivalent to 
 APIs that were custom in previous versions of the Ubiquity.NET.Llvm DLLs. This is only observable at the interop library layer where some

--- a/src/Ubiquity.NET.Llvm.Tests/DebugInfo/DebugStructTypeTests.cs
+++ b/src/Ubiquity.NET.Llvm.Tests/DebugInfo/DebugStructTypeTests.cs
@@ -1,0 +1,115 @@
+// -----------------------------------------------------------------------
+// <copyright file="DebugStructTypeTests.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Linq;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Ubiquity.NET.Llvm.DebugInfo;
+
+namespace Ubiquity.NET.Llvm.Tests.DebugInfo
+{
+    [TestClass]
+    public class DebugStructTypeTests
+    {
+        [TestMethod]
+        public void DebugStructType_constructing_empty_struct_succeeds()
+        {
+            using var context = new Context( );
+            using var testModule = context.CreateBitcodeModule( "test" );
+
+            string sourceName = "empty_struct";
+            string linkageName = "_empty_struct";
+
+            var structType = new DebugStructType( module: testModule
+                                                , nativeName: linkageName
+                                                , scope: null
+                                                , sourceName: sourceName
+                                                , file: null
+                                                , line: 0
+                                                , debugFlags: default
+                                                , members: Enumerable.Empty<DebugMemberInfo>()
+                                                ); // rest of args use defaults...
+            Assert.IsTrue( structType.IsSized );
+            Assert.IsFalse( structType.IsPacked );
+            Assert.IsTrue( structType.IsStruct );
+            Assert.AreEqual( linkageName, structType.Name );
+            Assert.AreEqual( sourceName, structType.SourceName );
+        }
+
+#if NOT_YET_READY_GENERATED
+        [TestMethod]
+        public void SetBody_StateUnderTest_ExpectedBehavior( )
+        {
+            var debugStructType = new DebugStructType( TODO, TODO, TODO, TODO, TODO, TODO, TODO, TODO, TODO, TODO, TODO, TODO );
+            bool packed = false;
+            ITypeRef[ ] elements = null;
+
+            debugStructType.SetBody(
+                packed,
+                elements );
+
+            Assert.Inconclusive( );
+        }
+
+        [TestMethod]
+        public void SetBody_StateUnderTest_ExpectedBehavior1( )
+        {
+            var debugStructType = new DebugStructType( TODO, TODO, TODO, TODO, TODO, TODO, TODO, TODO, TODO, TODO, TODO, TODO );
+            bool packed = false;
+            BitcodeModule module = null;
+            DIScope? scope = null;
+            DIFile? file = null;
+            uint line = 0;
+            DebugInfoFlags debugFlags = default( global::Ubiquity.NET.Llvm.DebugInfo.DebugInfoFlags );
+            IEnumerable debugElements = null;
+
+            debugStructType.SetBody(
+                packed,
+                module,
+                scope,
+                file,
+                line,
+                debugFlags,
+                debugElements );
+
+            Assert.Inconclusive( );
+        }
+
+        [TestMethod]
+        public void SetBody_StateUnderTest_ExpectedBehavior2( )
+        {
+            var debugStructType = new DebugStructType( TODO, TODO, TODO, TODO, TODO, TODO, TODO, TODO, TODO, TODO, TODO, TODO );
+            bool packed = false;
+            BitcodeModule module = null;
+            DIScope? scope = null;
+            DIFile? file = null;
+            uint line = 0;
+            DebugInfoFlags debugFlags = default( global::Ubiquity.NET.Llvm.DebugInfo.DebugInfoFlags );
+            IEnumerable nativeElements = null;
+            IEnumerable debugElements = null;
+            DIType? derivedFrom = null;
+            uint? bitSize = null;
+            uint bitAlignment = 0;
+
+            debugStructType.SetBody(
+                packed,
+                module,
+                scope,
+                file,
+                line,
+                debugFlags,
+                nativeElements,
+                debugElements,
+                derivedFrom,
+                bitSize,
+                bitAlignment );
+
+            Assert.Inconclusive( );
+        }
+#endif
+    }
+}

--- a/src/Ubiquity.NET.Llvm/DebugInfo/DebugStructType.cs
+++ b/src/Ubiquity.NET.Llvm/DebugInfo/DebugStructType.cs
@@ -25,11 +25,11 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// <param name="module">Module to contain the debug meta data</param>
         /// <param name="nativeName">Name of the type in LLVM IR</param>
         /// <param name="scope">Debug scope for the structure</param>
-        /// <param name="name">Source/debug name of the struct</param>
+        /// <param name="sourceName">Source/debug name of the struct</param>
         /// <param name="file">File containing the definition of this type</param>
         /// <param name="line">line number this type is defined at</param>
         /// <param name="debugFlags">debug flags for this type</param>
-        /// <param name="debugElements">Description of all the members of this structure</param>
+        /// <param name="members">Description of all the members of this structure</param>
         /// <param name="derivedFrom">Base type, if any for this type</param>
         /// <param name="packed">Indicates if this type is packed or not</param>
         /// <param name="bitSize">Total bit size for this type or <see langword="null"/> to use default for target</param>
@@ -37,33 +37,33 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         public DebugStructType( BitcodeModule module
                               , string nativeName
                               , DIScope? scope
-                              , string name
+                              , string sourceName
                               , DIFile? file
                               , uint line
                               , DebugInfoFlags debugFlags
-                              , IEnumerable<DebugMemberInfo> debugElements
+                              , IEnumerable<DebugMemberInfo> members
                               , DIType? derivedFrom = null
                               , bool packed = false
                               , uint? bitSize = null
                               , uint bitAlignment = 0
                               )
             : base( module.ValidateNotNull( nameof( module ) )
-                          .Context.CreateStructType( nativeName, packed, debugElements.Select( e => e.DebugType ).ToArray( ) )
+                          .Context.CreateStructType( nativeName, packed, members.Select( e => e.DebugType ).ToArray( ) )
                   , module.DIBuilder.CreateReplaceableCompositeType( Tag.StructureType
-                                                                   , name
+                                                                   , sourceName
                                                                    , scope
                                                                    , file
                                                                    , line
                                                                    )
             )
         {
-            DebugMembers = new ReadOnlyCollection<DebugMemberInfo>( debugElements as IList<DebugMemberInfo> ?? debugElements.ToList( ) );
+            DebugMembers = new ReadOnlyCollection<DebugMemberInfo>( members as IList<DebugMemberInfo> ?? members.ToList( ) );
 
             var memberTypes = from memberInfo in DebugMembers
                               select CreateMemberType( module, memberInfo );
 
             var concreteType = module.DIBuilder.CreateStructType( scope: scope
-                                                                , name: name
+                                                                , name: sourceName
                                                                 , file: file
                                                                 , line: line
                                                                 , bitSize: bitSize ?? module.Layout.BitSizeOf( NativeType )
@@ -191,6 +191,12 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
         /// <inheritdoc/>
         public void SetBody( bool packed, params ITypeRef[ ] elements )
+        {
+            NativeType.SetBody( packed, elements );
+        }
+
+        /// <inheritdoc/>
+        public void SetBody( bool packed, IEnumerable<ITypeRef> elements)
         {
             NativeType.SetBody( packed, elements );
         }

--- a/src/Ubiquity.NET.Llvm/Types/StructType.cs
+++ b/src/Ubiquity.NET.Llvm/Types/StructType.cs
@@ -40,22 +40,27 @@ namespace Ubiquity.NET.Llvm.Types
 
         /// <summary>Sets the body of the structure</summary>
         /// <param name="packed">Flag to indicate if the body elements are packed (e.g. no padding)</param>
-        /// <param name="elements">Optional types of each element</param>
-        /// <remarks>
-        /// To set the body, at least one element type is required. If none are provided this is a NOP.
-        /// </remarks>
+        /// <param name="elements">Types of each element (may be empty)</param>
         void SetBody( bool packed, params ITypeRef[ ] elements );
+
+        /// <summary>Sets the body of the structure</summary>
+        /// <param name="packed">Flag to indicate if the body elements are packed (e.g. no padding)</param>
+        /// <param name="elements">Types of each element (may be empty)</param>
+        void SetBody( bool packed, IEnumerable<ITypeRef> elements );
     }
 
     internal class StructType
         : TypeRef
         , IStructType
     {
-        public void SetBody( bool packed, params ITypeRef[ ] elements )
+        public void SetBody( bool packed, IEnumerable<ITypeRef> elements )
         {
             LLVMTypeRef[ ] llvmArgs = elements.Select( e => e.GetTypeRef() ).ToArray( );
             LLVMStructSetBody( TypeRefHandle, llvmArgs, ( uint )llvmArgs.Length, packed );
         }
+
+        public void SetBody( bool packed, params ITypeRef[ ] elements )
+            => SetBody(packed, (IEnumerable<ITypeRef>)elements);
 
         public string Name => LLVMGetStructName( TypeRefHandle );
 


### PR DESCRIPTION
Corrected behavior and documentation for overloads of Context.CreateStructType to allow creating empty sized structures (Anonymous or named) This is technically a breaking change so the release notes are updated to reflect that. Though the expectation is that there isn't anything depending on the current and odd behavior (effectively declaring packed but not providing any members for the body is a contradiction and should not have been allowed to create a forward reference, especially since a simpler single param overload was already available)