### PR TITLE
Updated to new LLVM APIs

### DIFF
--- a/src/Samples/CodeGenWithDebugInfo/CortexM3ABI.cs
+++ b/src/Samples/CodeGenWithDebugInfo/CortexM3ABI.cs
@@ -18,18 +18,12 @@ namespace CodeGenWithDebugInfo
     internal sealed class CortexM3ABI
         : ITargetABI
     {
-        public CortexM3ABI( )
+        public CortexM3ABI( ILibLlvm library)
         {
-            LlvmLib = Library.InitializeLLVM();
-            LlvmLib.RegisterTarget( CodeGenTarget.ARM );
+            library.RegisterTarget( CodeGenTarget.ARM );
         }
 
         public string ShortName => "M3";
-
-        public void Dispose( )
-        {
-            LlvmLib.Dispose();
-        }
 
         public TargetMachine CreateTargetMachine( )
         {
@@ -81,8 +75,8 @@ namespace CodeGenWithDebugInfo
         public void AddModuleFlags( Module module )
         {
             // Specify ABI const sizes so linker can detect mismatches
-            module.AddModuleFlag( ModuleFlagBehavior.Error, "wchar_size", 4 );
-            module.AddModuleFlag( ModuleFlagBehavior.Error, "min_enum_size", 4 );
+            module.AddModuleFlag( ModuleFlagBehavior.Error, "wchar_size"u8, 4 );
+            module.AddModuleFlag( ModuleFlagBehavior.Error, "min_enum_size"u8, 4 );
         }
 
         public ImmutableArray<AttributeValue> BuildTargetDependentFunctionAttributes( IContext ctx )
@@ -103,8 +97,6 @@ namespace CodeGenWithDebugInfo
                 ctx.CreateAttribute( "unsafe-fp-math"u8, "false"u8 ),
                 ctx.CreateAttribute( "use-soft-float"u8, "false"u8 )
             ];
-
-        private readonly ILibLlvm LlvmLib;
 
         // Sadly, these can't be utf8 literals, but, they can be static readonly LazyEncodedString!
         private static readonly LazyEncodedString Cpu = "cortex-m3"u8;

--- a/src/Samples/CodeGenWithDebugInfo/ITargetABI.cs
+++ b/src/Samples/CodeGenWithDebugInfo/ITargetABI.cs
@@ -25,7 +25,6 @@ namespace CodeGenWithDebugInfo
     /// </remarks>
     /// <seealso href="https://discourse.llvm.org/t/llvm-introduce-an-abi-lowering-library/84554"/>
     internal interface ITargetABI
-        : IDisposable
     {
         string ShortName { get; }
 

--- a/src/Samples/CodeGenWithDebugInfo/X64ABI.cs
+++ b/src/Samples/CodeGenWithDebugInfo/X64ABI.cs
@@ -18,18 +18,12 @@ namespace CodeGenWithDebugInfo
     internal sealed class X64ABI
         : ITargetABI
     {
-        public X64ABI( )
+        public X64ABI( ILibLlvm library )
         {
-            LlvmLib = Library.InitializeLLVM();
-            LlvmLib.RegisterTarget( CodeGenTarget.X86 );
+            library.RegisterTarget( CodeGenTarget.X86 );
         }
 
         public string ShortName => "x86";
-
-        public void Dispose( )
-        {
-            LlvmLib.Dispose();
-        }
 
         public TargetMachine CreateTargetMachine( )
         {
@@ -63,7 +57,7 @@ namespace CodeGenWithDebugInfo
 
         public void AddModuleFlags( Module module )
         {
-            module.AddModuleFlag( ModuleFlagBehavior.Error, "PIC Level", 2 );
+            module.AddModuleFlag( ModuleFlagBehavior.Error, "PIC Level"u8, 2 );
         }
 
         public ImmutableArray<AttributeValue> BuildTargetDependentFunctionAttributes( IContext ctx )
@@ -80,8 +74,6 @@ namespace CodeGenWithDebugInfo
                 ctx.CreateAttribute( "use-soft-float"u8, "false"u8 ),
                 ctx.CreateAttribute( "uwtable"u8, (ulong)UWTableKind.Async)
             ];
-
-        private readonly ILibLlvm LlvmLib;
 
         // Sadly, these can't be utf8 literals, but, they can be static readonly LazyEncodedString!
         private static readonly LazyEncodedString Cpu = "x86-64"u8;

--- a/src/Ubiquity.NET.Llvm.Tests/ModuleTests.cs
+++ b/src/Ubiquity.NET.Llvm.Tests/ModuleTests.cs
@@ -393,11 +393,13 @@ namespace Ubiquity.NET.Llvm.UT
         [TestMethod]
         public void AddModuleFlagTest( )
         {
+            Assert.IsNotNull(ModuleFixtures.LibLLVM);
+
             using var context = new Context( );
             using var module = context.CreateBitcodeModule( TestModuleName );
 
             module.AddModuleFlag( ModuleFlagBehavior.Warning, Module.DwarfVersionValue, 4 );
-            module.AddModuleFlag( ModuleFlagBehavior.Warning, Module.DebugVersionValue, Module.DebugMetadataVersion );
+            module.AddModuleFlag( ModuleFlagBehavior.Warning, Module.DebugVersionValue, ModuleFixtures.LibLLVM.DebugMetadataVersion );
             module.AddModuleFlag( ModuleFlagBehavior.Error, "wchar_size", 4 );
             module.AddModuleFlag( ModuleFlagBehavior.Error, "min_enum_size", 4 );
             module.AddVersionIdentMetadata( "unit-tests 1.0" );
@@ -424,7 +426,7 @@ namespace Ubiquity.NET.Llvm.UT
 
             var debugVerConst = ( ( ConstantAsMetadata )debugVerFlag.Metadata ).Constant;
             Assert.IsInstanceOfType<ConstantInt>( debugVerConst );
-            Assert.AreEqual( Module.DebugMetadataVersion, ((ConstantInt)debugVerConst).ZeroExtendedValue );
+            Assert.AreEqual( ModuleFixtures.LibLLVM.DebugMetadataVersion, ((ConstantInt)debugVerConst).ZeroExtendedValue );
 
             var wcharSizeFlag = module.ModuleFlags[ "wchar_size" ];
             Assert.AreEqual( ModuleFlagBehavior.Error, wcharSizeFlag.Behavior );

--- a/src/Ubiquity.NET.Llvm/DebugInfo/DIBuilder.cs
+++ b/src/Ubiquity.NET.Llvm/DebugInfo/DIBuilder.cs
@@ -1095,7 +1095,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         public readonly void Finish( DISubProgram subProgram )
         {
             ArgumentNullException.ThrowIfNull( subProgram );
-            LibLLVMDIBuilderFinalizeSubProgram( Handle.ThrowIfInvalid(), subProgram.Handle );
+            LLVMDIBuilderFinalizeSubprogram( Handle.ThrowIfInvalid(), subProgram.Handle );
         }
 
         /// <summary>Finalizes debug information for all items built by this builder</summary>

--- a/src/Ubiquity.NET.Llvm/ILibLLVM.cs
+++ b/src/Ubiquity.NET.Llvm/ILibLLVM.cs
@@ -144,5 +144,8 @@ namespace Ubiquity.NET.Llvm
         /// attributes not yet known to, or considered stable by, the LLVM core native code.
         /// </remarks>
         ImmutableDictionary<LazyEncodedString, AttributeInfo> AttributeMap { get; }
+
+        /// <summary>Gets the current debug metadata version for this library</summary>
+        uint DebugMetadataVersion { get; }
     }
 }

--- a/src/Ubiquity.NET.Llvm/IModule.cs
+++ b/src/Ubiquity.NET.Llvm/IModule.cs
@@ -86,6 +86,9 @@ namespace Ubiquity.NET.Llvm
         /// <summary>Gets or sets the module level inline assembly</summary>
         public LazyEncodedString ModuleInlineAsm { get; set; }
 
+        /// <summary>Gets the Debug metadata version that is present in this module</summary>
+        public uint DebugMetadataVersion { get; }
+
         /// <summary>Appends inline assembly to the module's inline assembly</summary>
         /// <param name="asm">assembly text</param>
         public void AppendInlineAsm( LazyEncodedString asm );
@@ -391,6 +394,10 @@ namespace Ubiquity.NET.Llvm
         /// <param name="targetContext"><see cref="IContext"/> to clone the module into</param>
         /// <returns>Cloned copy of the module</returns>
         public Module Clone( IContext targetContext );
+
+        /// <summary>Strips debug information from this module</summary>
+        /// <returns><see langword="true"/> if the module was modified; <see langword="false"/> if not</returns>
+        public bool StripDebugInformation();
     }
 
     // Internal helper to get the underlying ABI handle as an "Alias" handle

--- a/src/Ubiquity.NET.Llvm/Library.cs
+++ b/src/Ubiquity.NET.Llvm/Library.cs
@@ -13,6 +13,7 @@ the low level interop (Test code sometimes does) it must explicitly reference it
 using System.Collections.Immutable;
 
 using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.AttributeBindings;
+using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.DebugInfo;
 
 // Apply using aliases to simplify avoidance of name conflicts.
 using InteropCodeGenTarget = Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.LibLLVMCodeGenTarget;
@@ -54,6 +55,9 @@ namespace Ubiquity.NET.Llvm
 
         /// <summary>Gets the native target for the current runtime</summary>
         public static CodeGenTarget NativeTarget => (CodeGenTarget)RuntimeInformation.ProcessArchitecture.AsLLVMTarget();
+
+        /// <inheritdoc/>
+        public uint DebugMetadataVersion => LLVMDebugMetadataVersion();
 
         // "MOVE" construction, this instance takes over responsibility
         // of calling dispose.

--- a/src/Ubiquity.NET.Llvm/Module.cs
+++ b/src/Ubiquity.NET.Llvm/Module.cs
@@ -72,9 +72,6 @@ namespace Ubiquity.NET.Llvm
         /// <summary>Name of the Dwarf Version module flag</summary>
         public static readonly LazyEncodedString DwarfVersionValue = "Dwarf Version"u8;
 
-        /// <summary>Gets the current Version of the Debug information used by LLVM</summary>
-        public static UInt32 DebugMetadataVersion => LLVMDebugMetadataVersion();
-
         /// <summary>Gets a value indicating whether this instance is already disposed</summary>
         public bool IsDisposed => NativeHandle is null || NativeHandle.IsInvalid || NativeHandle.IsClosed;
 
@@ -192,6 +189,9 @@ namespace Ubiquity.NET.Llvm
         public Module Clone( IContext targetContext ) => Impl.Clone( targetContext );
 
         /// <inheritdoc/>
+        public bool StripDebugInformation() => Impl.StripDebugInformation();
+
+        /// <inheritdoc/>
         public LazyEncodedString SourceFileName { get => Impl.SourceFileName; set => Impl.SourceFileName = value; }
 
         /// <inheritdoc/>
@@ -236,6 +236,9 @@ namespace Ubiquity.NET.Llvm
 
         /// <inheritdoc/>
         public LazyEncodedString ModuleInlineAsm { get => Impl.ModuleInlineAsm; set => Impl.ModuleInlineAsm = value; }
+
+        /// <inheritdoc/>
+        public uint DebugMetadataVersion => Impl.DebugMetadataVersion;
         #endregion
 
         /// <summary>Load a bit-code module from a given file</summary>

--- a/src/Ubiquity.NET.Llvm/ModuleAlias.cs
+++ b/src/Ubiquity.NET.Llvm/ModuleAlias.cs
@@ -9,6 +9,7 @@ using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.ModuleBindings;
 using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Analysis;
 using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.BitWriter;
 using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Core;
+using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.DebugInfo;
 using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Linker;
 using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.PassBuilder;
 using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Target;
@@ -197,6 +198,9 @@ namespace Ubiquity.NET.Llvm
             get => LLVMGetModuleInlineAsm( NativeHandle ) ?? LazyEncodedString.Empty;
             set => LLVMSetModuleInlineAsm2( NativeHandle, value.ThrowIfNull() );
         }
+
+        /// <inheritdoc/>
+        public uint DebugMetadataVersion => LLVMGetModuleDebugMetadataVersion(NativeHandle);
 
         /// <inheritdoc/>
         public void AppendInlineAsm( LazyEncodedString asm )
@@ -614,6 +618,12 @@ namespace Ubiquity.NET.Llvm
             var retVal = Module.LoadFrom( buffer, targetContext );
             Debug.Assert( retVal.Context.Equals( targetContext ), Resources.Expected_to_get_a_module_bound_to_the_specified_context );
             return retVal;
+        }
+
+        /// <inheritdoc/>
+        public bool StripDebugInformation()
+        {
+            return LLVMStripModuleDebugInfo(NativeHandle);
         }
 
         internal ModuleAlias( LLVMModuleRefAlias handle )


### PR DESCRIPTION
Updated to new LLVM APIs
* Used call to `LLVMDIBuilderFinalizeSubprogram` instead of extension API.
* Moved support of getting current Debug Metadata version to library interface
* Added module property to get version of debug metadata that is present in a given module
* Added support to module to strop debug information
* Updated CodeGenWithDebugInfo sample to leverage debug version value for the library as a whole from the library