### PR TITLE
Fix header blank line elision

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -63,6 +63,7 @@
                 <Nullable Condition="$(Nullable)=='' AND '$(UsingMicrosoftNETSdk)'=='true'">enable</Nullable>
                 <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
                 <EnableNETAnalyzers>true</EnableNETAnalyzers>
+                <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
                 <!--
                 DO NOT ALLOW Implicit using msbuild feature - EVIL; causes mass issues and frustration moving code between projects when one doesn't
                 support it or uses a different version. Not to mention hiding the actual namespaces involved, making resolving conflicts HARDER.

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/AttributeBindings.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/AttributeBindings.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Usually ordering applies, however in this case the ordering is by method name
 // and sometimes contains a wrapper method on the low level to make use easier.
 #pragma warning disable SA1202 // Elements should be ordered by access

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/DataLayoutBindings.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/DataLayoutBindings.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Usually ordering applies, however in this case the ordering is by method name
 // and sometimes contains a wrapper method on the low level to make use easier.
 #pragma warning disable SA1202 // Elements should be ordered by access

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/MetadataBindings.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/MetadataBindings.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Usually ordering applies, however in this case the ordering is by method name
 // and sometimes contains a wrapper method on the low level to make use easier.
 #pragma warning disable SA1202 // Elements should be ordered by access

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/ModuleBindings.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/ModuleBindings.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Usually ordering applies, however in this case the ordering is by method name
 // and sometimes contains a wrapper method on the low level to make use easier.
 #pragma warning disable SA1202 // Elements should be ordered by access

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/TargetMachineBindings.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/TargetMachineBindings.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Usually ordering applies, however in this case the ordering is by method name
 // and sometimes contains a wrapper method on the low level to make use easier.
 #pragma warning disable SA1202 // Elements should be ordered by access

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/TargetRegistrationBindings.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/TargetRegistrationBindings.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Usually ordering applies, however in this case the ordering is by method name
 // and sometimes contains a wrapper method on the low level to make use easier.
 #pragma warning disable SA1202 // Elements should be ordered by access

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/ValueBindings.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/ValueBindings.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Usually ordering applies, however in this case the ordering is by method name
 // and sometimes contains a wrapper method on the low level to make use easier.
 #pragma warning disable SA1202 // Elements should be ordered by access

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/Core.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/Core.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Usually ordering applies, however in this case the ordering is by method name
 // and sometimes contains a wrapper method on the low level to make use easier.
 #pragma warning disable SA1202 // Elements should be ordered by access

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/DebugInfo.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/DebugInfo.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Usually ordering applies, however in this case the ordering is by method name
 // and sometimes contains a wrapper method on the low level to make use easier.
 #pragma warning disable SA1202 // Elements should be ordered by access

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/ExecutionEngine.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/ExecutionEngine.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Usually ordering applies, however in this case the ordering is by method name
 // and sometimes contains a wrapper method on the low level to make use easier.
 #pragma warning disable SA1202 // Elements should be ordered by access

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/LLJIT.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/LLJIT.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Usually ordering applies, however in this case the ordering is by method name
 // and sometimes contains a wrapper method on the low level to make use easier.
 #pragma warning disable SA1202 // Elements should be ordered by access

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/Object.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/Object.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Usually ordering applies, however in this case the ordering is by method name
 // and sometimes contains a wrapper method on the low level to make use easier.
 #pragma warning disable SA1202 // Elements should be ordered by access

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/Orc.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/llvm-c/Orc.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Usually ordering applies, however in this case the ordering is by method name
 // and sometimes contains a wrapper method on the low level to make use easier.
 #pragma warning disable SA1202 // Elements should be ordered by access

--- a/src/ReferenceEqualityVerifier/ReferenceEqualityVerifier.Test/GlobalSuppressions.cs
+++ b/src/ReferenceEqualityVerifier/ReferenceEqualityVerifier.Test/GlobalSuppressions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given

--- a/src/Ubiquity.NET.Llvm.Tests/DebugInfo/DebugUnionTypeTests.cs
+++ b/src/Ubiquity.NET.Llvm.Tests/DebugInfo/DebugUnionTypeTests.cs
@@ -8,6 +8,7 @@ using Ubiquity.NET.Llvm.Types;
 
 // warning SA1500: Braces for multi-line statements must not share line
 #pragma warning disable SA1500
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 
 namespace Ubiquity.NET.Llvm.UT
 {
@@ -85,6 +86,7 @@ namespace Ubiquity.NET.Llvm.UT
             Assert.AreEqual( 0U, union.IntegerBitWidth );
         }
 
+#pragma warning disable CA1506
         [TestMethod]
         public void DebugUnionTypeTest2( )
         {
@@ -180,5 +182,6 @@ namespace Ubiquity.NET.Llvm.UT
                 Assert.AreEqual( members[ i ].DebugType.DebugInfoType, memberType.BaseType );
             }
         }
+#pragma warning restore CA1506
     }
 }

--- a/src/Ubiquity.NET.Llvm/DebugInfo/DwarfEnumerations.cs
+++ b/src/Ubiquity.NET.Llvm/DebugInfo/DwarfEnumerations.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // The names describe what they are, further details are available in the DWARF specs
 #pragma warning disable CS1591, SA1600, SA1602 // Enumeration items must be documented
 

--- a/src/Ubiquity.NET.Llvm/DisAssembler.cs
+++ b/src/Ubiquity.NET.Llvm/DisAssembler.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // this file declares and uses the "experimental" interface `IDisassemblerCallbacks`.
 #pragma warning disable LLVM002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 

--- a/src/Ubiquity.NET.Llvm/ILibLLVM.cs
+++ b/src/Ubiquity.NET.Llvm/ILibLLVM.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // This is cribbed from the interop library to prevent the need for applications to take a direct dependency on the interop library
 using System.Collections.Immutable;
 

--- a/src/Ubiquity.NET.Llvm/IModule.cs
+++ b/src/Ubiquity.NET.Llvm/IModule.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // until compiler bug [#40325](https://github.com/dotnet/roslyn/issues/40325) is resolved disable this
 // as adding the parameter would result in 'warning: Duplicate parameter 'passes' found in comments, the latter one is ignored.'
 // when generating the final documentation. (It picks the first one and reports a warning).

--- a/src/Ubiquity.NET.Llvm/OrcJITv2/GenericSymbolOption.cs
+++ b/src/Ubiquity.NET.Llvm/OrcJITv2/GenericSymbolOption.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // shut up tooling for no docs on things that are 1:1 renames/aliasing of LLVM values and not entirely clear
 #pragma warning disable CS1591 // Disable warning: "Missing XML comment for publicly visible type or member"
 

--- a/src/Ubiquity.NET.Llvm/OrcJITv2/IOrcJit.cs
+++ b/src/Ubiquity.NET.Llvm/OrcJITv2/IOrcJit.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // They are order by access, unfortunately this analyzer has stupid built-in defaults that
 // puts internal as higher priority than protected and no way to override it.
 #pragma warning disable SA1202 // Elements should be ordered by access

--- a/src/Ubiquity.NET.Llvm/OrcJITv2/MaterializationUnit.cs
+++ b/src/Ubiquity.NET.Llvm/OrcJITv2/MaterializationUnit.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Elements ARE ordered correctly, analyzer has dumb defaults and doesn't allow override of order
 #pragma warning disable SA1202 // Elements should be ordered by access
 

--- a/src/Ubiquity.NET.Llvm/Types/ArrayType.cs
+++ b/src/Ubiquity.NET.Llvm/Types/ArrayType.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Interface+internal type matches file name
 #pragma warning disable SA1649
 

--- a/src/Ubiquity.NET.Llvm/Types/FunctionType.cs
+++ b/src/Ubiquity.NET.Llvm/Types/FunctionType.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Interface+internal type matches file name
 #pragma warning disable SA1649
 

--- a/src/Ubiquity.NET.Llvm/Types/IPointerType.cs
+++ b/src/Ubiquity.NET.Llvm/Types/IPointerType.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Interface+internal type matches file name
 #pragma warning disable SA1649
 

--- a/src/Ubiquity.NET.Llvm/Types/ITypeRef.cs
+++ b/src/Ubiquity.NET.Llvm/Types/ITypeRef.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Interface+internal type matches file name
 #pragma warning disable SA1649
 

--- a/src/Ubiquity.NET.Llvm/Types/SequenceType.cs
+++ b/src/Ubiquity.NET.Llvm/Types/SequenceType.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Interface+internal type matches file name
 #pragma warning disable SA1649
 

--- a/src/Ubiquity.NET.Llvm/Types/StructType.cs
+++ b/src/Ubiquity.NET.Llvm/Types/StructType.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Interface+internal type matches file name
 #pragma warning disable SA1649
 

--- a/src/Ubiquity.NET.Llvm/Types/VectorType.cs
+++ b/src/Ubiquity.NET.Llvm/Types/VectorType.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // Interface+internal type matches file name
 #pragma warning disable SA1649
 

--- a/src/Ubiquity.NET.Llvm/Values/CallingConvention.cs
+++ b/src/Ubiquity.NET.Llvm/Values/CallingConvention.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // until compiler bug [#40325](https://github.com/dotnet/roslyn/issues/40325) is resolved disable this
 // as adding the parameter would result in 'warning: Duplicate parameter 'passes' found in comments, the latter one is ignored.'
 // when generating the final documentation. (It picks the first one and reports a warning).

--- a/src/Ubiquity.NET.Llvm/Values/Function.cs
+++ b/src/Ubiquity.NET.Llvm/Values/Function.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
 // until compiler bug [#40325](https://github.com/dotnet/roslyn/issues/40325) is resolved disable this
 // as adding the parameter would result in 'warning: Duplicate parameter 'passes' found in comments, the latter one is ignored.'
 // when generating the final documentation. (It picks the first one and reports a warning).


### PR DESCRIPTION
PR #294 resolved header forms to a consistent style. However the "fixer" to apply the header elided blank lines that help explain things. Additionally, the missing blank line re-introduces SA1636 (Circular fix). So this adds the blank lines back again.

* Set general support for C# projects to treat warnings as errors to force explicit silencing of warnings AND catch things like this before they go into the repo.