### PR TITLE
Constant data string

### DIFF
--- a/Ubiquity.NET.ruleset
+++ b/Ubiquity.NET.ruleset
@@ -113,7 +113,6 @@
     <Rule Id="CA1715" Action="Error" />
     <Rule Id="CA1717" Action="Warning" />
     <Rule Id="CA1719" Action="Warning" />
-    <Rule Id="CA1720" Action="None" />
     <Rule Id="CA1721" Action="Warning" />
     <Rule Id="CA1722" Action="Warning" />
     <Rule Id="CA1724" Action="Warning" />
@@ -580,9 +579,17 @@
     <Rule Id="IDE0034" Action="Warning" />
     <Rule Id="IDE0058" Action="None" />
     <Rule Id="IDE0067" Action="None" />
+    <Rule Id="IDE0079" Action="Error" />
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.VisualBasic" RuleNamespace="Microsoft.CodeAnalysis.VisualBasic">
     <Rule Id="AD0001" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA1062" Action="Error" />
+    <Rule Id="CA1720" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
+    <Rule Id="CA1303" Action="Hidden" />
   </Rules>
   <Rules AnalyzerId="RefactoringEssentials" RuleNamespace="RefactoringEssentials">
     <Rule Id="RECS0070" Action="None" />
@@ -732,12 +739,5 @@
     <Rule Id="SA1651" Action="Error" />
     <Rule Id="SA1652" Action="Warning" />
     <Rule Id="SX1101" Action="Error" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
-    <Rule Id="CA1720" Action="None" />
-    <Rule Id="CA1062" Action="Error" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
-    <Rule Id="CA1303" Action="Hidden" />
   </Rules>
 </RuleSet>

--- a/docfx/current/ReleaseNotes.md
+++ b/docfx/current/ReleaseNotes.md
@@ -3,7 +3,7 @@
 
 ## Breaking changes
 With the 10.* release the Ubiquity.NET.Llvm.* libs have made a number of breaking changes.
-While these are mostly small and easily adapted to they are still a breaking change. Thus,
+While these are mostly small and easily adapted to, they are still a breaking change. Thus,
 these changes were held to only occur on a Major release. Despite the pain of updating code
 we think the changes are worth the effort to create a cleaner simpler and more consistent library.
 
@@ -16,7 +16,7 @@ projects no longer maintained.
 | Old Name                  | New Name     |
 |---------------------------|--------------|
 | Ubiquity.NET.Llvm.Interop | Ubiquity.Net.Llvm.Interop |
-| LibLLVM.dll               | Ubiquity.Net.LibLLVM.dll  |
+| LibLLVM.dll               | Ubiquity.Net.LibLLVM      |
 | Ubiquity.NET.Llvm         | Ubiquity.Net.Llvm         |
 
 ### Library initialization
@@ -27,8 +27,9 @@ is done through this interface. This prevents accidental use of the registration
 initializing the library (as that's a guaranteed app crash!)
 
 ### C#8 and non-Nullable references
-With the 10.* release the Ubiquity.NET.Llvm.* libs all updated to target .NET Standard 2.1 and C#8. This allows use of nullable types
-to make nullability more explicit. This necessitated a few minor breaking changes in the object model surface.
+With the 10.* release the Ubiquity.NET.Llvm.* libs all updated to target .NET Standard 2.1 and C#8. This allows
+use of nullable types to make nullability more explicit. This necessitated a few minor breaking changes in the
+object model surface.
 
 | Name            | Description  |
 |-----------------|--------------|
@@ -36,8 +37,8 @@ to make nullability more explicit. This necessitated a few minor breaking change
 
 
 ### Renamed instruction predicate enumerator values
-The comparison instruction predicates `Ubiquity.NET.Llvm.Instructions.[Predicate|IntPredicate]`were renamed for greater consistency
-and clarity (Some of the float predicates had 'Than' in the name while the integer counterparts did not. (See:
+The comparison instruction predicates `Ubiquity.NET.Llvm.Instructions.[Predicate|IntPredicate]`were renamed for greater
+consistency and clarity (Some of the float predicates had 'Than' in the name while the integer counterparts did not. (See:
 [Bug #152](https://github.com/UbiquityDotNET/Llvm.NET/issues/152) for details.)
 
 | Old Name               | New Name     |
@@ -73,21 +74,30 @@ a sized type is created, even if the size is 0 because no members are provided. 
 anonymous empty structs, used in many languages. To create a named opaque type then the overload with just the
 name is used. This isn't expected to impact many consumers, other than the tests, but it is a breaking change.
 
+#### Context.CreateConstantString()
+The behavior of Context.CreateConstantString(string) has changed slightly. It now constructs a valid C string with
+a null terminator, which is generally what would be expected of something called "string". (The (string,bool)
+overload remains, to allow apps to be explicit with intent) Additionally, the ConstantDataSequential.IsString
+property now reflects whether the string is a C string (terminating null but no embedded nulls) and the
+ConstantDataSequential.IsI8Sequence was added to provide the previous behavior of IsString, which was simply that
+the underlying sequence element type was i8 (with or without a terminator)
+
 ### Removed redundant APIs
-LLVM has made additional APIs available in the standard LLVM-C library that are either identical to or functionality equivalent to 
-APIs that were custom in previous versions of the Ubiquity.NET.Llvm DLLs. This is only observable at the interop library layer where some
-of the custom APIs were removed and replaced with the official ones.
+LLVM has made additional APIs available in the standard LLVM-C library that are either identical to or functionality
+equivalent to APIs that were custom in previous versions of the Ubiquity.NET.Llvm DLLs. This is only observable at
+the interop library layer where some of the custom APIs were removed and replaced with the official ones.
 
 | Removed custom API | New Official API |
 |--------------------|------------------|
 | LibLLVMFoo [TBD]   | LLVMFoo [TBD]    |
 
 ### Disabled ORCJIT LazyFunction binding
-Unfortunately, the ORCJIT truly lazy function generation callback support is currently disabled. LLVM itself is transitioning to the ORCJIT v2 and in the process
-broke the lazy function binding support (At least for Windows+COFF). Previously a workaround for the issue of the COFF exports was applied in the 
-Llvm.NET ORCJIT library code for symbol lookups. However, with ORCJIT v2 the JIT itself is doing lookups and it does so only for external symbols
-assuming the symbols it generates internally will be exports, but are not (at least for COFF modules anyway).
-For more details see the LLVM bugs [25493](https://bugs.llvm.org/show_bug.cgi?id=25493) and [28699](https://bugs.llvm.org/show_bug.cgi?id=28699)
+Unfortunately, the ORCJIT truly lazy function generation callback support is currently disabled. LLVM itself is
+transitioning to the ORCJIT v2 and in the process broke the lazy function binding support (At least for Windows+COFF).
+Previously a workaround for the issue of the COFF exports was applied in the Llvm.NET ORCJIT library code for symbol
+lookups. However, with ORCJIT v2 the JIT itself is doing lookups and it does so only for external symbols assuming the
+symbols it generates internally will be exports, but are not (at least for COFF modules anyway). For more details see
+the LLVM bugs [25493](https://bugs.llvm.org/show_bug.cgi?id=25493) and [28699](https://bugs.llvm.org/show_bug.cgi?id=28699)
 
 ## v8.0.1
 ### Bug Fixes

--- a/src/Interop/LibLLVM/ValueBindings.cpp
+++ b/src/Interop/LibLLVM/ValueBindings.cpp
@@ -26,7 +26,7 @@ extern "C"
     LLVMBool LibLLVMIsConstantZeroValue( LLVMValueRef valueRef )
     {
         auto pConstant = dyn_cast< Constant >( unwrap( valueRef ) );
-        if( pConstant == nullptr )
+        if ( pConstant == nullptr )
             return 0;
 
         return pConstant->isZeroValue( ) ? 1 : 0;
@@ -35,7 +35,7 @@ extern "C"
     void LibLLVMRemoveGlobalFromParent( LLVMValueRef valueRef )
     {
         auto pGlobal = dyn_cast< GlobalVariable >( unwrap( valueRef ) );
-        if( pGlobal == nullptr )
+        if ( pGlobal == nullptr )
             return;
 
         pGlobal->removeFromParent( );
@@ -43,7 +43,7 @@ extern "C"
 
     LibLLVMValueKind LibLLVMGetValueKind( LLVMValueRef valueRef )
     {
-        return static_cast<LibLLVMValueKind>( unwrap( valueRef )->getValueID( ) );
+        return static_cast< LibLLVMValueKind >( unwrap( valueRef )->getValueID( ) );
     }
 
     LLVMValueRef LibLLVMGetAliasee( LLVMValueRef Val )
@@ -55,7 +55,7 @@ extern "C"
     void LibLLVMGlobalVariableAddDebugExpression( LLVMValueRef /*GlobalVariable*/ globalVar, LLVMMetadataRef exp )
     {
         auto gv = unwrap<GlobalVariable>( globalVar );
-        gv->addDebugInfo( unwrap<DIGlobalVariableExpression>( exp ));
+        gv->addDebugInfo( unwrap<DIGlobalVariableExpression>( exp ) );
     }
 
     void LibLLVMFunctionAppendBasicBlock( LLVMValueRef /*Function*/ function, LLVMBasicBlockRef block )
@@ -87,5 +87,22 @@ extern "C"
     intptr_t LibLLVMValueCacheLookup( LibLLVMValueCacheRef cacheRef, LLVMValueRef valueRef )
     {
         return unwrap( cacheRef )->lookup( unwrap( valueRef ) );
+    }
+
+    LLVMBool LibLLVMIsConstantCString( LLVMValueRef C )
+    {
+        return unwrap<ConstantDataSequential>( C )->isCString( );
+    }
+
+    uint32_t LibLLVMGetConstantDataSequentialElementCount( LLVMValueRef C )
+    {
+        return unwrap<ConstantDataSequential>( C )->getNumElements( );
+    }
+
+    const char* LibLLVMGetConstantDataSequentialRawData( LLVMValueRef C, size_t* Length )
+    {
+        StringRef Str = unwrap<ConstantDataSequential>( C )->getRawDataValues( );
+        *Length = Str.size( );
+        return Str.data( );
     }
 }

--- a/src/Interop/LibLLVM/include/libllvm-c/ValueBindings.h
+++ b/src/Interop/LibLLVM/include/libllvm-c/ValueBindings.h
@@ -67,6 +67,14 @@ extern "C" {
     void LibLLVMDisposeValueCache( LibLLVMValueCacheRef cacheRef );
     void LibLLVMValueCacheAdd( LibLLVMValueCacheRef cacheRef, LLVMValueRef value, intptr_t handle );
     intptr_t LibLLVMValueCacheLookup( LibLLVMValueCacheRef cacheRef, LLVMValueRef valueRef );
+
+    // Detect if a ConstantDataSequentioal is a C string (i8 sequence terminated with \0 and no embedded \0)
+    LLVMBool LibLLVMIsConstantCString(LLVMValueRef C);
+
+    // Retrieve the number of elements in a ConstantDataSequential
+    uint32_t LibLLVMGetConstantDataSequentialElementCount( LLVMValueRef C );
+
+    const char* LibLLVMGetConstantDataSequentialRawData( LLVMValueRef C, size_t* Length );
 #ifdef __cplusplus
 }
 #endif

--- a/src/Interop/LlvmBindingsGenerator/Program.cs
+++ b/src/Interop/LlvmBindingsGenerator/Program.cs
@@ -6,6 +6,7 @@
 
 using System.IO;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 using CommandLine;
 
@@ -30,14 +31,44 @@ namespace LlvmBindingsGenerator
             };
 
             Diagnostics.Implementation = diagnostics;
-
-            // read in the binding configuration from the YAML file
-            // It is hoped, that going forward, the YAML file is the only thing that needs to change
-            // but either way, it helps keep the declarative part in a more easily edited format.
             string configPath = Path.Combine( Path.GetDirectoryName( Assembly.GetExecutingAssembly().Location ), "BindingsConfig.yml");
-            var config = new ReadOnlyConfig( YamlConfiguration.ParseFrom( configPath ) );
-            var library = new LibLlvmGeneratorLibrary( config, options.LlvmRoot, options.ExtensionsRoot, options.OutputPath );
-            Driver.Run( library );
+
+            try
+            {
+                // read in the binding configuration from the YAML file
+                // It is hoped, that going forward, the YAML file is the only thing that needs to change
+                // but either way, it helps keep the declarative part in a more easily edited format.
+                var config = new ReadOnlyConfig( YamlConfiguration.ParseFrom( configPath ) );
+                var library = new LibLlvmGeneratorLibrary( config, options.LlvmRoot, options.ExtensionsRoot, options.OutputPath );
+                Driver.Run( library );
+            }
+            catch(IOException ioex)
+            {
+                Diagnostics.Error( ioex.Message );
+            }
+            catch(YamlDotNet.Core.SyntaxErrorException yamlex)
+            {
+                // Sadly the yaml exception message includes the location info in a format that doesn't match any standard tooling
+                // for parsing error messages, so unpack it to get just the message of interest and re-format
+                var matcher = new Regex(@"\(Line\: \d+, Col\: \d+, Idx\: \d+\) - \(Line\: \d+, Col\: \d+, Idx\: \d+\)\: (.*)\Z");
+                var result = matcher.Match( yamlex.Message );
+                if( result.Success )
+                {
+                    Diagnostics.Error( "{0}({1},{2},{3},{4}): error CFG001: {5}"
+                                     , configPath
+                                     , yamlex.Start.Line
+                                     , yamlex.Start.Column
+                                     , yamlex.End.Line
+                                     , yamlex.End.Column
+                                     , result.Groups[ 1 ] );
+                }
+                else
+                {
+                    // message didn't match expectations, best effort at this point...
+                    Diagnostics.Error( yamlex.Message );
+                }
+            }
+
             return diagnostics.ErrorCount;
             /* TODO:
             Auto merge the generated docs XML with the Hand edited API Docs as hand merging is tedious and error prone.

--- a/src/Interop/LlvmBindingsGenerator/bindingsConfig.yml
+++ b/src/Interop/LlvmBindingsGenerator/bindingsConfig.yml
@@ -1088,6 +1088,9 @@ FunctionBindings:
     ParamTransforms:
       - !Array { Name: InputData, Semantics: In }
 
+  - Name: LibLLVMGetConstantDataSequentialRawData
+    ReturnTransform: !Unsafe {}
+
 # The HandleMap Lists the types of handles and their disposal semantics
 #HandleMap:
 #    - !ContextHandle { HandleName: LLVMTypeRef}

--- a/src/Ubiquity.NET.Llvm.Tests/CallTests.cs
+++ b/src/Ubiquity.NET.Llvm.Tests/CallTests.cs
@@ -1,0 +1,47 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="CallTests.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Linq;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Ubiquity.NET.Llvm.Instructions;
+using Ubiquity.NET.Llvm.Types;
+using Ubiquity.NET.Llvm.Values;
+
+namespace Ubiquity.NET.Llvm.Tests
+{
+    [TestClass]
+    public class CallTests
+    {
+        [TestMethod]
+        [TestCategory( "Instruction" )]
+        public void Create_varargs_function_with_arbitrary_params_succeeds()
+        {
+            using var ctx = new Context();
+            var module = ctx.CreateBitcodeModule();
+            var varArgsSig = ctx.GetFunctionType(ctx.VoidType, Enumerable.Empty<ITypeRef>(), true);
+            var callerSig = ctx.GetFunctionType(ctx.VoidType);
+
+            var function = module.CreateFunction( "VarArgFunc", varArgsSig );
+            var entryBlock = function.PrependBasicBlock("entry");
+            var bldr = new InstructionBuilder(entryBlock);
+            bldr.Return( );
+
+            var caller = module.CreateFunction("CallVarArgs", callerSig);
+            entryBlock = caller.PrependBasicBlock( "entry" );
+            bldr = new InstructionBuilder( entryBlock );
+            var callInstruction = bldr.Call( function, ctx.CreateConstant( 0 ), ctx.CreateConstant( 1 ), ctx.CreateConstant( 2 ) );
+            Assert.IsNotNull( callInstruction );
+
+            // operands of call are all arguments, plus the target function
+            Assert.AreEqual( 4, callInstruction.Operands.Count );
+            Assert.AreEqual( 0UL, callInstruction.Operands.GetOperand<ConstantInt>( 0 )!.ZeroExtendedValue );
+            Assert.AreEqual( 1UL, callInstruction.Operands.GetOperand<ConstantInt>( 1 )!.ZeroExtendedValue );
+            Assert.AreEqual( 2UL, callInstruction.Operands.GetOperand<ConstantInt>( 2 )!.ZeroExtendedValue );
+        }
+    }
+}

--- a/src/Ubiquity.NET.Llvm.Tests/ContextTests.cs
+++ b/src/Ubiquity.NET.Llvm.Tests/ContextTests.cs
@@ -141,7 +141,7 @@ namespace Ubiquity.NET.Llvm.Tests
         }
 
         [TestMethod]
-        [TestCategory("Function Type")]
+        [TestCategory( "Function Type" )]
         public void CreateFunctionTypeTest( )
         {
             var targetMachine = TargetTests.GetTargetMachine( );
@@ -211,7 +211,7 @@ namespace Ubiquity.NET.Llvm.Tests
         }
 
         [TestMethod]
-        [TestCategory("Function Type")]
+        [TestCategory( "Function Type" )]
         public void VerifySameFunctionSigRetrievesTheSameType( )
         {
             using var context = new Context( );
@@ -600,10 +600,10 @@ namespace Ubiquity.NET.Llvm.Tests
         {
             using var context = new Context( );
             var value = context.CreateConstantStruct( true
-                                                        , context.CreateConstant( ( byte )1)
-                                                        , context.CreateConstant( 2.0f )
-                                                        , context.CreateConstant( ( short )-3 )
-                                                        );
+                                                    , context.CreateConstant( ( byte )1)
+                                                    , context.CreateConstant( 2.0f )
+                                                    , context.CreateConstant( ( short )-3 )
+                                                    );
             Assert.AreEqual( 3, value.Operands.Count );
             Assert.IsInstanceOfType( value.Operands[ 0 ], typeof( ConstantInt ) );
             Assert.IsInstanceOfType( value.Operands[ 1 ], typeof( ConstantFP ) );
@@ -631,16 +631,16 @@ namespace Ubiquity.NET.Llvm.Tests
         {
             using var context = new Context( );
             var nestedValue = context.CreateConstantStruct( false
-                                                              , context.CreateConstant( 5 )
-                                                              , context.CreateConstantString("Hello")
-                                                              , context.CreateConstant( 6 )
-                                                              );
+                                                          , context.CreateConstant( 5 )
+                                                          , context.CreateConstantString("Hello")
+                                                          , context.CreateConstant( 6 )
+                                                          );
             var value = context.CreateConstantStruct( true
-                                                        , context.CreateConstant( ( byte )1)
-                                                        , context.CreateConstant( 2.0f )
-                                                        , nestedValue
-                                                        , context.CreateConstant( ( short )-3 )
-                                                        );
+                                                    , context.CreateConstant( ( byte )1)
+                                                    , context.CreateConstant( 2.0f )
+                                                    , nestedValue
+                                                    , context.CreateConstant( ( short )-3 )
+                                                    );
             Assert.AreEqual( 4, value.Operands.Count );
             Assert.IsInstanceOfType( value.Operands[ 0 ], typeof( ConstantInt ) );
             Assert.IsInstanceOfType( value.Operands[ 1 ], typeof( ConstantFP ) );
@@ -678,10 +678,10 @@ namespace Ubiquity.NET.Llvm.Tests
         {
             using var context = new Context( );
             var value = context.CreateConstantStruct( false
-                                                        , context.CreateConstant( ( byte )1)
-                                                        , context.CreateConstant( 2.0f )
-                                                        , context.CreateConstant( ( short )-3 )
-                                                        );
+                                                    , context.CreateConstant( ( byte )1)
+                                                    , context.CreateConstant( 2.0f )
+                                                    , context.CreateConstant( ( short )-3 )
+                                                    );
             Assert.AreEqual( 3, value.Operands.Count );
             Assert.IsInstanceOfType( value.Operands[ 0 ], typeof( ConstantInt ) );
             Assert.IsInstanceOfType( value.Operands[ 1 ], typeof( ConstantFP ) );
@@ -742,9 +742,9 @@ namespace Ubiquity.NET.Llvm.Tests
         {
             using var context = new Context( );
             var fields = new List<Constant> { context.CreateConstant( ( byte )1 )
-                                                , context.CreateConstant( 2.0f )
-                                                , context.CreateConstant( ( short )-3 )
-                                                };
+                                            , context.CreateConstant( 2.0f )
+                                            , context.CreateConstant( ( short )-3 )
+                                            };
             var value = context.CreateConstantStruct( false, fields );
             Assert.AreEqual( 3, value.Operands.Count );
             Assert.IsInstanceOfType( value.Operands[ 0 ], typeof( ConstantInt ) );
@@ -768,15 +768,15 @@ namespace Ubiquity.NET.Llvm.Tests
         }
 
         [TestMethod]
-        [TestCategory("Constants")]
+        [TestCategory( "Constants" )]
         public void CreateNamedConstantPackedStructTestUsingEnumerable( )
         {
             using var context = new Context( );
             var structType = context.CreateStructType( "struct.test", true, context.Int8Type, context.FloatType, context.Int16Type );
             var fields = new List<Constant> { context.CreateConstant( ( byte )1 )
-                                                , context.CreateConstant( 2.0f )
-                                                , context.CreateConstant( ( short )-3 )
-                                                };
+                                            , context.CreateConstant( 2.0f )
+                                            , context.CreateConstant( ( short )-3 )
+                                            };
             var value = context.CreateNamedConstantStruct( structType, fields );
             Assert.AreEqual( 3, value.Operands.Count );
             Assert.IsInstanceOfType( value.Operands[ 0 ], typeof( ConstantInt ) );
@@ -805,15 +805,15 @@ namespace Ubiquity.NET.Llvm.Tests
         {
             using var context = new Context( );
             var structType = context.CreateStructType( "struct.test"
-                                                         , false
-                                                         , context.Int8Type
-                                                         , context.FloatType
-                                                         , context.Int16Type
-                                                         );
+                                                     , false
+                                                     , context.Int8Type
+                                                     , context.FloatType
+                                                     , context.Int16Type
+                                                     );
             var fields = new List<Constant> { context.CreateConstant( ( byte )1 )
-                                                , context.CreateConstant( 2.0f )
-                                                , context.CreateConstant( ( short )-3 )
-                                                };
+                                            , context.CreateConstant( 2.0f )
+                                            , context.CreateConstant( ( short )-3 )
+                                            };
             var value = context.CreateNamedConstantStruct( structType, fields );
             Assert.AreEqual( 3, value.Operands.Count );
             Assert.IsInstanceOfType( value.Operands[ 0 ], typeof( ConstantInt ) );
@@ -842,16 +842,16 @@ namespace Ubiquity.NET.Llvm.Tests
         {
             using var context = new Context( );
             var structType = context.CreateStructType( "struct.test"
-                                                         , true
-                                                         , context.Int8Type
-                                                         , context.FloatType
-                                                         , context.Int16Type
-                                                         );
+                                                     , true
+                                                     , context.Int8Type
+                                                     , context.FloatType
+                                                     , context.Int16Type
+                                                     );
             var value = context.CreateNamedConstantStruct( structType
-                                                             , context.CreateConstant( ( byte )1 )
-                                                             , context.CreateConstant( 2.0f )
-                                                             , context.CreateConstant( ( short )-3 )
-                                                             );
+                                                         , context.CreateConstant( ( byte )1 )
+                                                         , context.CreateConstant( 2.0f )
+                                                         , context.CreateConstant( ( short )-3 )
+                                                         );
             Assert.AreEqual( 3, value.Operands.Count );
             Assert.IsInstanceOfType( value.Operands[ 0 ], typeof( ConstantInt ) );
             Assert.IsInstanceOfType( value.Operands[ 1 ], typeof( ConstantFP ) );
@@ -879,16 +879,16 @@ namespace Ubiquity.NET.Llvm.Tests
         {
             using var context = new Context( );
             var structType = context.CreateStructType( "struct.test"
-                                                         , false
-                                                         , context.Int8Type
-                                                         , context.FloatType
-                                                         , context.Int16Type
-                                                         );
+                                                     , false
+                                                     , context.Int8Type
+                                                     , context.FloatType
+                                                     , context.Int16Type
+                                                     );
             var value = context.CreateNamedConstantStruct( structType
-                                                             , context.CreateConstant( ( byte )1 )
-                                                             , context.CreateConstant( 2.0f )
-                                                             , context.CreateConstant( ( short )-3 )
-                                                             );
+                                                         , context.CreateConstant( ( byte )1 )
+                                                         , context.CreateConstant( 2.0f )
+                                                         , context.CreateConstant( ( short )-3 )
+                                                         );
             Assert.AreEqual( 3, value.Operands.Count );
             Assert.IsInstanceOfType( value.Operands[ 0 ], typeof( ConstantInt ) );
             Assert.IsInstanceOfType( value.Operands[ 1 ], typeof( ConstantFP ) );
@@ -943,15 +943,64 @@ namespace Ubiquity.NET.Llvm.Tests
 
         [TestMethod]
         [TestCategory( "Constants" )]
-        public void CreateConstantStringTest( )
+        public void CreateConstantCStringTest( )
         {
             using var context = new Context( );
             string str = "hello world";
             ConstantDataArray value = context.CreateConstantString( str );
             Assert.IsNotNull( value );
-            Assert.IsTrue( value.IsString );
+            Assert.IsTrue( value.IsString ); // Has terminating null, so it is a C String
+            Assert.IsTrue( value.IsI8Sequence );
+
             Assert.IsFalse( value.IsNull );
             Assert.IsFalse( value.IsUndefined );
+            Assert.IsFalse( value.IsInstruction );
+            Assert.IsFalse( value.IsFunction );
+            Assert.IsFalse( value.IsCallSite );
+            Assert.IsFalse( value.IsZeroValue );
+
+            Assert.AreSame( string.Empty, value.Name );
+            Assert.IsNotNull( value.NativeType );
+
+            var arrayType = value.NativeType as IArrayType;
+            Assert.IsNotNull( arrayType );
+            Assert.AreSame( context, arrayType!.Context );
+            Assert.AreSame( context.Int8Type, arrayType.ElementType );
+            Assert.AreEqual( ( uint )str.Length + 1 , arrayType.Length ); // +1 for terminating \0
+            string valueStr = value.ExtractAsString( );
+            Assert.IsFalse( string.IsNullOrWhiteSpace( valueStr ) );
+            Assert.AreEqual( str, valueStr );
+
+            var span = value.RawData;
+            byte[ ] strBytes = System.Text.Encoding.ASCII.GetBytes(str);
+
+            Assert.AreEqual( strBytes.Length + 1, span.Length ); // +1 for terminating \0
+            for( int i = 0; i < strBytes.Length; ++i )
+            {
+                Assert.AreEqual( strBytes[ i ], span[ i ], $"At index {i}" );
+            }
+
+            Assert.AreEqual( 0, span[ ^1 ] );
+        }
+
+        [TestMethod]
+        [TestCategory( "Constants" )]
+        public void CreateConstantStringTest( )
+        {
+            using var context = new Context( );
+            string str = "hello world";
+            ConstantDataArray value = context.CreateConstantString( str, false );
+            Assert.IsNotNull( value );
+            Assert.IsFalse( value.IsString ); // No terminating null, so it is not a C String
+            Assert.IsTrue( value.IsI8Sequence );
+
+            Assert.IsFalse( value.IsNull );
+            Assert.IsFalse( value.IsUndefined );
+            Assert.IsFalse( value.IsInstruction );
+            Assert.IsFalse( value.IsFunction );
+            Assert.IsFalse( value.IsCallSite );
+            Assert.IsFalse( value.IsZeroValue );
+
             Assert.AreSame( string.Empty, value.Name );
             Assert.IsNotNull( value.NativeType );
 
@@ -963,6 +1012,15 @@ namespace Ubiquity.NET.Llvm.Tests
             string valueStr = value.ExtractAsString( );
             Assert.IsFalse( string.IsNullOrWhiteSpace( valueStr ) );
             Assert.AreEqual( str, valueStr );
+
+            var span = value.RawData;
+            byte[ ] strBytes = System.Text.Encoding.ASCII.GetBytes(str);
+
+            Assert.AreEqual( strBytes.Length, span.Length );
+            for( int i = 0; i < strBytes.Length; ++i )
+            {
+                Assert.AreEqual( strBytes[ i ], span[ i ], $"At index {i}" );
+            }
         }
 
         private static void VerifyIntegerType( ITypeRef integerType, uint bitWidth )

--- a/src/Ubiquity.NET.Llvm/Context.cs
+++ b/src/Ubiquity.NET.Llvm/Context.cs
@@ -485,15 +485,11 @@ namespace Ubiquity.NET.Llvm
         /// <returns>new <see cref="ConstantDataArray"/></returns>
         /// <remarks>
         /// This converts the string to ANSI form and creates an LLVM constant array of i8
-        /// characters for the data without any terminating null character.
+        /// characters for the data with a terminating null character. To control the enforcement
+        /// of a terminating null character, use the <see cref="CreateConstantString(string, bool)"/>
+        /// overload to specify the intended behavior.
         /// </remarks>
-        public ConstantDataArray CreateConstantString( string value )
-        {
-            value.ValidateNotNull( nameof( value ) );
-
-            var handle = LLVMConstStringInContext( ContextHandle, value, ( uint )value.Length, true );
-            return Value.FromHandle<ConstantDataArray>( handle.ThrowIfInvalid( ) )!;
-        }
+        public ConstantDataArray CreateConstantString( string value ) => CreateConstantString( value, true );
 
         /// <summary>Create a constant data string value</summary>
         /// <param name="value">string to convert into an LLVM constant value</param>
@@ -501,7 +497,7 @@ namespace Ubiquity.NET.Llvm
         /// <returns>new <see cref="ConstantDataArray"/></returns>
         /// <remarks>
         /// This converts the string to ANSI form and creates an LLVM constant array of i8
-        /// characters for the data without any terminating null character.
+        /// characters for the data. Enforcement of a null terminator depends on the value of <paramref name="nullTerminate"/>
         /// </remarks>
         public ConstantDataArray CreateConstantString( string value, bool nullTerminate )
         {
@@ -780,7 +776,7 @@ namespace Ubiquity.NET.Llvm
         internal LLVMContextRef ContextHandle { get; }
 
         /* These interning methods provide unique mapping between the .NET wrappers and the underlying LLVM instances
-        // The mapping ensures that any LibLLVM handle is always re-mappable to a exactly one wrapper instance.
+        // The mapping ensures that any LibLLVM handle is always re-mappable to exactly one wrapper instance.
         // This helps reduce the number of wrapper instances created and also allows reference equality to work
         // as expected for managed types.
         */

--- a/src/Ubiquity.NET.Llvm/Instructions/InstructionBuilder.cs
+++ b/src/Ubiquity.NET.Llvm/Instructions/InstructionBuilder.cs
@@ -1864,12 +1864,15 @@ namespace Ubiquity.NET.Llvm.Instructions
                 throw new ArgumentException( Resources.A_pointer_to_a_function_is_required_for_an_indirect_call, nameof( func ) );
             }
 
-            if( args.Count != signatureType.ParameterTypes.Count )
+            // validate arg count; too few or too many (unless the signature supports varargs) is an error
+            if( args.Count < signatureType.ParameterTypes.Count
+                || ( args.Count > signatureType.ParameterTypes.Count && !signatureType.IsVarArg )
+              )
             {
                 throw new ArgumentException( Resources.Mismatched_parameter_count_with_call_site, nameof( args ) );
             }
 
-            for( int i = 0; i < args.Count; ++i )
+            for( int i = 0; i < signatureType.ParameterTypes.Count; ++i )
             {
                 if( args[ i ].NativeType != signatureType.ParameterTypes[ i ] )
                 {

--- a/src/Ubiquity.NET.Llvm/Values/ConstantDataSequential.cs
+++ b/src/Ubiquity.NET.Llvm/Values/ConstantDataSequential.cs
@@ -5,7 +5,9 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Text;
 
+using Ubiquity.ArgValidators;
 using Ubiquity.NET.Llvm.Interop;
 
 using static Ubiquity.NET.Llvm.Interop.NativeMethods;
@@ -14,7 +16,7 @@ namespace Ubiquity.NET.Llvm.Values
 {
     /// <summary>
     /// A vector or array constant whose element type is a simple 1/2/4/8-byte integer
-    /// or float/double, and whose elements are just  simple data values
+    /// or float/double, and whose elements are just simple data values
     /// (i.e. ConstantInt/ConstantFP).
     /// </summary>
     /// <remarks>
@@ -26,20 +28,51 @@ namespace Ubiquity.NET.Llvm.Values
         : ConstantData
     {
         /// <summary>Gets a value indicating whether this constant is a string</summary>
-        public bool IsString => LLVMIsConstantString( ValueHandle );
+        public bool IsString => LibLLVMIsConstantCString( ValueHandle );
 
-        /// <summary>Extract a string value from the constant</summary>
+        /// <summary>Gets a value indicating whether this constant is a sequence of 8bit integral values</summary>
+        public bool IsI8Sequence => LLVMIsConstantString( ValueHandle );
+
+        /// <summary>Extract a string value from the constant (Assumes encoding ASCII)</summary>
         /// <returns>Extracted string</returns>
-        /// <exception cref="InvalidOperationException">If the constant isn't a string</exception>
+        /// <exception cref="InvalidOperationException">If IsI8Sequence isn't <see langword="true"/></exception>
         public string ExtractAsString( )
         {
-            if( !IsString )
-            {
-                throw new InvalidOperationException( "Value is not a string" );
-            }
-
-            return LLVMGetAsString( ValueHandle, out size_t _ );
+            return ExtractAsString(Encoding.ASCII);
         }
+
+        /// <summary>summary</summary>
+        /// <param name="encoding">encoding</param>
+        /// <returns>string</returns>
+        public string ExtractAsString(Encoding encoding)
+        {
+            encoding.ValidateNotNull( nameof( encoding ) );
+
+            // ignore terminating \0 for C strings
+            var rawData = IsString ? RawData[0..^1] : RawData;
+            return IsI8Sequence ? encoding.GetString( rawData ) : throw new InvalidOperationException( "Value is not a string" );
+        }
+
+        /// <summary>Gets the raw Data for the data sequential as a <see cref="Span{T}"/> of <see cref="byte"/></summary>
+        /// <remarks>
+        /// This retrieves the underlying data, which may be empty, independent of the actual element type. Thus,
+        /// issues of endian mismatch can occur between host assumptions and target. Thus, caution is warranted
+        /// when using this property.
+        /// </remarks>
+        public ReadOnlySpan<byte> RawData
+        {
+            get
+            {
+                unsafe
+                {
+                    sbyte* ptr = LibLLVMGetConstantDataSequentialRawData( ValueHandle, out size_t len );
+                    return new ReadOnlySpan<byte>( ptr, len );
+                }
+            }
+        }
+
+        /// <summary>Gets the count of elements in this <see cref="ConstantDataSequential"/></summary>
+        public uint Count => LibLLVMGetConstantDataSequentialElementCount( ValueHandle );
 
         internal ConstantDataSequential( LLVMValueRef valueRef )
             : base( valueRef )


### PR DESCRIPTION
Resolves #200
# Breaking Change
This is a breaking change. The behavior of Context.CreateConstantString(string) has changed slightly. It now constructs a valid C string WITH a null terminator, which is generally what would be expected of something called "string". (The (string,bool) overload remains, to allow apps to be explicit with intent and get the previous behavior) Additionally, the ConstantDataSequential.IsString property now reflects whether the string is a C string (terminating null but no embedded nulls) and the ConstantDataSequential.IsI8Sequence was added to provide the previous behavior of IsString, which was simply that the underlying sequence element type was i8 (with or without a terminator). While this is a breaking change and may cause some issues on updating to this version, it is intended to help clarify the behavior and clean up some less than intuitive behavior of the previous implementation.

---
* Added error handling to parsing of YAML configuration in bindings generator app.
* Added RawData property to ConstandDataSequential (and used it for the ExtractAsString implementations
* Added ExtractAsString overload that accepts an Encoding
* ExtractAsString now automatically discards the terminating null if the underlying data is a C String, while allowing extraction of strings without a terminator and in different encodings.