### PR TITLE
Usage clarifications and updates.

### DIFF
--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/StringMarshaling/LLVMErrorRef.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/StringMarshaling/LLVMErrorRef.cs
@@ -48,7 +48,8 @@ namespace Ubiquity.NET.Llvm.Interop.ABI.StringMarshaling
         /// <summary>Gets a value indicating whether this instance represents a failure</summary>
         public bool Failed => !Success;
 
-        /// <inheritdoc/>
+        /// <summary>Gets a string representation of the error message</summary>
+        /// <returns>String representation of the error message</returns>
         public override string ToString( )
         {
             return LazyMessage.Value?.ToString() ?? string.Empty;

--- a/src/Ubiquity.NET.Llvm.Tests/ContextTests.cs
+++ b/src/Ubiquity.NET.Llvm.Tests/ContextTests.cs
@@ -41,7 +41,7 @@ namespace Ubiquity.NET.Llvm.UT
         public void GetPointerTypeForTest( )
         {
             using var context = new Context();
-            var int8PtrType = context.GetPointerTypeFor( context.Int8Type );
+            var int8PtrType = context.Int8Type.CreatePointerType();
             Assert.IsNotNull( int8PtrType );
             Assert.AreEqual( context, int8PtrType.Context );
 

--- a/src/Ubiquity.NET.Llvm/Context.cs
+++ b/src/Ubiquity.NET.Llvm/Context.cs
@@ -82,9 +82,6 @@ namespace Ubiquity.NET.Llvm
         public void SetDiagnosticHandler( DiagnosticInfoCallbackAction handler ) => Impl.SetDiagnosticHandler( handler );
 
         /// <inheritdoc/>
-        public IPointerType GetPointerTypeFor( ITypeRef elementType ) => Impl.GetPointerTypeFor( elementType );
-
-        /// <inheritdoc/>
         public ITypeRef GetIntType( uint bitWidth ) => Impl.GetIntType( bitWidth );
 
         /// <inheritdoc/>

--- a/src/Ubiquity.NET.Llvm/ContextAlias.cs
+++ b/src/Ubiquity.NET.Llvm/ContextAlias.cs
@@ -155,15 +155,6 @@ namespace Ubiquity.NET.Llvm
             }
         }
 
-        public IPointerType GetPointerTypeFor( ITypeRef elementType )
-        {
-            ArgumentNullException.ThrowIfNull( elementType );
-
-            return !Equals( elementType.Context )
-                ? throw new ArgumentException( Resources.Cannot_mix_types_from_different_contexts, nameof( elementType ) )
-                : (IPointerType)LLVMPointerType( elementType.GetTypeRef(), 0 ).CreateType();
-        }
-
         public ITypeRef GetIntType( uint bitWidth )
         {
             ArgumentOutOfRangeException.ThrowIfZero( bitWidth );

--- a/src/Ubiquity.NET.Llvm/ErrorInfo.cs
+++ b/src/Ubiquity.NET.Llvm/ErrorInfo.cs
@@ -37,7 +37,8 @@ namespace Ubiquity.NET.Llvm
         /// <summary>Gets a value indicating whether this instance is disposed</summary>
         public bool IsDisposed => Handle is not null && Handle.IsClosed;
 
-        /// <inheritdoc/>
+        /// <summary>Gets a string representation of the error message</summary>
+        /// <returns>String representation of the error message or an empty string if none</returns>
         public override string ToString( )
         {
             ObjectDisposedException.ThrowIf( IsDisposed, typeof( ErrorInfo ) );

--- a/src/Ubiquity.NET.Llvm/IContext.cs
+++ b/src/Ubiquity.NET.Llvm/IContext.cs
@@ -20,75 +20,75 @@ namespace Ubiquity.NET.Llvm
         : IEquatable<IContext>
     {
         /// <summary>Gets the LLVM void type for this context</summary>
-        public ITypeRef VoidType { get; }
+        ITypeRef VoidType { get; }
 
         /// <summary>Gets the LLVM boolean type for this context</summary>
-        public ITypeRef BoolType { get; }
+        ITypeRef BoolType { get; }
 
         /// <summary>Gets the LLVM 8 bit integer type for this context</summary>
-        public ITypeRef Int8Type { get; }
+        ITypeRef Int8Type { get; }
 
         /// <summary>Gets the LLVM 16 bit integer type for this context</summary>
-        public ITypeRef Int16Type { get; }
+        ITypeRef Int16Type { get; }
 
         /// <summary>Gets the LLVM 32 bit integer type for this context</summary>
-        public ITypeRef Int32Type { get; }
+        ITypeRef Int32Type { get; }
 
         /// <summary>Gets the LLVM 64 bit integer type for this context</summary>
-        public ITypeRef Int64Type { get; }
+        ITypeRef Int64Type { get; }
 
         /// <summary>Gets the LLVM 128 bit integer type for this context</summary>
-        public ITypeRef Int128Type { get; }
+        ITypeRef Int128Type { get; }
 
         /// <summary>Gets the LLVM half precision floating point type for this context</summary>
-        public ITypeRef HalfFloatType { get; }
+        ITypeRef HalfFloatType { get; }
 
         /// <summary>Gets the LLVM single precision floating point type for this context</summary>
-        public ITypeRef FloatType { get; }
+        ITypeRef FloatType { get; }
 
         /// <summary>Gets the LLVM double precision floating point type for this context</summary>
-        public ITypeRef DoubleType { get; }
+        ITypeRef DoubleType { get; }
 
         /// <summary>Gets the LLVM token type for this context</summary>
-        public ITypeRef TokenType { get; }
+        ITypeRef TokenType { get; }
 
         /// <summary>Gets the LLVM IrMetadata type for this context</summary>
-        public ITypeRef MetadataType { get; }
+        ITypeRef MetadataType { get; }
 
         /// <summary>Gets the LLVM X86 80-bit floating point type for this context</summary>
-        public ITypeRef X86Float80Type { get; }
+        ITypeRef X86Float80Type { get; }
 
         /// <summary>Gets the LLVM 128-Bit floating point type</summary>
-        public ITypeRef Float128Type { get; }
+        ITypeRef Float128Type { get; }
 
         /// <summary>Gets the LLVM PPC 128-bit floating point type</summary>
-        public ITypeRef PpcFloat128Type { get; }
+        ITypeRef PpcFloat128Type { get; }
 
         /// <summary>Gets or sets a value indicating whether the context keeps a map for uniqueing debug info identifiers across the context</summary>
-        public bool OdrUniqueDebugTypes { get; set; }
+        bool OdrUniqueDebugTypes { get; set; }
 
         /// <summary>Gets or sets a value indicating whether this context is configured to discard value names</summary>
-        public bool DiscardValueNames { get; set; }
+        bool DiscardValueNames { get; set; }
 
 #if HAVE_API_TO_ENUMERATE_METADATA
         /*
-        public IEnumerable<LazyEncodedString> MDKindNames { get; }
+        IEnumerable<LazyEncodedString> MDKindNames { get; }
         /*TODO: Create interop calls to support additional properties/methods
 
-        public unsigned GetOperandBundleTagId(LazyEncodedString name) {...}
-        public IEnumerable<LazyEncodedString> OperandBundleTagIds { get; }
+        unsigned GetOperandBundleTagId(LazyEncodedString name) {...}
+        IEnumerable<LazyEncodedString> OperandBundleTagIds { get; }
         */
 
         // Underlying LLVM has no mechanism to access the metadata in a context.
 
         /// <summary>Gets an enumerable collection of all the metadata created in this context</summary>
-        public IEnumerable<LlvmMetadata> Metadata => MetadataCache;
+        IEnumerable<LlvmMetadata> Metadata => MetadataCache;
 #endif
 
         /// <summary>Creates a simple attribute without arguments</summary>
         /// <param name="name">name of the attribute</param>
         /// <returns><see cref="AttributeValue"/> of the attribute</returns>
-        public AttributeValue CreateAttribute( LazyEncodedString name );
+        AttributeValue CreateAttribute( LazyEncodedString name );
 
         /// <summary>Creates an attribute with an integer value parameter</summary>
         /// <param name="name">name of the attribute</param>
@@ -98,14 +98,14 @@ namespace Ubiquity.NET.Llvm
         /// a full 64bit value. Se the LLVM docs for details.</para>
         /// </remarks>
         /// <returns><see cref="AttributeValue"/> with the specified kind and value</returns>
-        public AttributeValue CreateAttribute( LazyEncodedString name, UInt64 value );
+        AttributeValue CreateAttribute( LazyEncodedString name, UInt64 value );
 
         /// <summary>Create an attribute that accepts a type value</summary>
         /// <param name="name">name of the attribute</param>
         /// <param name="value">Type value to create the attribute with</param>
         /// <returns>Attribute value</returns>
         /// <exception cref="ArgumentException">The <paramref name="name"/> attribute does not accept a type argument</exception>
-        public AttributeValue CreateAttribute( LazyEncodedString name, ITypeRef value );
+        AttributeValue CreateAttribute( LazyEncodedString name, ITypeRef value );
 
         // TODO: Implement support for APInt with customized BigInteger.
         //       BigInteger mostly fits the bill except it doesn't constrain the max value by a specified number of bits
@@ -129,7 +129,7 @@ namespace Ubiquity.NET.Llvm
         /// and thus <paramref name="numBits"/> indicates the total bit width of the values in the range.
         /// </remarks>
         /// <exception cref="ArgumentException">The <paramref name="name"/> does not accept a constant range value</exception>
-        public AttributeValue CreateAttribute( LazyEncodedString name, UInt32 numBits, UInt64[] lowWords, UInt64[] upperWords );
+        AttributeValue CreateAttribute( LazyEncodedString name, UInt32 numBits, UInt64[] lowWords, UInt64[] upperWords );
 
         // TODO: Figure out how to create a constant range list attribute as LLVM-C API doesn't provide any means to do that.
 
@@ -137,16 +137,11 @@ namespace Ubiquity.NET.Llvm
         /// <param name="name">Attribute name</param>
         /// <param name="value">Value of the property</param>
         /// <returns><see cref="AttributeValue"/> with the specified name</returns>
-        public AttributeValue CreateAttribute( LazyEncodedString name, LazyEncodedString value );
+        AttributeValue CreateAttribute( LazyEncodedString name, LazyEncodedString value );
 
         /// <summary>Set a custom diagnostic handler</summary>
         /// <param name="handler">handler</param>
-        public void SetDiagnosticHandler( DiagnosticInfoCallbackAction handler );
-
-        /// <summary>Get a type that is a pointer to a value of a given type</summary>
-        /// <param name="elementType">Type of value the pointer points to</param>
-        /// <returns><see cref="IPointerType"/> for a pointer that references a value of type <paramref name="elementType"/></returns>
-        public IPointerType GetPointerTypeFor( ITypeRef elementType );
+        void SetDiagnosticHandler( DiagnosticInfoCallbackAction handler );
 
         /// <summary>Get's an LLVM integer type of arbitrary bit width</summary>
         /// <param name="bitWidth">Width of the integer type in bits</param>
@@ -157,30 +152,30 @@ namespace Ubiquity.NET.Llvm
         ///  GetIntType(16) is the same as <see cref="Int16Type"/>, etc... )
         /// </remarks>
         /// <returns>Integer <see cref="ITypeRef"/> for the specified width</returns>
-        public ITypeRef GetIntType( uint bitWidth );
+        ITypeRef GetIntType( uint bitWidth );
 
         /// <summary>Get an LLVM Function type (e.g. signature)</summary>
         /// <param name="returnType">Return type of the function</param>
         /// <param name="args">Potentially empty set of function argument types</param>
         /// <returns>Signature type for the specified signature</returns>
-        public IFunctionType GetFunctionType( ITypeRef returnType, params IEnumerable<ITypeRef> args );
+        IFunctionType GetFunctionType( ITypeRef returnType, params IEnumerable<ITypeRef> args );
 
         /// <summary>Get an LLVM Function type (e.g. signature)</summary>
         /// <param name="isVarArgs">Flag to indicate if the method supports C/C++ style VarArgs</param>
         /// <param name="returnType">Return type of the function</param>
         /// <param name="args">Potentially empty set of function argument types</param>
         /// <returns>Signature type for the specified signature</returns>
-        public IFunctionType GetFunctionType( bool isVarArgs, ITypeRef returnType, params IEnumerable<ITypeRef> args );
+        IFunctionType GetFunctionType( bool isVarArgs, ITypeRef returnType, params IEnumerable<ITypeRef> args );
 
         /// <summary>Creates a FunctionType with Debug information</summary>
         /// <param name="diBuilder"><see cref="DIBuilder"/>to use to create the debug information</param>
         /// <param name="retType">Return type of the function</param>
         /// <param name="argTypes">Argument types of the function</param>
         /// <returns>Function signature</returns>
-        public DebugFunctionType CreateFunctionType( IDIBuilder diBuilder
-                                                   , IDebugType<ITypeRef, DIType> retType
-                                                   , params IEnumerable<IDebugType<ITypeRef, DIType>> argTypes
-                                                   );
+        DebugFunctionType CreateFunctionType( IDIBuilder diBuilder
+                                            , IDebugType<ITypeRef, DIType> retType
+                                            , params IEnumerable<IDebugType<ITypeRef, DIType>> argTypes
+                                            );
 
         /// <summary>Creates a FunctionType with Debug information</summary>
         /// <param name="diBuilder"><see cref="DIBuilder"/>to use to create the debug information</param>
@@ -188,11 +183,11 @@ namespace Ubiquity.NET.Llvm
         /// <param name="retType">Return type of the function</param>
         /// <param name="argTypes">Argument types of the function</param>
         /// <returns>Function signature</returns>
-        public DebugFunctionType CreateFunctionType( IDIBuilder diBuilder
-                                                   , bool isVarArg
-                                                   , IDebugType<ITypeRef, DIType> retType
-                                                   , params IEnumerable<IDebugType<ITypeRef, DIType>> argTypes
-                                                   );
+        DebugFunctionType CreateFunctionType( IDIBuilder diBuilder
+                                            , bool isVarArg
+                                            , IDebugType<ITypeRef, DIType> retType
+                                            , params IEnumerable<IDebugType<ITypeRef, DIType>> argTypes
+                                            );
 
         /// <summary>Creates a constant structure from a set of values</summary>
         /// <param name="packed">Flag to indicate if the structure is packed and no alignment should be applied to the members</param>
@@ -210,7 +205,7 @@ namespace Ubiquity.NET.Llvm
         /// </list>
         /// </note>
         /// </remarks>
-        public Constant CreateConstantStruct( bool packed, params IEnumerable<Constant> values );
+        Constant CreateConstantStruct( bool packed, params IEnumerable<Constant> values );
 
         /// <summary>Creates a constant instance of a specified structure type from a set of values</summary>
         /// <param name="type">Type of the structure to create</param>
@@ -228,7 +223,7 @@ namespace Ubiquity.NET.Llvm
         /// </list>
         /// </note>
         /// </remarks>
-        public Constant CreateNamedConstantStruct( IStructType type, params IEnumerable<Constant> values );
+        Constant CreateNamedConstantStruct( IStructType type, params IEnumerable<Constant> values );
 
         /// <summary>Create an opaque structure type (e.g. a forward reference)</summary>
         /// <param name="name">Name of the type (use <see cref="LazyEncodedString.Empty"/> for anonymous types)</param>
@@ -239,7 +234,7 @@ namespace Ubiquity.NET.Llvm
         /// required)
         /// </remarks>
         /// <returns>New type</returns>
-        public IStructType CreateStructType( LazyEncodedString name );
+        IStructType CreateStructType( LazyEncodedString name );
 
         /// <summary>Create an anonymous structure type (e.g. Tuple)</summary>
         /// <param name="packed">Flag to indicate if the structure is "packed"</param>
@@ -247,7 +242,7 @@ namespace Ubiquity.NET.Llvm
         /// <returns>
         /// <see cref="IStructType"/> with the specified body defined.
         /// </returns>
-        public IStructType CreateStructType( bool packed, params IEnumerable<ITypeRef> elements );
+        IStructType CreateStructType( bool packed, params IEnumerable<ITypeRef> elements );
 
         /// <summary>Creates a new structure type in this <see cref="ContextAlias"/></summary>
         /// <param name="name">Name of the structure (use <see cref="LazyEncodedString.Empty"/> for anonymous types)</param>
@@ -259,7 +254,7 @@ namespace Ubiquity.NET.Llvm
         /// <remarks>
         /// If the elements argument list is empty then a complete 0 sized struct is created
         /// </remarks>
-        public IStructType CreateStructType( LazyEncodedString name, bool packed, params IEnumerable<ITypeRef> elements );
+        IStructType CreateStructType( LazyEncodedString name, bool packed, params IEnumerable<ITypeRef> elements );
 
         /// <summary>Creates a metadata string from the given string</summary>
         /// <param name="value">string to create as metadata</param>
@@ -268,12 +263,12 @@ namespace Ubiquity.NET.Llvm
         /// if <paramref name="value"/> is <see langword="null"/> then the result
         /// represents an empty string.
         /// </remarks>
-        public MDString CreateMetadataString( LazyEncodedString? value );
+        MDString CreateMetadataString( LazyEncodedString? value );
 
         /// <summary>Create an <see cref="MDNode"/> from a string</summary>
         /// <param name="value">String value</param>
         /// <returns>New node with the string as the first element of the <see cref="MDNode.Operands"/> property (as an MDString)</returns>
-        public MDNode CreateMDNode( LazyEncodedString value );
+        MDNode CreateMDNode( LazyEncodedString value );
 
         /// <summary>Create a constant data string value</summary>
         /// <param name="value">string to convert into an LLVM constant value</param>
@@ -284,7 +279,7 @@ namespace Ubiquity.NET.Llvm
         /// of a terminating null character, use the <see cref="CreateConstantString(LazyEncodedString, bool)"/>
         /// overload to specify the intended behavior.
         /// </remarks>
-        public ConstantDataArray CreateConstantString( LazyEncodedString value );
+        ConstantDataArray CreateConstantString( LazyEncodedString value );
 
         /// <summary>Create a constant data string value</summary>
         /// <param name="value">string to convert into an LLVM constant value</param>
@@ -294,97 +289,97 @@ namespace Ubiquity.NET.Llvm
         /// This converts the string to ANSI form and creates an LLVM constant array of i8
         /// characters for the data. Enforcement of a null terminator depends on the value of <paramref name="nullTerminate"/>
         /// </remarks>
-        public ConstantDataArray CreateConstantString( LazyEncodedString value, bool nullTerminate );
+        ConstantDataArray CreateConstantString( LazyEncodedString value, bool nullTerminate );
 
         /// <summary>Creates a new <see cref="ConstantInt"/> with a bit length of 1</summary>
         /// <param name="constValue">Value for the constant</param>
         /// <returns><see cref="ConstantInt"/> representing the value</returns>
-        public ConstantInt CreateConstant( bool constValue );
+        ConstantInt CreateConstant( bool constValue );
 
         /// <summary>Creates a new <see cref="ConstantInt"/> with a bit length of 8</summary>
         /// <param name="constValue">Value for the constant</param>
         /// <returns><see cref="ConstantInt"/> representing the value</returns>
-        public ConstantInt CreateConstant( byte constValue );
+        ConstantInt CreateConstant( byte constValue );
 
         /// <summary>Creates a new <see cref="ConstantInt"/> with a bit length of 8</summary>
         /// <param name="constValue">Value for the constant</param>
         /// <returns><see cref="ConstantInt"/> representing the value</returns>
-        public Constant CreateConstant( sbyte constValue );
+        Constant CreateConstant( sbyte constValue );
 
         /// <summary>Creates a new <see cref="ConstantInt"/> with a bit length of 16</summary>
         /// <param name="constValue">Value for the constant</param>
         /// <returns><see cref="ConstantInt"/> representing the value</returns>
-        public ConstantInt CreateConstant( Int16 constValue );
+        ConstantInt CreateConstant( Int16 constValue );
 
         /// <summary>Creates a new <see cref="ConstantInt"/> with a bit length of 16</summary>
         /// <param name="constValue">Value for the constant</param>
         /// <returns><see cref="ConstantInt"/> representing the value</returns>
-        public ConstantInt CreateConstant( UInt16 constValue );
+        ConstantInt CreateConstant( UInt16 constValue );
 
         /// <summary>Creates a new <see cref="ConstantInt"/> with a bit length of 32</summary>
         /// <param name="constValue">Value for the constant</param>
         /// <returns><see cref="ConstantInt"/> representing the value</returns>
-        public ConstantInt CreateConstant( Int32 constValue );
+        ConstantInt CreateConstant( Int32 constValue );
 
         /// <summary>Creates a new <see cref="ConstantInt"/> with a bit length of 32</summary>
         /// <param name="constValue">Value for the constant</param>
         /// <returns><see cref="ConstantInt"/> representing the value</returns>
-        public ConstantInt CreateConstant( UInt32 constValue );
+        ConstantInt CreateConstant( UInt32 constValue );
 
         /// <summary>Creates a new <see cref="ConstantInt"/> with a bit length of 64</summary>
         /// <param name="constValue">Value for the constant</param>
         /// <returns><see cref="ConstantInt"/> representing the value</returns>
-        public ConstantInt CreateConstant( Int64 constValue );
+        ConstantInt CreateConstant( Int64 constValue );
 
         /// <summary>Creates a new <see cref="ConstantInt"/> with a bit length of 64</summary>
         /// <param name="constValue">Value for the constant</param>
         /// <returns><see cref="ConstantInt"/> representing the value</returns>
-        public ConstantInt CreateConstant( UInt64 constValue );
+        ConstantInt CreateConstant( UInt64 constValue );
 
         /// <summary>Creates a new <see cref="ConstantInt"/> with a bit length of 64</summary>
         /// <param name="bitWidth">Bit width of the integer</param>
         /// <param name="constValue">Value for the constant</param>
         /// <param name="signExtend">flag to indicate if the constant value should be sign extended</param>
         /// <returns><see cref="ConstantInt"/> representing the value</returns>
-        public ConstantInt CreateConstant( uint bitWidth, UInt64 constValue, bool signExtend );
+        ConstantInt CreateConstant( uint bitWidth, UInt64 constValue, bool signExtend );
 
         /// <summary>Create a constant value of the specified integer type</summary>
         /// <param name="intType">Integer type</param>
         /// <param name="constValue">value</param>
         /// <param name="signExtend">flag to indicate if <paramref name="constValue"/> is sign extended</param>
         /// <returns>Constant for the specified value</returns>
-        public ConstantInt CreateConstant( ITypeRef intType, UInt64 constValue, bool signExtend );
+        ConstantInt CreateConstant( ITypeRef intType, UInt64 constValue, bool signExtend );
 
         /// <summary>Creates a constant floating point value for a given value</summary>
         /// <param name="constValue">Value to make into a <see cref="ConstantFP"/></param>
         /// <returns>Constant value</returns>
-        public ConstantFP CreateConstant( float constValue );
+        ConstantFP CreateConstant( float constValue );
 
         /// <summary>Creates a constant floating point value for a given value</summary>
         /// <param name="constValue">Value to make into a <see cref="ConstantFP"/></param>
         /// <returns>Constant value</returns>
-        public ConstantFP CreateConstant( double constValue );
+        ConstantFP CreateConstant( double constValue );
 
         /// <summary>Create a named <see cref="BasicBlock"/> without inserting it into a function</summary>
         /// <param name="name">Name of the block to create</param>
         /// <returns><see cref="BasicBlock"/> created</returns>
-        public BasicBlock CreateBasicBlock( LazyEncodedString name );
+        BasicBlock CreateBasicBlock( LazyEncodedString name );
 
         /// <summary>Creates a new instance of the <see cref="Module"/> class in this context</summary>
         /// <returns><see cref="Module"/></returns>
-        public Module CreateBitcodeModule( );
+        Module CreateBitcodeModule( );
 
         /// <summary>Creates a new instance of the <see cref="Module"/> class in a given context</summary>
         /// <param name="moduleId">ModuleHandle's ID</param>
         /// <returns><see cref="Module"/></returns>
-        public Module CreateBitcodeModule( LazyEncodedString moduleId );
+        Module CreateBitcodeModule( LazyEncodedString moduleId );
 
         /// <summary>Parse LLVM IR source for a module, into this context</summary>
         /// <param name="src">LLVM IR Source code of the module</param>
         /// <param name="name">Name of the module buffer</param>
         /// <returns>Newly created module parsed from the IR</returns>
         /// <exception cref="LlvmException">Any errors parsing the IR</exception>
-        public Module ParseModule( LazyEncodedString src, LazyEncodedString name );
+        Module ParseModule( LazyEncodedString src, LazyEncodedString name );
 
         /// <summary>Gets non-zero IrMetadata kind ID for a given name</summary>
         /// <param name="name">name of the metadata kind</param>
@@ -392,13 +387,13 @@ namespace Ubiquity.NET.Llvm
         /// <remarks>
         /// These IDs are uniqued across all modules in this context.
         /// </remarks>
-        public uint GetMDKindId( LazyEncodedString name );
+        uint GetMDKindId( LazyEncodedString name );
 
         /// <summary>Opens a <see cref="TargetBinary"/> from a path</summary>
         /// <param name="path">path to the object file binary</param>
         /// <returns>new object file</returns>
         /// <exception cref="System.IO.IOException">File IO failures</exception>
-        public TargetBinary OpenBinary( LazyEncodedString path );
+        TargetBinary OpenBinary( LazyEncodedString path );
     }
 
     internal static class ContextExtensions

--- a/src/Ubiquity.NET.Llvm/IModule.cs
+++ b/src/Ubiquity.NET.Llvm/IModule.cs
@@ -152,7 +152,7 @@ namespace Ubiquity.NET.Llvm
         /// <returns><see langword="true"/> if the function was found or <see langword="false"/> if not</returns>
         public bool TryGetNamedGlobalIFunc( LazyEncodedString name, [MaybeNullWhen( false )] out GlobalIFunc function );
 
-        /// <summary>Gets an existing function with the specified signature to the module or creates a new one if it doesn't exist</summary>
+        /// <summary>Gets an existing function with the specified signature in the module or creates a new one if it doesn't exist</summary>
         /// <param name="name">Name of the function to add</param>
         /// <param name="signature">Signature of the function</param>
         /// <returns><see cref="Function"/>matching the specified signature and name</returns>
@@ -163,6 +163,51 @@ namespace Ubiquity.NET.Llvm
         /// not perform any function overloading.
         /// </remarks>
         public Function CreateFunction( LazyEncodedString name, IFunctionType signature );
+
+        /// <summary>Creates a Function definition with Debug information</summary>
+        /// <param name="diBuilder">The debug info builder to use to create the function (must be associated with this module)</param>
+        /// <param name="scope">Containing scope for the function</param>
+        /// <param name="name">Name of the function in source language form</param>
+        /// <param name="linkageName">Mangled linker visible name of the function (may be same as <paramref name="name"/> if mangling not required by source language</param>
+        /// <param name="file">File containing the function definition</param>
+        /// <param name="line">Line number of the function definition</param>
+        /// <param name="signature">LLVM Function type for the signature of the function</param>
+        /// <param name="isLocalToUnit">Flag to indicate if this function is local to the compilation unit</param>
+        /// <param name="isDefinition">Flag to indicate if this is a definition</param>
+        /// <param name="scopeLine">First line of the function's outermost scope, this may not be the same as the first line of the function definition due to source formatting</param>
+        /// <param name="debugFlags">Additional flags describing this function</param>
+        /// <param name="isOptimized">Flag to indicate if this function is optimized</param>
+        /// <returns>Function described by the arguments</returns>
+        public Function CreateFunction( IDIBuilder diBuilder
+                                      , DIScope? scope
+                                      , LazyEncodedString name
+                                      , LazyEncodedString? linkageName
+                                      , DIFile? file
+                                      , uint line
+                                      , DebugFunctionType signature
+                                      , bool isLocalToUnit
+                                      , bool isDefinition
+                                      , uint scopeLine
+                                      , DebugInfoFlags debugFlags
+                                      , bool isOptimized
+                                      );
+
+        /// <summary>Creates a function</summary>
+        /// <param name="diBuilder"><see cref="DIBuilder"/> for creation of debug information</param>
+        /// <param name="name">Name of the function</param>
+        /// <param name="isVarArg">Flag indicating if the function supports a variadic argument list</param>
+        /// <param name="returnType">Return type of the function</param>
+        /// <param name="argumentTypes">Arguments for the function</param>
+        /// <returns>
+        /// Function, matching the signature specified. This may be a previously declared or defined
+        /// function or a new function if none matching the name and signature is already present.
+        /// </returns>
+        public Function CreateFunction( IDIBuilder diBuilder
+                                      , LazyEncodedString name
+                                      , bool isVarArg
+                                      , IDebugType<ITypeRef, DIType> returnType
+                                      , params IEnumerable<IDebugType<ITypeRef, DIType>> argumentTypes
+                                      );
 
         /// <summary>Writes a bit-code module to a file</summary>
         /// <param name="path">Path to write the bit-code into</param>
@@ -299,68 +344,6 @@ namespace Ubiquity.NET.Llvm
         /// <summary>Adds an llvm.ident metadata string to the module</summary>
         /// <param name="version">version information to place in the llvm.ident metadata</param>
         public void AddVersionIdentMetadata( LazyEncodedString version );
-
-        /// <summary>Creates a Function definition with Debug information</summary>
-        /// <param name="diBuilder">The debug info builder to use to create the function (must be associated with this module)</param>
-        /// <param name="scope">Containing scope for the function</param>
-        /// <param name="name">Name of the function in source language form</param>
-        /// <param name="linkageName">Mangled linker visible name of the function (may be same as <paramref name="name"/> if mangling not required by source language</param>
-        /// <param name="file">File containing the function definition</param>
-        /// <param name="line">Line number of the function definition</param>
-        /// <param name="signature">LLVM Function type for the signature of the function</param>
-        /// <param name="isLocalToUnit">Flag to indicate if this function is local to the compilation unit</param>
-        /// <param name="isDefinition">Flag to indicate if this is a definition</param>
-        /// <param name="scopeLine">First line of the function's outermost scope, this may not be the same as the first line of the function definition due to source formatting</param>
-        /// <param name="debugFlags">Additional flags describing this function</param>
-        /// <param name="isOptimized">Flag to indicate if this function is optimized</param>
-        /// <returns>Function described by the arguments</returns>
-        public Function CreateFunction( IDIBuilder diBuilder
-                                      , DIScope? scope
-                                      , LazyEncodedString name
-                                      , LazyEncodedString? linkageName
-                                      , DIFile? file
-                                      , uint line
-                                      , DebugFunctionType signature
-                                      , bool isLocalToUnit
-                                      , bool isDefinition
-                                      , uint scopeLine
-                                      , DebugInfoFlags debugFlags
-                                      , bool isOptimized
-                                      );
-
-        /// <summary>Creates a function</summary>
-        /// <param name="diBuilder"><see cref="DIBuilder"/> for creation of debug information</param>
-        /// <param name="name">Name of the function</param>
-        /// <param name="isVarArg">Flag indicating if the function supports a variadic argument list</param>
-        /// <param name="returnType">Return type of the function</param>
-        /// <param name="argumentTypes">Arguments for the function</param>
-        /// <returns>
-        /// Function, matching the signature specified. This may be a previously declared or defined
-        /// function or a new function if none matching the name and signature is already present.
-        /// </returns>
-        public Function CreateFunction( IDIBuilder diBuilder
-                                      , LazyEncodedString name
-                                      , bool isVarArg
-                                      , IDebugType<ITypeRef, DIType> returnType
-                                      , IEnumerable<IDebugType<ITypeRef, DIType>> argumentTypes
-                                      );
-
-        /// <summary>Creates a function</summary>
-        /// <param name="diBuilder"><see cref="DIBuilder"/> for creation of debug information</param>
-        /// <param name="name">Name of the function</param>
-        /// <param name="isVarArg">Flag indicating if the function supports a variadic argument list</param>
-        /// <param name="returnType">Return type of the function</param>
-        /// <param name="argumentTypes">Arguments for the function</param>
-        /// <returns>
-        /// Function, matching the signature specified. This may be a previously declared or defined
-        /// function or a new function if none matching the name and signature is already present.
-        /// </returns>
-        public Function CreateFunction( IDIBuilder diBuilder
-                                      , LazyEncodedString name
-                                      , bool isVarArg
-                                      , IDebugType<ITypeRef, DIType> returnType
-                                      , params IDebugType<ITypeRef, DIType>[] argumentTypes
-                                      );
 
         /// <summary>Gets a declaration for an LLVM intrinsic function</summary>
         /// <param name="name">Name of the intrinsic</param>

--- a/src/Ubiquity.NET.Llvm/Instructions/CallInstruction.cs
+++ b/src/Ubiquity.NET.Llvm/Instructions/CallInstruction.cs
@@ -15,8 +15,8 @@ namespace Ubiquity.NET.Llvm.Instructions
         , IFunctionAttributeAccessor
     {
         /// <summary>Gets the target function of the call</summary>
-        public Function TargetFunction
-            => FromHandle<Function>( LLVMGetCalledValue( Handle ).ThrowIfInvalid() )!;
+        public Value TargetFunction
+            => FromHandle<Value>( LLVMGetCalledValue( Handle ).ThrowIfInvalid() )!;
 
         /// <summary>Gets or sets a value indicating whether the call is a tail call</summary>
         public bool IsTailCall

--- a/src/Ubiquity.NET.Llvm/Instructions/InstructionBuilder.cs
+++ b/src/Ubiquity.NET.Llvm/Instructions/InstructionBuilder.cs
@@ -366,7 +366,10 @@ namespace Ubiquity.NET.Llvm.Instructions
             ArgumentNullException.ThrowIfNull( signature );
             ArgumentNullException.ThrowIfNull( target );
             ArgumentNullException.ThrowIfNull( args );
-            if(target is Function f && f.Signature != signature)
+
+            // NOTE: This only checks that the signatures refer to the same native value
+            //       (That is, it is native reference equality).
+            if(target is Function f && !f.Signature.Equals(signature))
             {
                 throw new ArgumentException("Function and signature mismatch");
             }

--- a/src/Ubiquity.NET.Llvm/Instructions/InstructionBuilder.cs
+++ b/src/Ubiquity.NET.Llvm/Instructions/InstructionBuilder.cs
@@ -333,18 +333,45 @@ namespace Ubiquity.NET.Llvm.Instructions
         /// <param name="func">Function to call</param>
         /// <param name="args">Arguments to pass to the function</param>
         /// <returns><see cref="CallInstruction"/></returns>
-        public CallInstruction Call( Function func, params Value[] args ) => Call( func, (IReadOnlyList<Value>)args );
+        /// <exception cref="ArgumentException">One of the parameters to this function is invalid</exception>
+        public CallInstruction Call( Function func, params IEnumerable<Value> args ) => Call( func, args.ToList().AsReadOnly() );
 
         /// <summary>Creates a call function</summary>
         /// <param name="func">Function to call</param>
         /// <param name="args">Arguments to pass to the function</param>
         /// <returns><see cref="CallInstruction"/></returns>
+        /// <exception cref="ArgumentException">One of the parameters to this function is invalid</exception>
         public CallInstruction Call( Function func, IReadOnlyList<Value> args )
         {
-            ArgumentNullException.ThrowIfNull( func );
-            ArgumentNullException.ThrowIfNull( args );
+            return Call(func.Signature, func, args);
+        }
 
-            LLVMValueRef hCall = BuildCall( func, args ).ThrowIfInvalid();
+        /// <summary>Creates a call instruction</summary>
+        /// <param name="signature">Function signature of the target</param>
+        /// <param name="target">Target of the function call (Must be invocable as <paramref name="signature"/>)</param>
+        /// <param name="args">Arguments to the function call (Must match types and number of <paramref name="signature"/>)</param>
+        /// <returns>Instruction created</returns>
+        /// <exception cref="ArgumentException">One of the parameters to this function is invalid</exception>
+        public CallInstruction Call( IFunctionType signature, Value target, params IEnumerable<Value> args )
+            => Call(signature, target, args.ToList().AsReadOnly() );
+
+        /// <summary>Creates a call instruction</summary>
+        /// <param name="signature">Function signature of the target</param>
+        /// <param name="target">Target of the function call (Must be invocable as <paramref name="signature"/>)</param>
+        /// <param name="args">Arguments to the function call (Must match types and number of <paramref name="signature"/>)</param>
+        /// <returns>Instruction created</returns>
+        /// <exception cref="ArgumentException">One of the parameters to this function is invalid</exception>
+        public CallInstruction Call( IFunctionType signature, Value target, IReadOnlyList<Value> args )
+        {
+            ArgumentNullException.ThrowIfNull( signature );
+            ArgumentNullException.ThrowIfNull( target );
+            ArgumentNullException.ThrowIfNull( args );
+            if(target is Function f && f.Signature != signature)
+            {
+                throw new ArgumentException("Function and signature mismatch");
+            }
+
+            LLVMValueRef hCall = BuildCall(signature, target, args ).ThrowIfInvalid();
             return Value.FromHandle<CallInstruction>( hCall )!;
         }
 
@@ -361,13 +388,13 @@ namespace Ubiquity.NET.Llvm.Instructions
             ArgumentNullException.ThrowIfNull( then );
             ArgumentNullException.ThrowIfNull( catchBlock );
 
-            ValidateCallArgs( func, args );
+            ValidateCallArgs( func.Signature, args );
             ArgumentNullException.ThrowIfNull( then );
             ArgumentNullException.ThrowIfNull( catchBlock );
 
             LLVMValueRef[ ] llvmArgs = [ .. args.Select( v => v.Handle ) ];
             LLVMValueRef invoke = LLVMBuildInvoke2( Handle
-                                                  , func.NativeType.GetTypeRef( ) // TODO: Is this legit with opaque pointers?
+                                                  , func.Signature.GetTypeRef( )
                                                   , func.Handle
                                                   , llvmArgs
                                                   , then.BlockHandle
@@ -1310,8 +1337,7 @@ namespace Ubiquity.NET.Llvm.Instructions
         {
             IModule module = GetModuleOrThrow( );
             var func = module.GetIntrinsicDeclaration( "llvm.donothing" );
-            var hCall = BuildCall( func );
-            return Value.FromHandle<CallInstruction>( hCall.ThrowIfInvalid() )!;
+            return Call(func);
         }
 
         /// <summary>Creates a llvm.debugtrap call</summary>
@@ -1320,7 +1346,6 @@ namespace Ubiquity.NET.Llvm.Instructions
         {
             var module = GetModuleOrThrow( );
             var func = module.GetIntrinsicDeclaration( "llvm.debugtrap" );
-
             return Call( func );
         }
 
@@ -1330,7 +1355,6 @@ namespace Ubiquity.NET.Llvm.Instructions
         {
             var module = GetModuleOrThrow( );
             var func = module.GetIntrinsicDeclaration( "llvm.trap" );
-
             return Call( func );
         }
 
@@ -1382,7 +1406,8 @@ namespace Ubiquity.NET.Llvm.Instructions
             // find the name of the appropriate overloaded form
             var func = module.GetIntrinsicDeclaration( "llvm.memcpy.p.p.i", dstPtrType, srcPtrType, len.NativeType );
 
-            var call = BuildCall( func
+            var call = BuildCall( func.Signature
+                                , func
                                 , destination
                                 , source
                                 , len
@@ -1439,7 +1464,7 @@ namespace Ubiquity.NET.Llvm.Instructions
             // find the name of the appropriate overloaded form
             var func = module.GetIntrinsicDeclaration( "llvm.memmove.p.p.i", dstPtrType, srcPtrType, len.NativeType );
 
-            var call = BuildCall( func, destination, source, len, module.Context.CreateConstant( isVolatile ) );
+            var call = BuildCall( func.Signature, func, destination, source, len, module.Context.CreateConstant( isVolatile ) );
             return Value.FromHandle( call.ThrowIfInvalid() )!;
         }
 
@@ -1486,7 +1511,8 @@ namespace Ubiquity.NET.Llvm.Instructions
             // find the appropriate overloaded form of the function
             var func = module.GetIntrinsicDeclaration( "llvm.memset.p.i", dstPtrType, value.NativeType );
 
-            var call = BuildCall( func
+            var call = BuildCall( func.Signature
+                                , func
                                 , destination
                                 , value
                                 , len
@@ -1694,10 +1720,8 @@ namespace Ubiquity.NET.Llvm.Instructions
             return Value.FromHandle<AtomicRMW>( handle.ThrowIfInvalid() )!;
         }
 
-        private static IFunctionType ValidateCallArgs( Function func, IReadOnlyList<Value> args )
+        private static void ValidateCallArgs( IFunctionType signatureType, IReadOnlyList<Value> args )
         {
-            IFunctionType signatureType = func.Signature;
-
             // validate arg count; too few or too many (unless the signature supports varargs) is an error
             if(args.Count < signatureType.ParameterTypes.Count
                 || (args.Count > signatureType.ParameterTypes.Count && !signatureType.IsVarArg)
@@ -1710,23 +1734,27 @@ namespace Ubiquity.NET.Llvm.Instructions
             {
                 if(!args[ i ].NativeType.Equals( signatureType.ParameterTypes[ i ] ))
                 {
-                    string msg = string.Format( CultureInfo.CurrentCulture, Resources.Call_site_argument_type_mismatch_for_function_0_at_index_1_argType_equals_2_signatureType_equals_3, func, i, args[ i ].NativeType, signatureType.ParameterTypes[ i ] );
+                    string msg = string.Format( CultureInfo.CurrentCulture
+                                              , Resources.Call_site_argument_type_mismatch_for_function_0_at_index_1_argType_equals_2_signatureType_equals_3
+                                              , signatureType.ToString()
+                                              , i
+                                              , args[ i ].NativeType
+                                              , signatureType.ParameterTypes[ i ]
+                                              );
                     throw new ArgumentException( msg, nameof( args ) );
                 }
             }
-
-            return signatureType;
         }
 
-        private LLVMValueRef BuildCall( Function func, params Value[] args ) => BuildCall( func, (IReadOnlyList<Value>)args );
+        private LLVMValueRef BuildCall( IFunctionType sig, Value target, params Value[] args ) => BuildCall( sig, target, (IReadOnlyList<Value>)args );
 
-        private LLVMValueRef BuildCall( Function func ) => BuildCall( func, new List<Value>() );
+        private LLVMValueRef BuildCall( IFunctionType sig, Value target ) => BuildCall( sig, target, new List<Value>() );
 
-        private LLVMValueRef BuildCall( Function func, IReadOnlyList<Value> args )
+        private LLVMValueRef BuildCall( IFunctionType sig, Value target, IReadOnlyList<Value> args )
         {
-            IFunctionType sig = ValidateCallArgs( func, args );
+            ValidateCallArgs( sig, args );
             LLVMValueRef[ ] llvmArgs = [ .. args.Select( v => v.Handle ) ];
-            return LLVMBuildCall2( Handle, sig.GetTypeRef(), func.Handle, llvmArgs, (uint)llvmArgs.Length, LazyEncodedString.Empty );
+            return LLVMBuildCall2( Handle, sig.GetTypeRef(), target.Handle, llvmArgs, (uint)llvmArgs.Length, LazyEncodedString.Empty );
         }
 
         private LLVMBuilderRef Handle { get; }

--- a/src/Ubiquity.NET.Llvm/Module.cs
+++ b/src/Ubiquity.NET.Llvm/Module.cs
@@ -110,6 +110,47 @@ namespace Ubiquity.NET.Llvm
         public Function CreateFunction( LazyEncodedString name, IFunctionType signature ) => Impl.CreateFunction( name, signature );
 
         /// <inheritdoc/>
+        public Function CreateFunction( IDIBuilder diBuilder
+                                      , DIScope? scope
+                                      , LazyEncodedString name
+                                      , LazyEncodedString? linkageName
+                                      , DIFile? file
+                                      , uint line
+                                      , DebugFunctionType signature
+                                      , bool isLocalToUnit
+                                      , bool isDefinition
+                                      , uint scopeLine
+                                      , DebugInfoFlags debugFlags
+                                      , bool isOptimized
+                                      )
+         {
+            return Impl.CreateFunction( diBuilder
+                                      , scope
+                                      , name
+                                      , linkageName
+                                      , file
+                                      , line
+                                      , signature
+                                      , isLocalToUnit
+                                      , isDefinition
+                                      , scopeLine
+                                      , debugFlags
+                                      , isOptimized
+                                      );
+         }
+
+        /// <inheritdoc/>
+        public Function CreateFunction( IDIBuilder diBuilder
+                                      , LazyEncodedString name
+                                      , bool isVarArg
+                                      , IDebugType<ITypeRef, DIType> returnType
+                                      , params IEnumerable<IDebugType<ITypeRef, DIType>> argumentTypes
+                                      )
+        {
+            return Impl.CreateFunction( diBuilder, name, isVarArg, returnType, argumentTypes );
+        }
+
+        /// <inheritdoc/>
         public void WriteToFile( string path ) => Impl.WriteToFile( path );
 
         /// <inheritdoc/>
@@ -162,18 +203,6 @@ namespace Ubiquity.NET.Llvm
 
         /// <inheritdoc/>
         public void AddVersionIdentMetadata( LazyEncodedString version ) => Impl.AddVersionIdentMetadata( version );
-
-        /// <inheritdoc/>
-        public Function CreateFunction( IDIBuilder diBuilder, DIScope? scope, LazyEncodedString name, LazyEncodedString? linkageName, DIFile? file, uint line, DebugFunctionType signature, bool isLocalToUnit, bool isDefinition, uint scopeLine, DebugInfoFlags debugFlags, bool isOptimized )
-            => Impl.CreateFunction( diBuilder, scope, name, linkageName, file, line, signature, isLocalToUnit, isDefinition, scopeLine, debugFlags, isOptimized );
-
-        /// <inheritdoc/>
-        public Function CreateFunction( IDIBuilder diBuilder, LazyEncodedString name, bool isVarArg, IDebugType<ITypeRef, DIType> returnType, IEnumerable<IDebugType<ITypeRef, DIType>> argumentTypes )
-            => Impl.CreateFunction( diBuilder, name, isVarArg, returnType, argumentTypes );
-
-        /// <inheritdoc/>
-        public Function CreateFunction( IDIBuilder diBuilder, LazyEncodedString name, bool isVarArg, IDebugType<ITypeRef, DIType> returnType, params IDebugType<ITypeRef, DIType>[] argumentTypes )
-            => Impl.CreateFunction( diBuilder, name, isVarArg, returnType, argumentTypes );
 
         /// <inheritdoc/>
         public Function GetIntrinsicDeclaration( LazyEncodedString name, params ITypeRef[] args ) => Impl.GetIntrinsicDeclaration( name, args );

--- a/src/Ubiquity.NET.Llvm/ModuleAlias.cs
+++ b/src/Ubiquity.NET.Llvm/ModuleAlias.cs
@@ -555,22 +555,11 @@ namespace Ubiquity.NET.Llvm
                                       , LazyEncodedString name
                                       , bool isVarArg
                                       , IDebugType<ITypeRef, DIType> returnType
-                                      , IEnumerable<IDebugType<ITypeRef, DIType>> argumentTypes
+                                      , params IEnumerable<IDebugType<ITypeRef, DIType>> argumentTypes
                                       )
         {
             IFunctionType signature = Context.CreateFunctionType( diBuilder, isVarArg, returnType, argumentTypes );
             return CreateFunction( name, signature );
-        }
-
-        /// <inheritdoc/>
-        public Function CreateFunction( IDIBuilder diBuilder
-                                      , LazyEncodedString name
-                                      , bool isVarArg
-                                      , IDebugType<ITypeRef, DIType> returnType
-                                      , params IDebugType<ITypeRef, DIType>[] argumentTypes
-                                      )
-        {
-            return CreateFunction( diBuilder, name, isVarArg, returnType, (IEnumerable<IDebugType<ITypeRef, DIType>>)argumentTypes );
         }
 
         /// <inheritdoc/>

--- a/src/Ubiquity.NET.Llvm/Types/IPointerType.cs
+++ b/src/Ubiquity.NET.Llvm/Types/IPointerType.cs
@@ -21,8 +21,8 @@ namespace Ubiquity.NET.Llvm.Types
         /// Unfortunately that means that IR generators need to track the type of
         /// elements and that this property may be <see langword="null"/> if not
         /// known. In practice, this is true when the pointer was retrieved directly
-        /// from the lower level LLVM APIs and no prior cached managed wrapper exists
-        /// with the type. This, at least, will provide it if available.
+        /// from the lower level LLVM APIs and no Debugging type wrapper exists
+        /// with the type. This, at least, will provide it if it is available.
         /// </remarks>
         ITypeRef? ElementType { get; init; }
     }

--- a/src/Ubiquity.NET.Llvm/Types/ITypeRef.cs
+++ b/src/Ubiquity.NET.Llvm/Types/ITypeRef.cs
@@ -75,6 +75,18 @@ namespace Ubiquity.NET.Llvm.Types
     }
 
     /// <summary>Interface for a Type in LLVM</summary>
+    /// <remarks>
+    /// <note type="important">
+    /// The <see cref="IEquatable{T}"/> on this type ONLY deals with the native reference equality. That is,
+    /// any reference type uses reference equality by default, but <see cref="IEquatable{T}.Equals"/> uses what
+    /// is implemented or a default of reference equality for reference types. In this case it determines if
+    /// the type refers to the exact same type instance. (Not an equivalent but different type). This is normally
+    /// valid as LLVM underneath is uniqueing types within a context. As an example a managed implementation of
+    /// <see cref="ITypeRef"/> `A` is a wrapper around an LLVM handle `H` that refers to an native LLVM type `T`.
+    /// If there is also a <see cref="ITypeRef"/> `B`, then `A.Equals(B)` is true ONLY if `B` also wraps an LLVM
+    /// handle that refers to native type `T`.
+    /// </note>
+    /// </remarks>
     public interface ITypeRef
         : IEquatable<ITypeRef>
     {

--- a/src/Ubiquity.NET.Llvm/Types/TypeRef.cs
+++ b/src/Ubiquity.NET.Llvm/Types/TypeRef.cs
@@ -14,7 +14,7 @@ namespace Ubiquity.NET.Llvm.Types
         , ITypeHandleOwner
     {
         /// <inheritdoc/>
-        bool IEquatable<ITypeRef>.Equals( ITypeRef? other ) => other is ITypeHandleOwner tho && tho.Equals( (ITypeHandleOwner)this );
+        bool IEquatable<ITypeRef>.Equals( ITypeRef? other ) => other is ITypeHandleOwner tho && tho.Equals( this );
 
         public bool Equals( ITypeHandleOwner? other ) => other is not null && Handle.Equals( other.Handle );
 


### PR DESCRIPTION
Usage clarifications and updates.
This contains support determined from actual usage.
* Added support for indirect calls etc..
    - Added support for using a `Value` as the target along with a function pointer type for generating a `call` instruction.
* Removed IContext.GetPointerTypeFor
    - Functionality exists in the type itself and a context instance is not needed
* Clarified docs on ToString() for ErrorInfo
    - Includes LLVMErrorRef
* Removed visibility from IContext interface as it is redundant.
    - While the language now supports visibility on interface members, use of it has all sorts of confusing and subtle rules and complications that it generally results in surprising
* Moved Module `CreateFunction` overloads together so it is easier to see the group of methods.