### PR TITLE
Bumped version of Versioning task

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     Global references are included in ALL projects in this repository
   -->
   <ItemGroup>
-    <GlobalPackageReference Include="Ubiquity.NET.Versioning.Build.Tasks" Version="5.0.6" />
+    <GlobalPackageReference Include="Ubiquity.NET.Versioning.Build.Tasks" Version="5.0.7-alpha" />
     <GlobalPackageReference Include="IDisposableAnalyzers" Version="4.0.8" Condition="'$(NoCommonAnalyzers)' !=' true'" />
     <GlobalPackageReference Include="MustUseRetVal" Version="0.0.2" />
     <!--


### PR DESCRIPTION
Bumped version of Versioning task
* Proper versions had a bug where it didn't provide the version for project references.
    - How NuGet deals with project references and gets a version to use for the generated NuSpec dependency is a bit of a black art. None of it is formally documented, but is critical to any automated versioning system. Sadly the versioning task got this wrong and thus the generated packages all had `1.0.0` as the version for all project reference dependencies.