### PR TITLE
This works around the MSVC headers reporting incorrect clang version

### DIFF
--- a/Build-All.ps1
+++ b/Build-All.ps1
@@ -11,7 +11,7 @@ $oldPath = $env:Path
 try
 {
     . .\buildutils.ps1
-    $buildInfo = Initialize-BuildEnvironment -FullInit
+    $buildInfo = Initialize-BuildEnvironment -FullInit -AllowVsPreReleases:$AllowVsPreReleases
 
     $BuildSource = $false
     $BuildDocs = $false;
@@ -33,12 +33,12 @@ try
 
     if($BuildSource)
     {
-        .\Build-Source.ps1
+        .\Build-Source.ps1 -AllowVsPreReleases:$AllowVsPreReleases
     }
 
     if($BuildDocs)
     {
-        .\Build-Docs.ps1
+        .\Build-Docs.ps1 -AllowVsPreReleases:$AllowVsPreReleases
     }
 }
 catch

--- a/Build-Interop.ps1
+++ b/Build-Interop.ps1
@@ -44,7 +44,7 @@ $oldPath = $env:Path
 try
 {
     . .\buildutils.ps1
-    $buildInfo = Initialize-BuildEnvironment
+    $buildInfo = Initialize-BuildEnvironment -AllowVsPreReleases:$AllowVsPreReleases
 
     # Download and unpack the LLVM libs if not already present, this doesn't use NuGet as the NuGet compression
     # is insufficient to keep the size reasonable enough to support posting to public galleries. Additionally, the

--- a/Build-Source.ps1
+++ b/Build-Source.ps1
@@ -8,7 +8,7 @@ $oldPath = $env:Path
 try
 {
     . .\buildutils.ps1
-    $buildInfo = Initialize-BuildEnvironment
+    $buildInfo = Initialize-BuildEnvironment -AllowVsPreReleases:$AllowVsPreReleases
 
     $packProperties = @{ version=$($buildInfo['PackageVersion'])
                          llvmversion=$($buildInfo['LlvmVersion'])
@@ -20,7 +20,7 @@ try
                             LlvmVersion = $buildInfo['LlvmVersion']
                           }
 
-    .\Build-Interop.ps1
+    .\Build-Interop.ps1 -AllowVsPreReleases:$AllowVsPreReleases
 
     $buildLogPath = Join-Path $buildInfo['BinLogsPath'] Ubiquity.NET.Llvm.binlog
     Write-Information "Building Ubiquity.NET.Llvm"

--- a/Packages.props
+++ b/Packages.props
@@ -13,7 +13,7 @@
         <PackageReference Update="MSTest.TestFramework" Version="2.1.0" />
         <PackageReference Update="MSTest.TestAdapter" Version="2.1.0" />
         <PackageReference Update="System.Memory" Version="4.5.4" />
-        <PackageReference Update="CppSharp" Version="0.10.1" />
+        <PackageReference Update="CppSharp" Version="0.10.2" />
         <PackageReference Update="Antlr4" Version="4.6.6"/>
         <PackageReference Update="OpenSoftware.DgmlBuilder" Version="1.14.0" />
         <PackageReference Update="System.Collections.Immutable" Version="1.7.0" />

--- a/Packages.props
+++ b/Packages.props
@@ -22,5 +22,7 @@
         <PackageReference Update="memberpage" Version="2.49.0" />
         <PackageReference Update="msdn.4.5.2" Version="0.1.0-alpha-1611021200" />
         <PackageReference Update="YamlDotNet" Version="8.1.0" />
+        <PackageReference Update="google-diff-match-patch" Version="1.1.24" />
+        <PackageReference Update="CommandLineParser" Version="2.8.0" />
     </ItemGroup>
 </Project>

--- a/PsModules/CommonBuild/CommonBuild.psm1
+++ b/PsModules/CommonBuild/CommonBuild.psm1
@@ -243,9 +243,11 @@ function Find-VSInstance([switch]$PreRelease, $Version = '[15.0, 17.0)', [string
         Install-Module VSSetup -Scope CurrentUser -Force:$forceModuleInstall | Out-Null
     }
 
-    Get-VSSetupInstance -Prerelease:$PreRelease |
-        Select-VSSetupInstance -Version $Version -Require $requiredComponents |
-        select -First 1
+    $vs = Get-VSSetupInstance -Prerelease:$PreRelease |
+          Select-VSSetupInstance -Version $Version -Require $requiredComponents |
+          select -Last 1
+
+    return $vs
 }
 
 function Find-MSBuild([switch]$AllowVsPreReleases)

--- a/buildutils.ps1
+++ b/buildutils.ps1
@@ -49,7 +49,7 @@ function Initialize-BuildEnvironment
 {
     # support common parameters
     [cmdletbinding()]
-    Param([switch]$FullInit)
+    Param([switch]$FullInit, [switch]$AllowVsPreReleases)
 
     # Script code should ALWAYS use the global CurrentBuildKind
     $currentBuildKind = Get-CurrentBuildKind
@@ -81,7 +81,7 @@ function Initialize-BuildEnvironment
         }
     }
 
-    $msbuildInfo = Find-MSBuild
+    $msbuildInfo = Find-MSBuild -AllowVsPreReleases:$AllowVsPreReleases
     if( !$msbuildInfo['FoundOnPath'] )
     {
         $env:Path = "$env:Path;$($msbuildInfo['BinPath'])"

--- a/src/Interop/LlvmBindingsGenerator/bindingsConfig.yml
+++ b/src/Interop/LlvmBindingsGenerator/bindingsConfig.yml
@@ -10,8 +10,8 @@
 #        - ...
 # ----
 # Some functions are exported, but not projected into Ubiquity.NET.Llvm.Interop.NativeMethods. While this may seem strange, it is
-# generally used only for dipose functions that are only used by the hadle wrappers. Exposing such APIs for random callers
-# would introduce undefined behavior that most likely results i hard to diagnose crashes. So, they have private PInvoke
+# generally used only for dipose functions that are only used by the handle wrappers. Exposing such APIs for random callers
+# would introduce undefined behavior that most likely results in hard to diagnose crashes. So, they have private PInvoke
 # signatures in the handle types themselves, but are ignored for generating the public NativeMethods API surface
 #
 # Marshaling Info has a base type and multiple derived types
@@ -1144,11 +1144,6 @@ AnonymousEnums:
   LLVMAttributeReturnIndex: LLVMAttributeIndex
   LLVMMDStringMetadataKind: LLVMMetadataKind
 
-#IgnoredHeaders:
-#    - lto.h
-#    - LinkTimeOptimizer.h
-#    - OptRemarks.h
-#
 IgnoredHeaders:
   - llvm-c/LinkTimeOptimizer.h
   - llvm-c/lto.h

--- a/src/PatchVsForLibClang/GlobalSuppressions.cs
+++ b/src/PatchVsForLibClang/GlobalSuppressions.cs
@@ -1,0 +1,15 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="GlobalSuppressions.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+/* This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+*/
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Application doesn't provide public APIs" )]

--- a/src/PatchVsForLibClang/PatchOptions.cs
+++ b/src/PatchVsForLibClang/PatchOptions.cs
@@ -1,0 +1,46 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="PatchOptions.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+
+using CommandLine;
+
+namespace PatchVsForLibClang
+{
+    [Verb("patch", isDefault: true, HelpText = "patch the specified VS install")]
+    public class PatchOptions
+    {
+        [SuppressMessage( "StyleCop.CSharp.NamingRules", "SA1305:Field names should not use Hungarian notation", Justification = "Not Hungarian notation" )]
+        public PatchOptions(string vsInstallPath, bool force)
+        {
+            VsInstallPath = vsInstallPath;
+            Force = force;
+        }
+
+        [Value( 0, Required = true, HelpText = "Installation path to Visual Studio. [Normally retrieved from the 'InstallationPath' property of a VS Setup Instance class]" )]
+        public string VsInstallPath { get; }
+
+        [Option('F', "Force", Required = false, HelpText = "Force patch, no prompting if patch applies to source [overwrites existing backup]")]
+        public bool Force { get; }
+    }
+
+    [Verb("diff", HelpText = "Generate diff file", Hidden = true)]
+    [SuppressMessage( "StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "All verb Options in one place" )]
+    public class GenerateOptions
+    {
+        public GenerateOptions(string unpatched, string patched)
+        {
+            Unpatched = unpatched;
+            Patched = patched;
+        }
+
+        [Value( 0, Required = true, HelpText = "unpatched file for diff" )]
+        public string Unpatched { get; }
+
+        [Value( 1, Required = true, HelpText = "patched file for diff" )]
+        public string Patched { get; }
+    }
+}

--- a/src/PatchVsForLibClang/PatchVsForLibClang.csproj
+++ b/src/PatchVsForLibClang/PatchVsForLibClang.csproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" />
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <OutputType>exe</OutputType>
+    <OutputTypeEx>exe</OutputTypeEx>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Remove="intrin0_h.diff" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="intrin0_h.diff" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="google-diff-match-patch" />
+  </ItemGroup>
+
+</Project>

--- a/src/PatchVsForLibClang/PatchVsForLibClang.sln
+++ b/src/PatchVsForLibClang/PatchVsForLibClang.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30804.86
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PatchVsForLibClang", "PatchVsForLibClang.csproj", "{25A3C866-5F84-41A3-AA9C-1BAD214D1BD6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{25A3C866-5F84-41A3-AA9C-1BAD214D1BD6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25A3C866-5F84-41A3-AA9C-1BAD214D1BD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25A3C866-5F84-41A3-AA9C-1BAD214D1BD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25A3C866-5F84-41A3-AA9C-1BAD214D1BD6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B73143CE-96C2-4FEA-9F76-3ACF66904B3A}
+	EndGlobalSection
+EndGlobal

--- a/src/PatchVsForLibClang/Program.cs
+++ b/src/PatchVsForLibClang/Program.cs
@@ -1,0 +1,147 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="Program.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+using CommandLine;
+
+using DiffMatchPatch;
+
+[assembly: CLSCompliant(true)]
+
+namespace PatchVsForLibClang
+{
+    internal class Program
+    {
+        // example paths
+        // With Fix From MS => @"D:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.28.29617\include\intrin0.h";
+        //      MSVC 16.8.3 => @"D:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29333\include\intrin0.h";
+
+        // VS 2019 16.9 Preview 2 is the first publicly available version with the fix included
+        private static readonly Version MinVersionWithFix = new Version( 14, 28, 2933 );
+        private const string MsVCRelativePath = @"VC\Tools\MSVC";
+        private const string VersionRelativeRoot = "Include";
+
+        public static int Main( string[ ] args )
+        {
+            using var x = new Parser( );
+            return x.ParseArguments( args, typeof(PatchOptions), typeof(GenerateOptions) )
+                    .MapResult( (PatchOptions o) => ApplyPatch( o ),
+                                (GenerateOptions o) => GenerateDiffFile(o),
+                               _ => -1 );
+        }
+
+        private static int ApplyPatch(PatchOptions options)
+        {
+            if( !Directory.Exists( options.VsInstallPath ) )
+            {
+                Console.Error.WriteLine( "Specified VS install path does not exist. '{0}'", options.VsInstallPath );
+                return -1;
+            }
+
+            string msvcPath = Path.Combine( options.VsInstallPath, MsVCRelativePath );
+            if( !Directory.Exists( msvcPath ) )
+            {
+                Console.Error.WriteLine( "Specified VS install path does not contain the MSVC libraries path. '{0}'", msvcPath );
+                return -1;
+            }
+
+            var versions = GetInstalledMsVcVersions( msvcPath ).ToList( );
+            if( versions.Count == 0 )
+            {
+                Console.Error.WriteLine( "Could not find any installed versions at '{0}'", msvcPath );
+                return -1;
+            }
+
+            var maxInstalledVersion = versions.Max( );
+            if( maxInstalledVersion <= MinVersionWithFix )
+            {
+                Console.WriteLine( "Installation already contains the fix from MS no files modified" );
+                return 0;
+            }
+
+            string versionRelativeIncludePath = Path.Combine( msvcPath, maxInstalledVersion.ToString( ), VersionRelativeRoot );
+            if( !Directory.Exists( versionRelativeIncludePath ) )
+            {
+                Console.Error.WriteLine( "Could not find include path '{0}'", versionRelativeIncludePath );
+                return -1;
+            }
+
+            string intrin0_h_Path = Path.Combine( versionRelativeIncludePath, "intrin0.h" );
+            if( !File.Exists( intrin0_h_Path ) )
+            {
+                Console.Error.WriteLine( "intrin0.h not found. ({0})", intrin0_h_Path );
+                return -1;
+            }
+
+            // compute patched content before trying backup as it might not apply to this install
+            string patchedContent = PatchFile( intrin0_h_Path, Resources.Intrin0_h_diff );
+            if( string.IsNullOrWhiteSpace( patchedContent ) )
+            {
+                Console.WriteLine( "File contents did not match - patches not applied." );
+                return 0;
+            }
+
+            string backupPath = Path.Combine( versionRelativeIncludePath, "intrin0.h.bak" );
+            if( File.Exists( backupPath ) && !options.Force )
+            {
+                Console.WriteLine( "Backup already exists, no backup will be made" );
+            }
+            else
+            {
+                try
+                {
+                    File.Copy( intrin0_h_Path, backupPath, false );
+                }
+                catch( IOException ex )
+                {
+                    Console.Error.WriteLine( "ERROR creating backup: {0}", ex.Message );
+                    return -1;
+                }
+            }
+
+            File.WriteAllText( intrin0_h_Path, patchedContent );
+            return 0;
+        }
+
+        private static string PatchFile( string source, string diffText )
+        {
+            string fileText = File.ReadAllText( source );
+            var patches = PatchList.Parse( diffText );
+            var (patchedText, results) = patches.Apply( fileText );
+
+            // all patches must apply or the source wasn't a proper match
+            return results.Aggregate( true, ( l, r ) => l & r ) ? patchedText : string.Empty;
+        }
+
+        private static IEnumerable<Version> GetInstalledMsVcVersions( string msvcPath )
+        {
+            var verPattern = new Regex( @"\d+\.\d+\.\d+" );
+            return from dir in Directory.EnumerateDirectories( msvcPath )
+                   where verPattern.IsMatch( dir )
+                   select Version.Parse( Path.GetFileName( dir ) );
+        }
+
+        // While VS team did publish the GIT patch DIFF, that's not usable by the DiffMatchPatch library
+        // (or any other I could find on short notice). So this is used to generate the DIFF applied.
+        //
+        // The resulting intrin0_h.diff is already part of this project so not likely needed, but
+        // this is retained as a reference for how it was created)
+        private static int GenerateDiffFile( GenerateOptions o )
+        {
+            string unpatched = File.ReadAllText( o.Unpatched );
+            string patched = File.ReadAllText( o.Patched );
+
+            // compute and write the diff file for inclusion
+            File.WriteAllText( "intrin0_h.diff", Patch.Compute( unpatched, patched ).ToText( ) );
+            return 0;
+        }
+    }
+}

--- a/src/PatchVsForLibClang/Resources.cs
+++ b/src/PatchVsForLibClang/Resources.cs
@@ -1,0 +1,38 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="Resources.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+
+namespace PatchVsForLibClang
+{
+    internal static class Resources
+    {
+        // to prevent problems with GIT line ending translation, convert line endings here to the LF form required by the DiffMatchPatch library...
+        public static string Intrin0_h_diff => GetResourceStreamText( ResourceNames.Intrin0_h_diff ).Replace("\r\n","\n", StringComparison.Ordinal);
+
+        private static string GetResourceStreamText( string fileName )
+        {
+            string resName = "PatchVsForLibClang." + fileName;
+            var manifestStream = typeof( Resources ).Assembly.GetManifestResourceStream( resName );
+            if(manifestStream == null)
+            {
+                throw new FileNotFoundException( $"Resource {resName} not found!" );
+            }
+
+            using var rdr = new StreamReader( manifestStream );
+            return rdr.ReadToEnd( );
+        }
+
+        private static class ResourceNames
+        {
+            [SuppressMessage( "Potential Code Quality Issues", "RECS0146:Member hides static member from outer class", Justification = "Intentional" )]
+            [SuppressMessage( "StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Intentional" )]
+            internal const string Intrin0_h_diff = "intrin0_h.diff";
+        }
+    }
+}

--- a/src/PatchVsForLibClang/intrin0_h.diff
+++ b/src/PatchVsForLibClang/intrin0_h.diff
@@ -1,0 +1,15 @@
+﻿@@ -428,251 +428,8 @@
+ H_%0d%0a
+-#ifdef __clang__%0d%0a// This looks like a circular include but it is not because clang overrides %3cintrin.h%3e with their specific version.%0d%0a// See further discussion in LLVM-47099.%0d%0a#include %3cintrin.h%3e%0d%0a#else /* %5e%5e%5e __clang__ // !__clang__ vvv */%0d%0a
+ #inc
+@@ -16617,24 +16617,43 @@
+ r _Shift))%0d%0a
++#ifndef __clang__%0d%0a
+ __MACHINEX86
+@@ -16750,32 +16750,53 @@
+ gned __int64))%0d%0a
++#endif // __clang__%0d%0a
+ __MACHINEX64(uns
+@@ -18275,31 +18275,4 @@
+ */%0d%0a
+-#endif /* %5e%5e%5e !__clang__ */

--- a/src/PatchVsForLibClang/readme.md
+++ b/src/PatchVsForLibClang/readme.md
@@ -1,0 +1,26 @@
+﻿# PatchVsForLibClang
+The VS headers contain a bug, tracked by [microsoft/STL bug 1300](https://github.com/microsoft/STL/issues/1300),
+that causes failures to parse correctly with LibClang, which is used by the LlvmBindingsGenerator.
+
+Unfortunately the fix is not made as a hotpatch as of this time, and is only included in
+VS 2019 16.9 Preview 2. This makes it unavailable to automated builds where the hosting platform
+doesn't make environments available with preview releases of VS. Fortunately the fix is small,
+and the STL team even published the GIT patch file for intrin0.h (the core file that triggers
+the issues).
+
+This project contains a program to apply a patch to the existing installation of VS (making a
+ backup of the original, of course :grin:)
+
+Usage:  
+`PatchVsForLibClang <VsInstallPath>`
+
+Where:  
+VsInstallPath is the installation path of a VS instance. Normally this is retrieved in a PowerShell
+script from a VS Setup Instance (See the [vssetup.powershell](https://github.com/Microsoft/vssetup.powershell)
+repo for more information)
+
+Example:  
+`PatchVsForLibClang "D:\Program Files (x86)\Microsoft Visual Studio\2019\Community"`
+
+This will patch the file @"D:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29333\include\intrin0.h"
+creating a backup file (intrin0.h.bak) in the same directory


### PR DESCRIPTION
* Corrected build scripts to allow VS pre-release versions.
* Updated to CPPSharp 0.10.2 (NOTE: 0.10.3-0.10.5 have distinct issues that trigger a dereference of NULL in native code)

With this change and VS 16.9 preview 2 or later you can build with the following PowerShell command:
```PowerShell
.\Build-All.ps1 -AllowVsPreReleases
```
**NOTE:**  This requires VS 16.9 Preview 2 or later to work

This is related to #197 though it isn't really a fix for it as the fix is in VS