### PR TITLE
Added support for creating MemoryBuffer from a byte array

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -18,8 +18,8 @@
         <PackageReference Update="OpenSoftware.DgmlBuilder" Version="1.14.0" />
         <PackageReference Update="System.Collections.Immutable" Version="1.7.0" />
         <!-- See: https://github.com/dotnet/docfx/issues/5536 before updating...-->
-        <PackageReference Update="docfx.console" Version="2.48.1" />
-        <PackageReference Update="memberpage" Version="2.49.0" />
+        <PackageReference Update="docfx.console" Version="2.56.6" />
+        <PackageReference Update="memberpage" Version="2.56.6" />
         <PackageReference Update="msdn.4.5.2" Version="0.1.0-alpha-1611021200" />
         <PackageReference Update="YamlDotNet" Version="8.1.0" />
         <PackageReference Update="google-diff-match-patch" Version="1.1.24" />

--- a/src/Interop/LlvmBindingsGenerator/Configuration/Yaml/YamlArrayMarshalInfo.cs
+++ b/src/Interop/LlvmBindingsGenerator/Configuration/Yaml/YamlArrayMarshalInfo.cs
@@ -56,7 +56,26 @@ namespace LlvmBindingsGenerator.Configuration
 
         public override QualifiedType TransformType( QualifiedType type )
         {
-            return new QualifiedType( new ArrayType( ) { QualifiedType = ( type.Type as PointerType ).QualifiedPointee } );
+            // attempt to get a more precise type than sbyte* for byte sized values and bool
+            QualifiedType elementType;
+            switch(SubType)
+            {
+            case UnmanagedType.Bool:
+                elementType = new QualifiedType( new BuiltinType( PrimitiveType.Bool ), type.Qualifiers);
+                break;
+
+            case UnmanagedType.I1:
+                elementType = new QualifiedType( new BuiltinType( PrimitiveType.SChar ), type.Qualifiers );
+                break;
+            case UnmanagedType.U1:
+                elementType = new QualifiedType( new BuiltinType( PrimitiveType.UChar ), type.Qualifiers );
+                break;
+            default:
+                elementType = ( type.Type as PointerType ).QualifiedPointee;
+                break;
+            }
+
+            return new QualifiedType( new ArrayType( ) { QualifiedType = elementType } );
         }
     }
 }

--- a/src/Interop/LlvmBindingsGenerator/LlvmBindingsGenerator.csproj
+++ b/src/Interop/LlvmBindingsGenerator/LlvmBindingsGenerator.csproj
@@ -12,9 +12,10 @@
         This means that this project can't use language features > 7.3 (Limits for .NET Framework)
         -->
         <TargetFramework>net47</TargetFramework>
-        <Nullable/>
+        <Nullable />
     </PropertyGroup>
     <ItemGroup>
+        <PackageReference Include="CommandLineParser" />
         <PackageReference Include="Ubiquity.ArgValidators" />
         <PackageReference Include="CppSharp" />
         <PackageReference Include="YamlDotNet" />

--- a/src/Interop/LlvmBindingsGenerator/Options.cs
+++ b/src/Interop/LlvmBindingsGenerator/Options.cs
@@ -1,0 +1,39 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="Options.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+using CommandLine;
+
+using CppSharp;
+
+namespace LlvmBindingsGenerator
+{
+    [SuppressMessage("Build", "CA1812", Justification = "Instantiated via reflection from commandline parser" )]
+    internal class Options
+    {
+        public Options( string llvmRoot, string extensionsRoot, string outputPath, DiagnosticKind diagnostics )
+        {
+            LlvmRoot = llvmRoot;
+            ExtensionsRoot = extensionsRoot;
+            OutputPath = outputPath;
+            Diagnostics = diagnostics;
+        }
+
+        [Value( 0, MetaName = "LLVM Root", HelpText = "Root of source with the LLVM headers to parse", Required = true )]
+        public string LlvmRoot { get; }
+
+        [Value( 1, MetaName = "Extensions Root", HelpText = "Root of source with the LibLLVM extension headers to parse", Required = true )]
+        public string ExtensionsRoot { get; }
+
+        [Value( 2, MetaName = "Output Path", HelpText = "Root of the output to place the generated code", Required = true )]
+        public string OutputPath { get; } = Environment.CurrentDirectory;
+
+        [Option( HelpText = "Diagnostics output level", Required = false, Default = DiagnosticKind.Message )]
+        public DiagnosticKind Diagnostics { get; }
+    }
+}

--- a/src/Interop/LlvmBindingsGenerator/bindingsConfig.yml
+++ b/src/Interop/LlvmBindingsGenerator/bindingsConfig.yml
@@ -70,7 +70,7 @@
 #
 #   !Array
 #       SubType - the unmanaged type of the elements of the array (See: System.Runtime.InteropServices.UnmanagedType enum for details)
-#       SizeParam - optional integer index of an out parmater that contains the size of the array
+#       SizeParam - optional integer index of an out parmater that contains the size of the array [for out params]
 #
 FunctionBindings:
   - Name: LLVMMDStringInContext
@@ -191,10 +191,12 @@ FunctionBindings:
   - Name: LLVMStartMultithreaded
     IsObsolete: True
     DeprecationMessage: "This function is deprecated, multi-threading support is a compile-time variable and cannot be changed at run-time"
+    IsProjected: False
 
   - Name: LLVMStopMultithreaded
     IsObsolete: True
     DeprecationMessage: "This function is deprecated, multi-threading support is a compile-time variable and cannot be changed at run-time"
+    IsProjected: False
 
   - Name: LLVMCreateBinary
     ParamTransforms:
@@ -1075,6 +1077,16 @@ FunctionBindings:
 
   - Name: LLVMSymbolLookupCallback
     ReturnTransform: !String {Kind: CopyAlias}
+
+    # lifetime management of shared ownership between managed and unmanaged semantics in .NET is dodgy at best
+    # so this is exported, but not projected to allow for experimentation until a safe way of managing
+    # the shared/pinned nature of things is determined
+  - Name: LLVMCreateMemoryBufferWithMemoryRange
+    IsProjected: false
+
+  - Name: LLVMCreateMemoryBufferWithMemoryRangeCopy
+    ParamTransforms:
+      - !Array { Name: InputData, Semantics: In }
 
 # The HandleMap Lists the types of handles and their disposal semantics
 #HandleMap:

--- a/src/Ubiquity.NET.Llvm.Tests/MemoryBufferTests.cs
+++ b/src/Ubiquity.NET.Llvm.Tests/MemoryBufferTests.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -83,6 +84,43 @@ namespace Ubiquity.NET.Llvm.Tests
 
             byte[ ] expected = Encoding.ASCII.GetBytes( TestData );
             Assert.IsTrue( expected.AsSpan( 5, 2 ).SequenceEqual( result ) );
+        }
+
+        [TestMethod]
+        public void Buffer_from_array_with_null_name_succeeds( )
+        {
+            byte[ ] data = Range(0, 255);
+            var buffer = new MemoryBuffer(data, null);
+            Assert.IsNotNull( buffer );
+            Assert.AreEqual( 255, buffer.Size );
+        }
+
+        [TestMethod]
+        public void Buffer_from_array_with_valid_name_succeeds( )
+        {
+            byte[ ] data = Range(0, 255);
+            var buffer = new MemoryBuffer(data, "testName");
+            Assert.IsNotNull( buffer );
+            Assert.AreEqual( 255, buffer.Size );
+        }
+
+        [TestMethod]
+        public void Buffer_from_array_contains_correct_data( )
+        {
+            byte[ ] data = Range(0, 255);
+            var buffer = new MemoryBuffer(data);
+            Assert.IsNotNull( buffer );
+            Assert.AreEqual( 255, buffer.Size );
+            var span = buffer.Slice();
+            for(int i = 0; i < data.Length; ++i )
+            {
+                Assert.AreEqual( data[ i ], span[ i ], $"Index {i}" );
+            }
+        }
+
+        private static byte[] Range(byte start, byte length)
+        {
+            return Enumerable.Range( start, length ).Select( n => ( byte )n ).ToArray( );
         }
     }
 }

--- a/src/Ubiquity.NET.Llvm/BitcodeModule.cs
+++ b/src/Ubiquity.NET.Llvm/BitcodeModule.cs
@@ -924,12 +924,9 @@ namespace Ubiquity.NET.Llvm
             buffer.ValidateNotNull( nameof( buffer ) );
             context.ValidateNotNull( nameof( context ) );
 
-            if( LLVMParseBitcodeInContext2( context.ContextHandle, buffer.BufferHandle, out LLVMModuleRef modRef ).Failed )
-            {
-                throw new InternalCodeGeneratorException( Resources.Could_not_parse_bit_code_from_buffer );
-            }
-
-            return context.GetModuleFor( modRef );
+            return LLVMParseBitcodeInContext2( context.ContextHandle, buffer.BufferHandle, out LLVMModuleRef modRef ).Failed
+                ? throw new InternalCodeGeneratorException( Resources.Could_not_parse_bit_code_from_buffer )
+                : context.GetModuleFor( modRef );
         }
 
         internal LLVMModuleRef? ModuleHandle { get; private set; }
@@ -943,7 +940,6 @@ namespace Ubiquity.NET.Llvm
             return retVal!; // can't be null as ThrowIfDisposed would consider it disposed
         }
 
-        [SuppressMessage( "Reliability", "CA2000:Dispose objects before losing scope", Justification = "Context created here is owned, and disposed of via the ContextCache" )]
         internal static BitcodeModule? FromHandle( LLVMModuleRef nativeHandle )
         {
             nativeHandle.ValidateNotDefault( nameof( nativeHandle ) );
@@ -996,16 +992,12 @@ namespace Ubiquity.NET.Llvm
             private protected override BitcodeModule ItemFactory( LLVMModuleRef handle )
             {
                 var contextRef = LLVMGetModuleContext( handle );
-                if( Context.ContextHandle != contextRef )
-                {
-                    throw new ArgumentException( Resources.Context_mismatch_cannot_cache_modules_from_multiple_contexts );
-                }
-
-                return new BitcodeModule( handle );
+                return Context.ContextHandle != contextRef
+                    ? throw new ArgumentException( Resources.Context_mismatch_cannot_cache_modules_from_multiple_contexts )
+                    : new BitcodeModule( handle );
             }
         }
 
-        [SuppressMessage( "Reliability", "CA2000:Dispose objects before losing scope", Justification = "Context created here is owned, and disposed of via the ContextCache" )]
         private BitcodeModule( LLVMModuleRef handle )
         {
             handle.ValidateNotDefault( nameof( handle ) );

--- a/src/Ubiquity.NET.Llvm/JIT/OrcJit.cs
+++ b/src/Ubiquity.NET.Llvm/JIT/OrcJit.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
@@ -22,6 +23,7 @@ namespace Ubiquity.NET.Llvm.JIT
     /// The LLVM OrcJIT supports lazy compilation and better resource management for
     /// clients. For more details on the implementation see the LLVM Documentation.
     /// </remarks>
+    [SuppressMessage( "Style", "IDE0046:Convert to conditional expression", Justification = "multiple levels of the ternary conditional expression is anything but a simplification" )]
     public class OrcJit
         : DisposableObject
         , ILazyCompileExecutionEngine
@@ -107,9 +109,12 @@ namespace Ubiquity.NET.Llvm.JIT
                     throw new InvalidOperationException( string.Format( CultureInfo.CurrentCulture, Resources.Unresolved_Symbol_0_1, name, LLVMOrcGetErrorMsg( JitStackHandle ) ) );
                 }
 
-                return retAddr != 0
-                    ? retAddr
-                    : GlobalInteropFunctions.TryGetValue( name, out WrappedNativeCallback callBack ) ? ( ulong )callBack.ToIntPtr( ).ToInt64( ) : 0;
+                if( retAddr != 0)
+                {
+                    return retAddr;
+                }
+
+                return GlobalInteropFunctions.TryGetValue( name, out WrappedNativeCallback callBack ) ? ( ulong )callBack.ToIntPtr( ).ToInt64( ) : 0;
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch

--- a/src/Ubiquity.NET.Llvm/MemoryBuffer.cs
+++ b/src/Ubiquity.NET.Llvm/MemoryBuffer.cs
@@ -32,6 +32,20 @@ namespace Ubiquity.NET.Llvm
             BufferHandle = handle;
         }
 
+        /// <summary>Initializes a new instance of the <see cref="MemoryBuffer"/> class from a byte array</summary>
+        /// <param name="data">Array of bytes to copy into the memory buffer</param>
+        /// <param name="name">Name of the buffer (for diagnostics)</param>
+        /// <remarks>
+        /// This constructor makes a copy of the data array as a <see cref="MemoryBuffer"/> the memory in the buffer
+        /// is unmanaged memory usable by the LLVM native code. It is released in the Dispose method
+        /// </remarks>
+        public MemoryBuffer( byte[] data, string? name = null)
+        {
+            data.ValidateNotNull( nameof( data ) );
+            BufferHandle = LLVMCreateMemoryBufferWithMemoryRangeCopy( data, data.Length, name ?? string.Empty )
+                          .ThrowIfInvalid( );
+        }
+
         /// <summary>Gets the size of the buffer</summary>
         public int Size => BufferHandle.IsInvalid ? 0 : ( int )LLVMGetBufferSize( BufferHandle );
 

--- a/stylecop.json
+++ b/stylecop.json
@@ -11,7 +11,7 @@
         "namingRules":
         {
             "allowCommonHungarianPrefixes": false,
-            "allowedHungarianPrefixes": ["h", "di", "op", "os", "ir", "is", "do", "un", "on", "to", "if", "no", "v"]
+            "allowedHungarianPrefixes": ["h", "di", "op", "os", "ir", "is", "do", "un", "on", "to", "if", "no", "v","in"]
         },
         "orderingRules":
         {


### PR DESCRIPTION
Resolves #196
---
* Added new constructor to Memory Buffer
* Added new tests for the new MemoryBuffer constructor
* Updated YamalArrayMarshalInfo.TransformType to convert simpler types to signed/unsigned bytes (and bools) based on marshaling attribute
* Added debug messages for detection of char* without any marshaling information. (Most are fine with default treatment as string, however this allows finding others more easily then searching headers)
* Added use of CommandLineParser library to bindings generator to provide standard usage help and allow for optional params (including new diagnostics level so it is an actual parameter now)
* Added suppression of CS rule/suggestion to "simplify" an if statement to a multi level conditional expression. The result of applying the rule is anything but simpler.
* Converted some checks in BitCodeModule to use conditional and throw expressions