### PR TITLE
Corrections for anonymous structs

### DIFF
--- a/src/Design.md
+++ b/src/Design.md
@@ -11,13 +11,13 @@ Ubiquity.NET.Llvm is designed to provide an OO model that faithfully reflects th
 underlying LLVM model while fitting naturally into .NET programming patterns.
    1) While the underlying extended "C" LLVM API is available in the Ubiquity.NET.Llvm.Interop package
       direct use of those APIs is generally discouraged as there are a lot of subtleties for correct
-      usage that are automatically mnaged by the Ubiquity.NET.Llvm class library.
+      usage that are automatically managed by the Ubiquity.NET.Llvm class library.
 1) FxCop Clean
 4) Leverage existing LLVM-C APIs underneath whenever possible
    1) Extend only when needed with custom wrappers
 
 # Details
-## Interning (Uniquing in LLVM)
+## Interning (Uniqueing in LLVM)
 Many of the underlying object instances in LLVM are interned/Uniqued. That is,
 there will only be one instance of a type with a given value within some scope.
 

--- a/src/Ubiquity.NET.Llvm.Tests/DebugInfo/DebugStructTypeTests.cs
+++ b/src/Ubiquity.NET.Llvm.Tests/DebugInfo/DebugStructTypeTests.cs
@@ -40,6 +40,31 @@ namespace Ubiquity.NET.Llvm.Tests.DebugInfo
             Assert.AreEqual( sourceName, structType.SourceName );
         }
 
+        [TestMethod]
+        public void DebugStructType_constructing_empty_anonymous_struct_succeeds( )
+        {
+            using var context = new Context( );
+            using var testModule = context.CreateBitcodeModule( "test" );
+
+            string sourceName = string.Empty;
+            string linkageName = string.Empty;
+
+            var structType = new DebugStructType( module: testModule
+                                                , nativeName: linkageName
+                                                , scope: null
+                                                , sourceName: sourceName
+                                                , file: null
+                                                , line: 0
+                                                , debugFlags: default
+                                                , members: Enumerable.Empty<DebugMemberInfo>()
+                                                ); // rest of args use defaults...
+            Assert.IsTrue( structType.IsSized );
+            Assert.IsFalse( structType.IsPacked );
+            Assert.IsTrue( structType.IsStruct );
+            Assert.AreEqual( linkageName, structType.Name );
+            Assert.AreEqual( sourceName, structType.SourceName );
+        }
+
 #if NOT_YET_READY_GENERATED
         [TestMethod]
         public void SetBody_StateUnderTest_ExpectedBehavior( )

--- a/src/Ubiquity.NET.Llvm/Context.cs
+++ b/src/Ubiquity.NET.Llvm/Context.cs
@@ -440,7 +440,7 @@ namespace Ubiquity.NET.Llvm
             => CreateStructType( name, packed, ( IEnumerable<ITypeRef> )elements );
 
         /// <summary>Creates a new structure type in this <see cref="Context"/></summary>
-        /// <param name="name">Name of the structure</param>
+        /// <param name="name">Name of the structure (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="packed">Flag indicating if the structure is packed</param>
         /// <param name="elements">Types for the structures elements in layout order</param>
         /// <returns>
@@ -451,7 +451,7 @@ namespace Ubiquity.NET.Llvm
         /// </remarks>
         public IStructType CreateStructType( string name, bool packed, IEnumerable<ITypeRef> elements )
         {
-            name.ValidateNotNullOrWhiteSpace( nameof( name ) );
+            name.ValidateNotNull( nameof( name ) );
             elements.ValidateNotNull( nameof( elements ) );
 
             var retVal = TypeRef.FromHandle<IStructType>( LLVMStructCreateNamed( ContextHandle, name ).ThrowIfInvalid( ) )!;

--- a/src/Ubiquity.NET.Llvm/DebugInfo/DebugInfoBuilder.cs
+++ b/src/Ubiquity.NET.Llvm/DebugInfo/DebugInfoBuilder.cs
@@ -601,7 +601,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
         /// <summary>Creates debug description of a structure type</summary>
         /// <param name="scope">Scope containing the structure</param>
-        /// <param name="name">Name of the type</param>
+        /// <param name="name">Name of the type (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="file">File containing the type</param>
         /// <param name="line">Line of the start of the type</param>
         /// <param name="bitSize">Size of the type in bits</param>
@@ -626,7 +626,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
         /// <summary>Creates debug description of a structure type</summary>
         /// <param name="scope">Scope containing the structure</param>
-        /// <param name="name">Name of the type</param>
+        /// <param name="name">Name of the type (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="file">File containing the type</param>
         /// <param name="line">Line of the start of the type</param>
         /// <param name="bitSize">Size of the type in bits</param>
@@ -679,7 +679,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
         /// <summary>Creates debug description of a union type</summary>
         /// <param name="scope">Scope containing the union</param>
-        /// <param name="name">Name of the type</param>
+        /// <param name="name">Name of the type (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="file">File containing the union</param>
         /// <param name="line">Line of the start of the union</param>
         /// <param name="bitSize">Size of the union in bits</param>
@@ -703,7 +703,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
         /// <summary>Creates debug description of a union type</summary>
         /// <param name="scope">Scope containing the union</param>
-        /// <param name="name">Name of the type</param>
+        /// <param name="name">Name of the type (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="file">File containing the union</param>
         /// <param name="line">Line of the start of the union</param>
         /// <param name="bitSize">Size of the union in bits</param>
@@ -726,7 +726,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
         /// <summary>Creates debug description of a union type</summary>
         /// <param name="scope">Scope containing the union</param>
-        /// <param name="name">Name of the type</param>
+        /// <param name="name">Name of the type (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="file">File containing the union</param>
         /// <param name="line">Line of the start of the union</param>
         /// <param name="bitSize">Size of the union in bits</param>
@@ -978,7 +978,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
         /// <summary>Creates an enumeration type</summary>
         /// <param name="scope">Containing scope for the type</param>
-        /// <param name="name">source language name of the type</param>
+        /// <param name="name">source language name of the type (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="file">Source file containing the type</param>
         /// <param name="lineNumber">Source file line number for the type</param>
         /// <param name="sizeInBits">Size, in bits, for the type</param>
@@ -1407,7 +1407,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
         /// <summary>Creates a replaceable composite type</summary>
         /// <param name="tag">Debug information <see cref="Tag"/> for the composite type (only values for a composite type are allowed)</param>
-        /// <param name="name">Name of the type</param>
+        /// <param name="name">Name of the type (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="scope">Scope of the type</param>
         /// <param name="file">Source file for the type</param>
         /// <param name="line">Source line for the type</param>

--- a/src/Ubiquity.NET.Llvm/DebugInfo/DebugStructType.cs
+++ b/src/Ubiquity.NET.Llvm/DebugInfo/DebugStructType.cs
@@ -23,9 +23,9 @@ namespace Ubiquity.NET.Llvm.DebugInfo
     {
         /// <summary>Initializes a new instance of the <see cref="DebugStructType"/> class.</summary>
         /// <param name="module">Module to contain the debug meta data</param>
-        /// <param name="nativeName">Name of the type in LLVM IR</param>
+        /// <param name="nativeName">Name of the type in LLVM IR (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="scope">Debug scope for the structure</param>
-        /// <param name="sourceName">Source/debug name of the struct</param>
+        /// <param name="sourceName">Source/debug name of the struct (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="file">File containing the definition of this type</param>
         /// <param name="line">line number this type is defined at</param>
         /// <param name="debugFlags">debug flags for this type</param>
@@ -81,7 +81,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// <param name="llvmType">LLVM native type to build debug information for</param>
         /// <param name="module">Module to contain the debug meta data</param>
         /// <param name="scope">Debug scope for the structure</param>
-        /// <param name="name">Source/debug name of the struct</param>
+        /// <param name="name">Source/debug name of the struct (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="file">File containing the definition of this type</param>
         /// <param name="line">line number this type is defined at</param>
         /// <param name="debugFlags">debug flags for this type</param>
@@ -119,7 +119,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// <param name="llvmType">LLVM native type to build debug information for</param>
         /// <param name="module">Module to contain the debug meta data</param>
         /// <param name="scope">Debug scope for the structure</param>
-        /// <param name="name">Source/debug name of the struct</param>
+        /// <param name="name">Source/debug name of the struct (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="file">File containing the definition of this type</param>
         /// <param name="line">line number this type is defined at</param>
         /// <remarks>
@@ -150,7 +150,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// <param name="module">Module to contain the debug meta data</param>
         /// <param name="nativeName">Name of the type in LLVM IR</param>
         /// <param name="scope">Debug scope for the structure</param>
-        /// <param name="name">Source/debug name of the struct</param>
+        /// <param name="name">Source/debug name of the struct (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="file">File containing the definition of this type</param>
         /// <param name="line">line number this type is defined at</param>
         /// <remarks>
@@ -184,7 +184,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         public IReadOnlyList<ITypeRef> Members => NativeType.Members;
 
         /// <summary>Gets the name of the type</summary>
-        public string Name => NativeType.Name;
+        public string Name => NativeType.Name ?? string.Empty;
 
         /// <summary>Gets the Source/Debug name</summary>
         public string SourceName => DIType?.Name ?? string.Empty;


### PR DESCRIPTION
Fixes #188
* Updating comments to indicate string.Empty is a valid struct name for anonymous structs.
* Corrected DebugStructType.Name to never produce a null name (uses string.Empty instead)
* Corrected Context.CreateStructType to allow empty string