### PR TITLE
Fixed generation of calls to varargs functions

### DIFF
--- a/Ubiquity.NET.ruleset
+++ b/Ubiquity.NET.ruleset
@@ -113,7 +113,6 @@
     <Rule Id="CA1715" Action="Error" />
     <Rule Id="CA1717" Action="Warning" />
     <Rule Id="CA1719" Action="Warning" />
-    <Rule Id="CA1720" Action="None" />
     <Rule Id="CA1721" Action="Warning" />
     <Rule Id="CA1722" Action="Warning" />
     <Rule Id="CA1724" Action="Warning" />
@@ -580,9 +579,17 @@
     <Rule Id="IDE0034" Action="Warning" />
     <Rule Id="IDE0058" Action="None" />
     <Rule Id="IDE0067" Action="None" />
+    <Rule Id="IDE0079" Action="Error" />
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.VisualBasic" RuleNamespace="Microsoft.CodeAnalysis.VisualBasic">
     <Rule Id="AD0001" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA1062" Action="Error" />
+    <Rule Id="CA1720" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
+    <Rule Id="CA1303" Action="Hidden" />
   </Rules>
   <Rules AnalyzerId="RefactoringEssentials" RuleNamespace="RefactoringEssentials">
     <Rule Id="RECS0070" Action="None" />
@@ -732,12 +739,5 @@
     <Rule Id="SA1651" Action="Error" />
     <Rule Id="SA1652" Action="Warning" />
     <Rule Id="SX1101" Action="Error" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
-    <Rule Id="CA1720" Action="None" />
-    <Rule Id="CA1062" Action="Error" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
-    <Rule Id="CA1303" Action="Hidden" />
   </Rules>
 </RuleSet>

--- a/src/Ubiquity.NET.Llvm.Tests/CallTests.cs
+++ b/src/Ubiquity.NET.Llvm.Tests/CallTests.cs
@@ -1,0 +1,47 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="CallTests.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Linq;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Ubiquity.NET.Llvm.Instructions;
+using Ubiquity.NET.Llvm.Types;
+using Ubiquity.NET.Llvm.Values;
+
+namespace Ubiquity.NET.Llvm.Tests
+{
+    [TestClass]
+    public class CallTests
+    {
+        [TestMethod]
+        [TestCategory( "Instruction" )]
+        public void Create_varargs_function_with_arbitrary_params_succeeds()
+        {
+            using var ctx = new Context();
+            var module = ctx.CreateBitcodeModule();
+            var varArgsSig = ctx.GetFunctionType(ctx.VoidType, Enumerable.Empty<ITypeRef>(), true);
+            var callerSig = ctx.GetFunctionType(ctx.VoidType);
+
+            var function = module.CreateFunction( "VarArgFunc", varArgsSig );
+            var entryBlock = function.PrependBasicBlock("entry");
+            var bldr = new InstructionBuilder(entryBlock);
+            bldr.Return( );
+
+            var caller = module.CreateFunction("CallVarArgs", callerSig);
+            entryBlock = caller.PrependBasicBlock( "entry" );
+            bldr = new InstructionBuilder( entryBlock );
+            var callInstruction = bldr.Call( function, ctx.CreateConstant( 0 ), ctx.CreateConstant( 1 ), ctx.CreateConstant( 2 ) );
+            Assert.IsNotNull( callInstruction );
+
+            // operands of call are all arguments, plus the target function
+            Assert.AreEqual( 4, callInstruction.Operands.Count );
+            Assert.AreEqual( 0UL, callInstruction.Operands.GetOperand<ConstantInt>( 0 )!.ZeroExtendedValue );
+            Assert.AreEqual( 1UL, callInstruction.Operands.GetOperand<ConstantInt>( 1 )!.ZeroExtendedValue );
+            Assert.AreEqual( 2UL, callInstruction.Operands.GetOperand<ConstantInt>( 2 )!.ZeroExtendedValue );
+        }
+    }
+}

--- a/src/Ubiquity.NET.Llvm/Instructions/InstructionBuilder.cs
+++ b/src/Ubiquity.NET.Llvm/Instructions/InstructionBuilder.cs
@@ -1864,12 +1864,15 @@ namespace Ubiquity.NET.Llvm.Instructions
                 throw new ArgumentException( Resources.A_pointer_to_a_function_is_required_for_an_indirect_call, nameof( func ) );
             }
 
-            if( args.Count != signatureType.ParameterTypes.Count )
+            // validate arg count; too few or too many (unless the signature supports varargs) is an error
+            if( args.Count < signatureType.ParameterTypes.Count
+                || ( args.Count > signatureType.ParameterTypes.Count && !signatureType.IsVarArg )
+              )
             {
                 throw new ArgumentException( Resources.Mismatched_parameter_count_with_call_site, nameof( args ) );
             }
 
-            for( int i = 0; i < args.Count; ++i )
+            for( int i = 0; i < signatureType.ParameterTypes.Count; ++i )
             {
                 if( args[ i ].NativeType != signatureType.ParameterTypes[ i ] )
                 {


### PR DESCRIPTION
The validation of args for call sites was overly protective, to the point of failing for varargs functions as by definition they accept more args than the signature specifies. This change updates the validation to specifically handle varargs, while still validating all of the fixed args.