### PR TITLE
Simplification of array parameters for interop calls

### DIFF
--- a/src/Interop/InteropTests/DebugRecordTests.cs
+++ b/src/Interop/InteropTests/DebugRecordTests.cs
@@ -73,7 +73,7 @@ namespace Ubiquity.NET.Llvm.Interop.UT
 
             LLVMMetadataRef int32PtrDiType = LLVMDIBuilderCreatePointerType(diBuilder, int32DiType, 32, 0, 0, "int*"u8);
             LLVMMetadataRef emptyExpression = LLVMDIBuilderCreateExpression(diBuilder, []);
-            LLVMMetadataRef diFuncType = LLVMDIBuilderCreateSubroutineType(diBuilder, default, [], 0, LLVMDIFlags.LLVMDIFlagPrivate);
+            LLVMMetadataRef diFuncType = LLVMDIBuilderCreateSubroutineType(diBuilder, default, [], LLVMDIFlags.LLVMDIFlagPrivate);
             LLVMMetadataRef scope = LLVMDIBuilderCreateFunction(
                 diBuilder,
                 Scope: default,

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/DebugInfo.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/DebugInfo.cs
@@ -414,9 +414,22 @@ namespace Ubiquity.NET.Llvm.Interop.ABI.llvm_c
             uint Line
             );
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static LLVMMetadataRef LLVMDIBuilderCreateImportedModuleFromAlias(
+            LLVMDIBuilderRef Builder,
+            LLVMMetadataRef Scope,
+            LLVMMetadataRef ImportedEntity,
+            LLVMMetadataRef File,
+            uint Line,
+            LLVMMetadataRef[] Elements
+            )
+        {
+            return LLVMDIBuilderCreateImportedModuleFromAlias(Builder, Scope, ImportedEntity, File, Line, Elements, checked((uint)Elements.Length));
+        }
+
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial LLVMMetadataRef LLVMDIBuilderCreateImportedModuleFromAlias(
+        private static unsafe partial LLVMMetadataRef LLVMDIBuilderCreateImportedModuleFromAlias(
             LLVMDIBuilderRef Builder,
             LLVMMetadataRef Scope,
             LLVMMetadataRef ImportedEntity,
@@ -426,9 +439,22 @@ namespace Ubiquity.NET.Llvm.Interop.ABI.llvm_c
             uint NumElements // NumElements MUST be <= Elements.Length
             );
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static LLVMMetadataRef LLVMDIBuilderCreateImportedModuleFromModule(
+            LLVMDIBuilderRef Builder,
+            LLVMMetadataRef Scope,
+            LLVMMetadataRef M,
+            LLVMMetadataRef File,
+            uint Line,
+            LLVMMetadataRef[] Elements
+            )
+        {
+            return LLVMDIBuilderCreateImportedModuleFromModule(Builder, Scope, M, File, Line, Elements, checked((uint)Elements.Length));
+        }
+
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial LLVMMetadataRef LLVMDIBuilderCreateImportedModuleFromModule(
+        private static unsafe partial LLVMMetadataRef LLVMDIBuilderCreateImportedModuleFromModule(
             LLVMDIBuilderRef Builder,
             LLVMMetadataRef Scope,
             LLVMMetadataRef M,
@@ -559,9 +585,20 @@ namespace Ubiquity.NET.Llvm.Interop.ABI.llvm_c
             nuint NumElements // NumElements MUST be <= Data.Length
             );
 
+        [MethodImpl( MethodImplOptions.AggressiveInlining )]
+        public static LLVMMetadataRef LLVMDIBuilderCreateSubroutineType(
+            LLVMDIBuilderRef Builder,
+            LLVMMetadataRef File,
+            LLVMMetadataRef[] ParameterTypes,
+            LLVMDIFlags Flags
+            )
+        {
+            return LLVMDIBuilderCreateSubroutineType(Builder, File, ParameterTypes, checked((uint)ParameterTypes.Length), Flags);
+        }
+
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial LLVMMetadataRef LLVMDIBuilderCreateSubroutineType(
+        private static unsafe partial LLVMMetadataRef LLVMDIBuilderCreateSubroutineType(
             LLVMDIBuilderRef Builder,
             LLVMMetadataRef File,
             [In] LLVMMetadataRef[] ParameterTypes,
@@ -602,7 +639,12 @@ namespace Ubiquity.NET.Llvm.Interop.ABI.llvm_c
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial LLVMMetadataRef LLVMDIBuilderCreateTempMacroFile( LLVMDIBuilderRef Builder, LLVMMetadataRef ParentMacroFile, uint Line, LLVMMetadataRef File );
+        public static unsafe partial LLVMMetadataRef LLVMDIBuilderCreateTempMacroFile(
+            LLVMDIBuilderRef Builder,
+            LLVMMetadataRef ParentMacroFile,
+            uint Line,
+            LLVMMetadataRef File
+            );
 
         [MethodImpl( MethodImplOptions.AggressiveInlining )]
         public static LLVMMetadataRef LLVMDIBuilderCreateEnumerator(
@@ -1248,7 +1290,7 @@ namespace Ubiquity.NET.Llvm.Interop.ABI.llvm_c
             UInt64 OffsetInBits,
             LLVMDIFlags Flags,
             LLVMMetadataRef DerivedFrom,
-            [In] LLVMMetadataRef[] Elements,
+            LLVMMetadataRef[] Elements,
             LLVMMetadataRef VTableHolder,
             LLVMMetadataRef TemplateParamsNode,
             LazyEncodedString UniqueIdentifier

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/Disassembler.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/Disassembler.cs
@@ -125,6 +125,7 @@ namespace Ubiquity.NET.Llvm.Interop.ABI.llvm_c
         [return: MarshalAs( UnmanagedType.Bool )]
         public static unsafe partial bool LLVMSetDisasmOptions( LLVMDisasmContextRef DC, UInt64 Options );
 
+        // OutString is a pre-allocated buffer, OutStringSize is [In] param to indicate how big it is. (Text is Truncated if not big enough)
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
         public static unsafe partial nuint LLVMDisasmInstruction(
@@ -132,7 +133,7 @@ namespace Ubiquity.NET.Llvm.Interop.ABI.llvm_c
             byte* Bytes,
             UInt64 BytesSize,
             UInt64 PC,
-            byte* OutString, nuint OutStringSize // OutString is a pre-allocated buffer, size is how big it is. (Truncated if not big enough)
+            byte* OutString, nuint OutStringSize
             );
     }
 }

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/DisassemblerTypes.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/DisassemblerTypes.cs
@@ -6,6 +6,10 @@
 
 namespace Ubiquity.NET.Llvm.Interop
 {
+    // NOTE: these are intentionally, NOT record structs as those do NOT allow unsafe types as fields (CS8908)
+    // Sadly, there is a bug where that error won't show in an IDE so it might look safe/OK until you build
+    // (see: https://github.com/dotnet/roslyn/issues/58878)
+
     [StructLayout( LayoutKind.Sequential )]
     public unsafe readonly struct LLVMOpInfoSymbol1
         : IEquatable<LLVMOpInfoSymbol1>

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/OrcEE.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/OrcEE.cs
@@ -24,10 +24,22 @@ namespace Ubiquity.NET.Llvm.Interop.ABI.llvm_c
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial LLVMOrcObjectLayerRef LLVMOrcCreateRTDyldObjectLinkingLayerWithMCJITMemoryManagerLikeCallbacks( LLVMOrcExecutionSessionRef ES, void* CreateContextCtx, LLVMMemoryManagerCreateContextCallback CreateContext, LLVMMemoryManagerNotifyTerminatingCallback NotifyTerminating, LLVMMemoryManagerAllocateCodeSectionCallback AllocateCodeSection, LLVMMemoryManagerAllocateDataSectionCallback AllocateDataSection, LLVMMemoryManagerFinalizeMemoryCallback FinalizeMemory, LLVMMemoryManagerDestroyCallback Destroy );
+        public static unsafe partial LLVMOrcObjectLayerRef LLVMOrcCreateRTDyldObjectLinkingLayerWithMCJITMemoryManagerLikeCallbacks(
+            LLVMOrcExecutionSessionRef ES,
+            void* CreateContextCtx,
+            LLVMMemoryManagerCreateContextCallback CreateContext,
+            LLVMMemoryManagerNotifyTerminatingCallback NotifyTerminating,
+            LLVMMemoryManagerAllocateCodeSectionCallback AllocateCodeSection,
+            LLVMMemoryManagerAllocateDataSectionCallback AllocateDataSection,
+            LLVMMemoryManagerFinalizeMemoryCallback FinalizeMemory,
+            LLVMMemoryManagerDestroyCallback Destroy
+            );
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial void LLVMOrcRTDyldObjectLinkingLayerRegisterJITEventListener( LLVMOrcObjectLayerRef RTDyldObjLinkingLayer, LLVMJITEventListenerRef Listener );
+        public static unsafe partial void LLVMOrcRTDyldObjectLinkingLayerRegisterJITEventListener(
+            LLVMOrcObjectLayerRef RTDyldObjLinkingLayer,
+            LLVMJITEventListenerRef Listener
+            );
     }
 }

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/PassBuilder.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/PassBuilder.cs
@@ -32,55 +32,94 @@ namespace Ubiquity.NET.Llvm.Interop.ABI.llvm_c
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial void LLVMPassBuilderOptionsSetVerifyEach( LLVMPassBuilderOptionsRef Options, [MarshalAs( UnmanagedType.Bool )] bool VerifyEach );
+        public static unsafe partial void LLVMPassBuilderOptionsSetVerifyEach(
+            LLVMPassBuilderOptionsRef Options,
+            [MarshalAs( UnmanagedType.Bool )] bool VerifyEach
+            );
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial void LLVMPassBuilderOptionsSetDebugLogging( LLVMPassBuilderOptionsRef Options, [MarshalAs( UnmanagedType.Bool )] bool DebugLogging );
+        public static unsafe partial void LLVMPassBuilderOptionsSetDebugLogging(
+            LLVMPassBuilderOptionsRef Options,
+            [MarshalAs( UnmanagedType.Bool )] bool DebugLogging
+            );
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial void LLVMPassBuilderOptionsSetAAPipeline( LLVMPassBuilderOptionsRef Options, LazyEncodedString AAPipeline );
+        public static unsafe partial void LLVMPassBuilderOptionsSetAAPipeline(
+            LLVMPassBuilderOptionsRef Options,
+            LazyEncodedString AAPipeline
+            );
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial void LLVMPassBuilderOptionsSetLoopInterleaving( LLVMPassBuilderOptionsRef Options, [MarshalAs( UnmanagedType.Bool )] bool LoopInterleaving );
+        public static unsafe partial void LLVMPassBuilderOptionsSetLoopInterleaving(
+            LLVMPassBuilderOptionsRef Options,
+            [MarshalAs( UnmanagedType.Bool )] bool LoopInterleaving
+            );
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial void LLVMPassBuilderOptionsSetLoopVectorization( LLVMPassBuilderOptionsRef Options, [MarshalAs( UnmanagedType.Bool )] bool LoopVectorization );
+        public static unsafe partial void LLVMPassBuilderOptionsSetLoopVectorization(
+            LLVMPassBuilderOptionsRef Options,
+            [MarshalAs( UnmanagedType.Bool )] bool LoopVectorization
+            );
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial void LLVMPassBuilderOptionsSetSLPVectorization( LLVMPassBuilderOptionsRef Options, [MarshalAs( UnmanagedType.Bool )] bool SLPVectorization );
+        public static unsafe partial void LLVMPassBuilderOptionsSetSLPVectorization(
+            LLVMPassBuilderOptionsRef Options,
+            [MarshalAs( UnmanagedType.Bool )] bool SLPVectorization
+            );
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial void LLVMPassBuilderOptionsSetLoopUnrolling( LLVMPassBuilderOptionsRef Options, [MarshalAs( UnmanagedType.Bool )] bool LoopUnrolling );
+        public static unsafe partial void LLVMPassBuilderOptionsSetLoopUnrolling(
+            LLVMPassBuilderOptionsRef Options,
+            [MarshalAs( UnmanagedType.Bool )] bool LoopUnrolling
+            );
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial void LLVMPassBuilderOptionsSetForgetAllSCEVInLoopUnroll( LLVMPassBuilderOptionsRef Options, [MarshalAs( UnmanagedType.Bool )] bool ForgetAllSCEVInLoopUnroll );
+        public static unsafe partial void LLVMPassBuilderOptionsSetForgetAllSCEVInLoopUnroll(
+            LLVMPassBuilderOptionsRef Options,
+            [MarshalAs( UnmanagedType.Bool )] bool ForgetAllSCEVInLoopUnroll
+            );
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial void LLVMPassBuilderOptionsSetLicmMssaOptCap( LLVMPassBuilderOptionsRef Options, uint LicmMssaOptCap );
+        public static unsafe partial void LLVMPassBuilderOptionsSetLicmMssaOptCap(
+            LLVMPassBuilderOptionsRef Options,
+            uint LicmMssaOptCap
+            );
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial void LLVMPassBuilderOptionsSetLicmMssaNoAccForPromotionCap( LLVMPassBuilderOptionsRef Options, uint LicmMssaNoAccForPromotionCap );
+        public static unsafe partial void LLVMPassBuilderOptionsSetLicmMssaNoAccForPromotionCap(
+            LLVMPassBuilderOptionsRef Options,
+            uint LicmMssaNoAccForPromotionCap
+            );
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial void LLVMPassBuilderOptionsSetCallGraphProfile( LLVMPassBuilderOptionsRef Options, [MarshalAs( UnmanagedType.Bool )] bool CallGraphProfile );
+        public static unsafe partial void LLVMPassBuilderOptionsSetCallGraphProfile(
+            LLVMPassBuilderOptionsRef Options,
+            [MarshalAs( UnmanagedType.Bool )] bool CallGraphProfile
+            );
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial void LLVMPassBuilderOptionsSetMergeFunctions( LLVMPassBuilderOptionsRef Options, [MarshalAs( UnmanagedType.Bool )] bool MergeFunctions );
+        public static unsafe partial void LLVMPassBuilderOptionsSetMergeFunctions(
+            LLVMPassBuilderOptionsRef Options,
+            [MarshalAs( UnmanagedType.Bool )] bool MergeFunctions
+            );
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
-        public static unsafe partial void LLVMPassBuilderOptionsSetInlinerThreshold( LLVMPassBuilderOptionsRef Options, int Threshold );
+        public static unsafe partial void LLVMPassBuilderOptionsSetInlinerThreshold(
+            LLVMPassBuilderOptionsRef Options,
+            int Threshold
+            );
 
         [LibraryImport( LibraryName )]
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]

--- a/src/Ubiquity.NET.Llvm/DebugInfo/DIBuilder.cs
+++ b/src/Ubiquity.NET.Llvm/DebugInfo/DIBuilder.cs
@@ -590,7 +590,6 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             var handle = LLVMDIBuilderCreateSubroutineType( Handle.ThrowIfInvalid()
                                                           , LLVMMetadataRef.Zero
                                                           , handles
-                                                          , checked(( uint )handles.Length)
                                                           , ( LLVMDIFlags )debugFlags
                                                           );
 

--- a/src/Ubiquity.NET.Llvm/Values/CallSiteAttributeAccessor.cs
+++ b/src/Ubiquity.NET.Llvm/Values/CallSiteAttributeAccessor.cs
@@ -28,22 +28,7 @@ namespace Ubiquity.NET.Llvm.Values
         public static IEnumerable<AttributeValue> GetAttributesAtIndex( this Instruction self, FunctionAttributeIndex index )
         {
             ThrowIfNotCallSite( self );
-            uint count = GetAttributeCountAtIndex(self, index );
-            if(count == 0)
-            {
-                return [];
-            }
-
-            var buffer = new LLVMAttributeRef[ count ];
-            unsafe
-            {
-                fixed(LLVMAttributeRef* pBuf = buffer)
-                {
-                    LLVMGetCallSiteAttributes( self.Handle, (LLVMAttributeIndex)index, pBuf );
-                }
-            }
-
-            return from attribRef in buffer
+            return from attribRef in LLVMGetCallSiteAttributes( self.Handle, (LLVMAttributeIndex)index)
                    select new AttributeValue( attribRef );
         }
 


### PR DESCRIPTION
Simplification of array parameters for interop calls
- To say that the AOT source generator marshaling was under documented would be the understatement of the century. Sadly, that includes marshaling of arrays, especially arrays of safe handles (or in this case global Handles)

This PR contains interop wrapper function that take care of the heavy lifting as needed.