### PR TITLE
Updated antlr highlighter to better reflect language

### DIFF
--- a/docfx/templates/Ubiquity/public/antlr.js
+++ b/docfx/templates/Ubiquity/public/antlr.js
@@ -4,58 +4,108 @@ Simple antlr syntax highlighting for Highlight.JS
 
 export function antlr(hljs)
 {
-    return {
-        aliases: ['antlr'],
+    // lexer rules always begin with uppercase character
+    const lexerIdent_RE = '\\b[A-Z]' + hljs.UNDERSCORE_IDENT_RE + '\\b';
+    const lexerIdent = {
+        scope: 'LexerRuleName',
+        begin: lexerIdent_RE,
+        relevance: 0
+    };
+
+    // grammar rules always begin with a lowercase character
+    const grammarIdent_RE = '\\b[a-z]' + hljs.UNDERSCORE_IDENT_RE + '\\b';
+    const grammarIdent = {
+        scope: 'GrammarRuleName',
+        begin: grammarIdent_RE,
+        relevance: 0
+    };
+
+    const semanticPredicate = {
+        scope: 'SemanticPredicate',
+        begin: '{',
+        end: /}\?/,
+    };
+
+    const lexerCommand = {
+        scope: 'LexerCommand',
+        begin: '->',
+        beginScope: 'punctuation',
+        end: ';',
+        endScope: 'punctuation',
+        endsParent: true,
         keywords: {
-            keyword: 'grammar fragment'
+            built_in: 'skip more popMode mode pushMode type channel'
+        }
+    };
+
+    const lexerRule = {
+        scope: 'LexerRule',
+        begin: [lexerIdent_RE, '\\s*', ':', '\\s*'],
+        beginScope: {
+            1: 'LexerRuleName',
+            3: 'punctuation',
+        },
+        end: ';',
+        endScope: 'punctuation',
+        relevance: 10,
+        contains: [
+            semanticPredicate,
+            lexerCommand,
+            lexerIdent,
+            hljs.C_LINE_COMMENT_MODE,
+            hljs.APOS_STRING_MODE,
+            hljs.QUOTE_STRING_MODE,
+            hljs.BACKSLASH_ESCAPE,
+        ]
+    };
+
+    const grammarAltName = {
+        begin: "#",
+        end: /\s*$/,
+        contains: [
+            {
+                scope: 'GrammarAltName',
+                begin: hljs.UNDERSCORE_IDENT_RE,
+            }
+        ]
+    };
+
+    const grammarRule = {
+        scope: 'GrammarRule',
+        begin: [grammarIdent_RE, '\\s*', ':', '\\s*'],
+        beginScope: {
+            1: "GrammarRuleName",
+            3: "punctuation",
+        },
+        end: ';',
+        endScope: 'punctuation',
+        relevance: 10,
+        contains: [
+            grammarAltName,
+            semanticPredicate,
+            lexerIdent,
+            grammarIdent,
+            hljs.C_LINE_COMMENT_MODE,
+            hljs.APOS_STRING_MODE,
+            hljs.QUOTE_STRING_MODE,
+            hljs.C_NUMBER_MODE,
+        ]
+    };
+
+    return {
+        name: "ANTLR V4 (.g4)",
+        aliases: ['antlr'],
+        keywords: ['grammar', 'fragment', 'skip'],
+        classNameAliases: {
+            LexerRuleName: 'type',
+            GrammarRuleName: 'type',
+            GrammarAltName: 'function',
+            // TODO: Fill these in once tagging is complete.
         },
         contains: [
-            hljs.COMMENT('//', '\\n', { relevance: 0 }),
-            {
-                scope: 'regexp',
-                variants: [
-                    { begin: '\\[', end: '\\]' }
-                ],
-                relevance: 0
-            },
-            {
-                scope: 'string',
-                variants: [
-                    { begin: '\'', end: '\'' },
-                    { begin: '"', end: '"' }
-                ],
-                relevance: 0
-            },
-            {
-                scope: 'keyword',
-                variants: [
-                    { begin: 'i\\d+' }
-                ],
-                relevance: 0
-            },
-            {
-                scope: 'meta',
-                variants: [
-                    { begin: '{', end: '}' },
-                    { begin: '{', end: '}\?' }
-                ],
-                relevance: 0
-            },
-            {
-                scope: 'number',
-                variants: [
-                    { begin: '0[xX][a-fA-F0-9]+' },
-                    { begin: '-?\\d+(?:[.]\\d+)?(?:[eE][-+]?\\d+(?:[.]\\d+)?)?' }
-                ],
-                relevance: 0
-            },
-            {
-                scope: 'symbol',
-                variants: [
-                    { begin: '([A-Z][\\w\\-$.]*)' }
-                ],
-                relevance: 0
-            }
+            hljs.C_LINE_COMMENT_MODE,
+            lexerRule,
+            grammarRule,
         ]
     };
 }

--- a/docfx/templates/Ubiquity/readme.md
+++ b/docfx/templates/Ubiquity/readme.md
@@ -1,15 +1,8 @@
 # Ubiquity DOCFX template
-This template adds support to the syntx highlighting provided by [HightlightJS](https://highlightjs.readthedocs.io/en/latest/supported-languages.html).
-The languages added are for ANTLR^1^ (Which seems bizarre it isn't already covered given the
+This template adds support to the syntax highlighting provided by [HightlightJS](https://highlightjs.readthedocs.io/en/latest/supported-languages.html).
+The languages added are for ANTLR (Which seems bizarre it isn't already covered given the
 esoteric nature of some of the supported languages...) and of course the `Kaleidoscope`
 language, which was made up entirely for the purposes of LLVM tutorials. (No surprise that one
-isn't supported)
+isn't supported) [Though it oddly IS supported directly in the [Local MarkDig
+based editor](https://github.com/MadsKristensen/MarkdownEditor2022) used to edit these files...
 
-^1^The support for ANTLR is not present. DOCFX officially documents that Highlight JS
-extensibility is supported by this. It even has an example. However, that example uses
-a language that is built-in to Highlight JS already. It doesn't seem to actually use
-this extention point as the Kaleidoscope highlighting never happens ([Local MarkDig
-based editor](https://github.com/MadsKristensen/MarkdownEditor2022) will render the
-ANTLR with syntax highlighting [That seems to be using PRISM for highlighting though].
-But the final docs hosted by DOCFX do not. Thus, this functionality is currently
-broken.


### PR DESCRIPTION
Updated the Highlight.JS tagging to better reflect the ANLR language. It isn't a perfect representation but is good enough for syntax highlighting.