### PR TITLE
Minor updates for versioning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,17 +17,26 @@
     Package versions made consistent across all packages referenced in this repository
    -->
   <ItemGroup>
-    <PackageVersion Include="System.IO.Hashing" Version="9.0.4" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="CppSharp" Version="1.1.5.3168" />
+    <!-- Roslyn Analyzers ***MUST*** target older framework -->
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="4.14.0" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.2" />
+    <PackageVersion Include="System.IO.Hashing" Version="9.0.7" />
+
+    <!-- Common packages for solution -->
+    <PackageVersion Include="System.Linq.Async" Version="6.0.3" />
+    <PackageVersion Include="Ubiquity.NET.Versioning" Version="6.0.1" />
     <PackageVersion Include="Antlr4BuildTasks" Version="12.10.0" />
     <PackageVersion Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageVersion Include="OpenSoftware.DgmlBuilder" Version="2.1.0" />
+
     <!-- Tests all use the same framework versions -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.9.1" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.9.1" />
     <PackageVersion Include="Tmds.ExecFunction" Version="0.8.0" />
-    <PackageVersion Include="Ubiquity.NET.Versioning" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ILibLlvm.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ILibLlvm.cs
@@ -36,7 +36,7 @@ namespace Ubiquity.NET.Llvm.Interop
         ImmutableArray<LibLLVMCodeGenTarget> SupportedTargets { get; }
 
         /// <summary>Gets version information for the library implementation</summary>
-        /// <returns><see cref="FileVersionQuad"/> for the native interop library</returns>
+        /// <returns><see cref="SemVer"/> for the native interop library</returns>
         /// <remarks>
         /// <note type="note">Since it is dealing with an extension of LLVM, the version is NOT guaranteed to match that
         /// of LLVM itself. Though, to avoid confusion, the major, minor and patch usually does and would only deviate

--- a/src/Samples/Kaleidoscope/Kaleidoscope-Overview.md
+++ b/src/Samples/Kaleidoscope/Kaleidoscope-Overview.md
@@ -6,33 +6,47 @@ uid: Kaleidoscope-ch1
 # 1. Kaleidoscope: Language Introduction
 The general flow of this tutorial follows that of the official
 [LLVM tutorial](xref:llvm_kaleidoscope_tutorial)
-and many of the samples are lifted directly from that tutorial to make it easier to follow
-along both tutorials to see how the various LLVM concepts are projected in the Ubiquity.NET.Llvm library.
+and many of the samples are lifted directly from that tutorial to make it easier to
+follow along both tutorials to see how the various LLVM concepts are projected in the
+Ubiquity.NET.Llvm library.
+
+>[!NOTE]
+> The samples are all setup to include `<PublishAot>True</PublishAot>` and therefore
+> support AOT code generation. To use that you only need to run
+> `dotnet publish <project path> -r win-x64` to build the native standalone version
+> of the app. This demonstrates that the libraries are AOT compatible. While this makes
+> things run faster as no JIT used, everything is already native code, it has the
+> drawback of making the app RID specific. That is, you must AOT build for EVERY
+>supported RID target. Thus, every use must make a choice and there is no single
+> "one size fits all" answer.
 
 ## Overview
-Kaleidoscope is a simple functional language that is used to illustrate numerous real world
-use cases for Ubiquity.NET.Llvm for code generation and JIT execution.
+Kaleidoscope is a simple functional language that is used to illustrate numerous real
+world use cases for Ubiquity.NET.Llvm for code generation and JIT execution.
 
-It is worth pointing out that this example is not intended as a treatise on compiler design nor
-on language parsing. While it contains many aspects of those topics the tutorial is, mostly, focused
-on the use of Ubiquity.NET.Llvm for code generation. Furthermore it isn't a trans-literation of the LLVM C++
-sample as that would defeat one of the major points of Ubiquity.NET.Llvm - to provide a familiar API and
-use pattern to C# developers.
+It is worth pointing out that this example is not intended as a treatise on compiler
+design nor on language parsing. While it contains many aspects of those topics the
+tutorial is, mostly, focused on the use of Ubiquity.NET.Llvm for code generation.
+Furthermore it isn't a trans-literation of the LLVM C++ sample as that would defeat
+one of the major points of Ubiquity.NET.Llvm - to provide a familiar API and use
+pattern to C# developers.
 
 ## General layout
-The samples are built using common core libraries and patterns. They are explicitly designed to
-make code comparisons between chapters via your favorite code comparison tool. Each, chapter builds
-on the next so running a comparison makes it easy to see the changes in full context. The text of
-the tutorials explains why the changes are made and a comparison helps provide the "big picture"
-view.
+The samples are built using common core libraries and patterns. They are explicitly
+designed to make code comparisons between chapters via your favorite code comparison
+tool. Each, chapter builds on the next so running a comparison makes it easy to see
+the changes in full context. The text of the tutorials explains why the changes are
+made and a comparison helps provide the "big picture" view.
 
 ## Variations from the Official LLVM Tutorial
-The Ubiquity.NET.Llvm version of the Kaleidoscope series takes a different route for parsing from the
-LLVM implementation. In particular the Ubiquity.NET.Llvm version defines a formal grammar using
-[ANTLR4](http://antlr.org) with the full grammar for all variations of the language features in
-a single assembly. Ultimately the parsing produces an [AST](xref:Kaleidoscope-AST) so that the actual
-technology used for the parse is hidden as an implementation detail. This helps in isolating the parsing
-from the use of Ubiquity.NET.Llvm for code generation and JIT compilation for interactive languages.
+The Ubiquity.NET.Llvm version of the Kaleidoscope series takes a different route for
+parsing from the LLVM implementation. In particular the Ubiquity.NET.Llvm version
+defines a formal grammar using [ANTLR4](http://antlr.org) with the full grammar for
+all variations of the language features in a single assembly. Ultimately the parsing
+produces an [AST](xref:Kaleidoscope-AST) so that the actual technology used for the
+parse is hidden as an implementation detail. This helps in isolating the parsing from
+the use of Ubiquity.NET.Llvm for code generation and JIT compilation for interactive
+languages.
 
 ## The Kaleidoscope Language
 ### General Concepts
@@ -44,43 +58,52 @@ Kaleidoscope is a simple functional language with the following major features:
 * For loop style control flow
 * User defined operators
   - User defined operators can specify operator precedence
-    - User defined precedence is arguably the most complex part of parsing and implementing the language.
-      Though, ANTLR4's flexibility made it fairly easy to do once fully understood. (more details in
-      [Chapter 6](xref:Kaleidoscope-ch6))
+    - User defined precedence is arguably the most complex part of parsing and
+      implementing the language. Though, ANTLR4's flexibility made it fairly easy to
+      do once fully understood. (more details in [Chapter 6](xref:Kaleidoscope-ch6))
 
 ### Expressions
-In Kaleidoscope, everything is an expression (e.g. everything has or returns a value even if the value
-is a constant 0.0). There are no statements and no "void" functions etc...
+In Kaleidoscope, everything is an expression (e.g. everything has or returns a value
+even if the value is a constant 0.0). There are no statements and no "void" functions
+etc...
 
 #### Multi-line expressions
-There are a few different ways to represent an expression that is long enough to warrant splitting it across
-multiple lines when typing it out.
+There are a few different ways to represent an expression that is long enough to
+warrant splitting it across multiple lines when typing it out.
 
 ##### Expression Continuation Marker
-One mechanism for handling multi-line expressions that is used in most shell scripting languages is a line
-continuation marker. In such cases a special character followed by a line-termination char or char sequence
-indicates that the expression continues on the next line (e.g. it isn't complete yet).
+One mechanism for handling multi-line expressions that is used in most shell scripting
+languages is a line continuation marker. In such cases a special character followed by
+a line-termination char or char sequence indicates that the expression continues on
+the next line (e.g. it isn't complete yet).
 
 ##### Expression Complete Marker
-Another approach to handling long expressions spanning multiple lines is basically the opposite of line
-continuation, expression complete markers. This marker indicates the end of a potentially multi-line expression. (A variant
-of this might require a line termination following the marker as with the line continuation).
+Another approach to handling long expressions spanning multiple lines is basically the
+opposite of line continuation, expression complete markers. This marker indicates the
+end of a potentially multi-line expression. (A variant of this might require a line
+termination following the marker as with the line continuation).
 
 ##### Kaleidoscope Implementation
-The original LLVM C++ implementation chose the expression completion approach using a semicolon as the completion.
-(So it seems familiar like statements in other C like languages) Therefore, the Ubiquity.NET.Llvm tutorial follows the same
-design. [Implementing the line continuation mechanism in Kaleidoscope is left as an exercise for the reader :wink:]
+The original LLVM C++ implementation chose the expression completion approach using a
+semicolon as the completion. (So it seems familiar like statements in other C like
+languages) Therefore, the Ubiquity.NET.Llvm tutorial follows the same design.
+[Implementing the line continuation mechanism in Kaleidoscope is left as an exercise
+for the reader - though if you come up with a mechanism to support either that is
+determined by the calling application; PRs are welcome! :wink:]
 
 ### Example
-The following example is a complete program in Kaleidoscope that will generate a textual representation
-of the classic Mandelbrot Set.
+The following example is a complete program in Kaleidoscope that will generate a
+textual representation of the classic Mandelbrot Set.
 
 [!code-Kaleidoscope[mandel.kls](mandel.kls)]
 
-When entered ( or copy/pasted) to the command line Kaleidoscope will print out the following:
+When entered ( or copy/pasted) to the command line Kaleidoscope will print out the
+following:
+
 >[!NOTE]
->This example uses features of the language only enabled/discussed in Chapter 6 of the tutorial.
->The runtime from chapters 3-5 will generate errors trying to parse this code.
+>This example uses features of the language only enabled/discussed in Chapter 6 of the
+>tutorial.The runtime from chapters 3-5 will generate errors trying to parse this
+>code.
 
 ```shell
 Ready>mandel(-2.3, -1.3, 0.05, 0.07);
@@ -130,8 +153,9 @@ Ready>
 ```
 
 ## Conclusion
-Kaleidoscope is a simple, yet complete, language with a good deal of functionality. This serves as
-a great language to study the use of Ubiquity.NET.Llvm for code generation and Domain Specific
-Languages. While, generally speaking, the functionality of the Ubiquity.NET.Llvm version of this
-tutorial differs only slightly from that of the official LLVM version, it serves well as an example
-of what you can do with Ubiquity.NET.Llvm.
+Kaleidoscope is a simple, yet complete, language with a good deal of functionality.
+This serves as a great language to study the use of Ubiquity.NET.Llvm for code
+generation and Domain Specific Languages. While, generally speaking, the functionality
+of the Ubiquity.NET.Llvm version of this tutorial differs only slightly from that of
+the official LLVM version, it serves well as an example of what you can do with
+Ubiquity.NET.Llvm.

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Runtime/Kaleidoscope.Runtime.csproj
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Runtime/Kaleidoscope.Runtime.csproj
@@ -11,9 +11,6 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="System.Linq.Async" />
-    </ItemGroup>
-    <ItemGroup>
         <ProjectReference Include="..\..\..\Ubiquity.NET.Llvm\Ubiquity.NET.Llvm.csproj" />
         <ProjectReference Include="..\Kaleidoscope.Grammar\Kaleidoscope.Grammar.csproj" />
     </ItemGroup>

--- a/src/Ubiquity.NET.Runtime.Utils/Ubiquity.NET.Runtime.Utils.csproj
+++ b/src/Ubiquity.NET.Runtime.Utils/Ubiquity.NET.Runtime.Utils.csproj
@@ -22,11 +22,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Linq.Async" />
+    <None Include="ReadMe.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="ReadMe.md" Pack="true" PackagePath="\" />
+    <PackageReference Include="System.Linq.Async" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Minor updates for versioning
* Corrected some doc comment typos
* Fixed so there's only one ref to Async Linq support.
    - Sadly that's not part of the built-in framework refs yet...
* Updated docs markdown for clarity on AOT support
    - Don't use VS publish profiles, they don't work.
* Updated package version for dependencies