### PR TITLE
Unified editor config with consumer to provide more common support.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -161,7 +161,7 @@ dotnet_style_prefer_auto_properties = true:error
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_collection_initializer = true:warning
 dotnet_style_prefer_simplified_boolean_expressions = true:error
-dotnet_style_prefer_conditional_expression_over_assignment = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
 dotnet_style_prefer_conditional_expression_over_return = true:warning
 dotnet_style_explicit_tuple_names = true:warning
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
@@ -1608,3 +1608,6 @@ dotnet_diagnostic.SA1652.severity = warning
 
 dotnet_diagnostic.SX1101.severity = error
 
+
+# IDE0045: Convert to conditional expression
+dotnet_diagnostic.IDE0045.severity = suggestion

--- a/src/Ubiquity.NET.Llvm/IGlobalHandleOwner.cs
+++ b/src/Ubiquity.NET.Llvm/IGlobalHandleOwner.cs
@@ -7,6 +7,7 @@
 namespace Ubiquity.NET.Llvm
 {
     [SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1649:File name should match first type name", Justification = "Closely related interfaces" )]
+    [SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Internal Interface" )]
     internal interface IHandleWrapper<THandle>
     {
         /// <summary>Gets the handle for this wrapper</summary>
@@ -19,6 +20,7 @@ namespace Ubiquity.NET.Llvm
         internal THandle Handle { get; }
     }
 
+    [SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Internal Interface" )]
     internal interface IGlobalHandleOwner<THandle>
         : IDisposable
         where THandle : GlobalHandleBase

--- a/stylecop.json
+++ b/stylecop.json
@@ -35,7 +35,7 @@
             "companyName": "Ubiquity.NET Contributors",
             "headerDecoration": "-----------------------------------------------------------------------",
             "documentExposedElements": true,
-            "documentInterfaces": false,
+            "documentInterfaces": true,
             "documentInternalElements": false,
             "documentPrivateElements": false,
             "documentPrivateFields": false,


### PR DESCRIPTION
Unified editor config with consumer to provide more common support.
* Includes updates to StyleCop.json
    - This enables doc check for interfaces
        - Sadly this applies to any interface even internal ones. If any member of the interface has XML docs it will trigger an issue that the whole thing doesn't have docs.