### PR TITLE
Added Unit tests for CommandLine

### DIFF
--- a/src/Ubiquity.NET.CommandLine.UT/AssemblyInfo.cs
+++ b/src/Ubiquity.NET.CommandLine.UT/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+// In SDK-style projects such as this one, several assembly attributes that were historically
+// defined in this file are now automatically added during build and populated with
+// values defined in project properties. For details of which attributes are included
+// and how to customize this process see: https://aka.ms/assembly-info-properties
+
+// Setting ComVisible to false makes the types in this assembly not visible to COM
+// components.  If you need to access a type in this assembly from COM, set the ComVisible
+// attribute to true on that type.
+[assembly: ComVisible( false )]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM.
+[assembly: Guid( "994905c9-5cea-480a-b9fa-1458c5fc04d5" )]
+
+[assembly: CLSCompliant( false )]

--- a/src/Ubiquity.NET.CommandLine.UT/CommandLineTests.cs
+++ b/src/Ubiquity.NET.CommandLine.UT/CommandLineTests.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+using System.CommandLine;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ubiquity.NET.CommandLine.UT
+{
+    [TestClass]
+    public class CommandLineTests
+    {
+        [TestMethod]
+        public void CommandLine_parse_with_version_option_only_succeeds( )
+        {
+            var settings = CreateTestSettings();
+            var result = ArgsParsing.Parse<TestOptions>(["--version"], settings);
+
+            // due to bug in underlying library this will fail, see: https://github.com/dotnet/command-line-api/issues/2659
+            // bug is fixed in PR https://github.com/dotnet/command-line-api/pull/2644 but not available
+            // yet. (as of version 2.0.0-beta7.25380.108)
+            //Assert.HasCount( 0, result.Errors );
+            Assert.HasCount( 1, result.Errors );
+
+            var versionOption = result.GetVersionOption();
+            Assert.IsNotNull(versionOption);
+            Assert.AreEqual( versionOption.Action, result.Action);
+        }
+
+        [TestMethod]
+        public void CommandLine_with_help_option_only_succeeds( )
+        {
+            var settings = CreateTestSettings();
+
+            var result = ArgsParsing.Parse<TestOptions>(["--help"], settings);
+            Assert.HasCount( 0, result.Errors );
+        }
+
+        [TestMethod]
+        public void CommandLine_with_unknown_option_has_errors( )
+        {
+            var settings = CreateTestSettings();
+            ParseResult result = ArgsParsing.Parse<TestOptions>(["--FooBar"], settings );
+            Assert.HasCount( 2, result.Errors, "Errors should include missing Required, and invalid param" );
+        }
+
+        [TestMethod]
+        [Ignore("https://github.com/dotnet/command-line-api/issues/2664")]
+        public void CommandLine_with_known_option_and_version_has_errors( )
+        {
+            var settings = CreateTestSettings();
+            ParseResult result = ArgsParsing.Parse<TestOptions>(["--version", "--option1"], settings );
+
+            // until https://github.com/dotnet/command-line-api/issues/2664 is resolved this will fail
+            Assert.HasCount( 2, result.Errors, "Should be one error (--version must be set alone, missing arg for --option1)" );
+        }
+
+        [TestMethod]
+        [Ignore("https://github.com/dotnet/command-line-api/issues/2664")]
+        public void CommandLine_with_known_option_requiring_arg_and_version_has_errors( )
+        {
+            var settings = CreateTestSettings();
+            ParseResult result = ArgsParsing.Parse<TestOptions>(["--option1", "--version"], settings );
+
+            // until https://github.com/dotnet/command-line-api/issues/2664 is resolved this will fail
+            Assert.HasCount( 2, result.Errors, "Should be one error (--version must be set alone, missing arg for --option1)" );
+        }
+
+        internal static CmdLineSettings CreateTestSettings( DefaultOption defaultOptions = DefaultOption.Help | DefaultOption.Version )
+        {
+            return new CmdLineSettings()
+            {
+                DefaultOptions = defaultOptions,
+            };
+        }
+    }
+}

--- a/src/Ubiquity.NET.CommandLine.UT/GlobalSuppressions.cs
+++ b/src/Ubiquity.NET.CommandLine.UT/GlobalSuppressions.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Unit Tests" )]
+[assembly: SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1652:Enable XML documentation output", Justification = "Unit Tests" )]

--- a/src/Ubiquity.NET.CommandLine.UT/ModuleFixtures.cs
+++ b/src/Ubiquity.NET.CommandLine.UT/ModuleFixtures.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+#if USE_MODULE_FIXTURES
+using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ubiquity.NET.CommandLine.UT
+{
+    // Provides common location for one time initialization for all tests in this assembly
+    [TestClass]
+    public static class ModuleFixtures
+    {
+        [AssemblyInitialize]
+        public static void AssemblyInitialize( TestContext ctx )
+        {
+            ArgumentNullException.ThrowIfNull( ctx );
+        }
+
+        [AssemblyCleanup]
+        public static void AssemblyCleanup( )
+        {
+        }
+    }
+}
+#endif

--- a/src/Ubiquity.NET.CommandLine.UT/RawApiTests.cs
+++ b/src/Ubiquity.NET.CommandLine.UT/RawApiTests.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+using System.CommandLine;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ubiquity.NET.CommandLine.UT
+{
+    /// <summary>This is mostly for validation.understanding of the underlying RAW API as well as a good place to put "samples" for bug reports</summary>
+    [TestClass]
+    public class RawApiTests
+    {
+        [TestMethod]
+        [Ignore( "https://github.com/dotnet/command-line-api/issues/2664" )]
+        public void RawApi_Version_Error_tests( )
+        {
+            var rootCommand = new RootCommand("Test Root")
+            {
+                new Option<string>("--option1")
+                {
+                    Description = "Test option `",
+                    Required = true,
+                },
+            };
+
+            var result = rootCommand.Parse(["--FooBar", "--version"]);
+            Assert.HasCount( 3, result.Errors, "Errors should account for, bogus arg (`--FooBar`), missing required arg (`--option1`), AND that `--version` should be solo" );
+        }
+
+        [TestMethod]
+        [Ignore( "https://github.com/dotnet/command-line-api/issues/2664" )]
+        public void RawApi_Help_Error_tests( )
+        {
+            var rootCommand = new RootCommand("Test Root")
+            {
+                new Option<string>("--option1")
+                {
+                    Description = "Test option `",
+                    Required = true,
+                },
+            };
+
+            var result = rootCommand.Parse(["--FooBar", "--help"]);
+            Assert.HasCount( 3, result.Errors, "Errors should account for bogus arg (`--FooBar`), missing required arg (`--option1`), AND that `--version` should be solo" );
+        }
+
+        [TestMethod]
+        [Ignore( "https://github.com/dotnet/command-line-api/issues/2659" )]
+        public void RawApi_Version_Only_with_required_has_no_errors( )
+        {
+            var rootCommand = new RootCommand("Test Root")
+            {
+                new Option<string>("--option1")
+                {
+                    Description = "Test option `",
+                    Required = true,
+                },
+            };
+
+            var result = rootCommand.Parse(["--version"]);
+            Assert.HasCount( 0, result.Errors, "Should not be any errors" );
+        }
+
+        [TestMethod]
+        [Ignore("https://github.com/dotnet/command-line-api/issues/2664")]
+        public void RawApi_Version_with_required_option_has_errors( )
+        {
+            var rootCommand = new RootCommand("Test Root")
+            {
+                new Option<string>("--option1")
+                {
+                    Description = "Test option `",
+                    Required = true,
+                },
+            };
+
+            var result = rootCommand.Parse(["--version", "--option1"]);
+
+            // This assert will fail - result.Errors.Count == 3!
+            // result.Errors:
+            //    [0]{--version option cannot be combined with other arguments.}
+            //    [1]{Required argument missing for option: '--option1'.}
+            //    [2]{Required argument missing for option: '--option1'.} // Why is this occurring twice?
+            //Assert.HasCount( 2, result.Errors, "Should be two errors (version not used solo, missing arg)" );
+
+            // try with arguments in reversed order (--version is later)
+            result = rootCommand.Parse(["--option1", "--version"]);
+
+            // result.Action == null! [BUG]
+            // result.Errors.Count == 0! [BUG]
+            Assert.HasCount( 2, result.Errors, "Should be two errors (version not used solo, missing arg)" );
+
+            result = rootCommand.Parse("--option1 --version");
+
+            // result.Action == null! [BUG]
+            // result.Errors.Count == 0! [BUG]
+            Assert.HasCount( 2, result.Errors, "Should be two errors (version not used solo, missing arg)" );
+        }
+    }
+}

--- a/src/Ubiquity.NET.CommandLine.UT/SettingsTestExtensions.cs
+++ b/src/Ubiquity.NET.CommandLine.UT/SettingsTestExtensions.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+
+namespace Ubiquity.NET.CommandLine.UT
+{
+    internal static class SettingsTestExtensions
+    {
+        public static ImmutableArray<string> GetOutput( this StringWriter self )
+        {
+            ArgumentNullException.ThrowIfNull( self );
+            string underlyingString = self.ToString();
+            return string.IsNullOrWhiteSpace( underlyingString )
+                ? []
+                : [ .. underlyingString.Split( self.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries ) ];
+        }
+    }
+}

--- a/src/Ubiquity.NET.CommandLine.UT/TestOptions.cs
+++ b/src/Ubiquity.NET.CommandLine.UT/TestOptions.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+namespace Ubiquity.NET.CommandLine.UT
+{
+    internal partial class TestOptions
+    {
+        public string Option1 { get; init; } = string.Empty;
+    }
+}

--- a/src/Ubiquity.NET.CommandLine.UT/TestOptions.g.cs
+++ b/src/Ubiquity.NET.CommandLine.UT/TestOptions.g.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ubiquity.NET.CommandLine.UT
+{
+    // FUTURE: Generate this with source generator from attributes in other partial declaration
+    internal partial class TestOptions
+        : ICommandLineOptions<TestOptions>
+    {
+        public static TestOptions Bind( ParseResult parseResult )
+        {
+            return new()
+            {
+                Option1 = parseResult.GetValue(Descriptors.Option1),
+            };
+        }
+
+        public static AppControlledDefaultsRootCommand BuildRootCommand( CmdLineSettings settings )
+        {
+            return new( settings, "Test option root command")
+            {
+                Descriptors.Option1,
+            };
+        }
+
+        internal static class Descriptors
+        {
+            internal static Option<string> Option1
+                = new("--option1")
+                {
+                    Description = "Test Option",
+                    Required = true, // Should have no impact on Help/Version
+                };
+        }
+    }
+}

--- a/src/Ubiquity.NET.CommandLine.UT/Ubiquity.NET.CommandLine.UT.csproj
+++ b/src/Ubiquity.NET.CommandLine.UT/Ubiquity.NET.CommandLine.UT.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+      <TargetFramework>net9.0</TargetFramework>
+      <IsPackable>false</IsPackable>
+      <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" />
+      <PackageReference Include="MSTest.TestFramework" />
+      <PackageReference Include="MSTest.TestAdapter" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ubiquity.NET.CommandLine\Ubiquity.NET.CommandLine.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Ubiquity.NET.Llvm.slnx
+++ b/src/Ubiquity.NET.Llvm.slnx
@@ -64,14 +64,17 @@
     <Project Path="Samples/Kaleidoscope/Kaleidoscope.Runtime/Kaleidoscope.Runtime.csproj" />
     <Project Path="Samples/Kaleidoscope/Kaleidoscope.Tests/Kaleidoscope.Tests.csproj" />
   </Folder>
+  <Folder Name="/Tests/">
+    <Project Path="Ubiquity.NET.CommandLine.UT/Ubiquity.NET.CommandLine.UT.csproj" />
+    <Project Path="Ubiquity.NET.Llvm.JIT.Tests/Ubiquity.NET.Llvm.JIT.Tests.csproj" />
+    <Project Path="Ubiquity.NET.Llvm.Tests/Ubiquity.NET.Llvm.UT.csproj" />
+  </Folder>
   <Project Path="../docfx/documentation.msbuildproj" Type="13b669be-bb05-4ddf-9536-439f39a36129" />
   <Project Path="../PsModules/CommonBuild/CommonBuild.pssproj" Type="f5034706-568f-408a-b7b3-4d38c6db8a32" Id="6cafc0c6-a428-4d30-a9f9-700e829fea51" />
   <Project Path="../PsModules/RepoBuild/RepoBuild.pssproj" Type="f5034706-568f-408a-b7b3-4d38c6db8a32" Id="118e4d2b-5adb-4f7c-9395-b4ceeee3d2e1" />
   <Project Path="Ubiquity.NET.ANTLR.Utils/Ubiquity.NET.ANTLR.Utils.csproj" />
   <Project Path="Ubiquity.NET.CommandLine/Ubiquity.NET.CommandLine.csproj" Id="3dae7afd-0d33-4805-855b-c1283237b58a" />
   <Project Path="Ubiquity.NET.Extensions/Ubiquity.NET.Extensions.csproj" />
-  <Project Path="Ubiquity.NET.Llvm.JIT.Tests/Ubiquity.NET.Llvm.JIT.Tests.csproj" />
-  <Project Path="Ubiquity.NET.Llvm.Tests/Ubiquity.NET.Llvm.UT.csproj" />
   <Project Path="Ubiquity.NET.Llvm/Ubiquity.NET.Llvm.csproj" />
   <Project Path="Ubiquity.NET.Runtime.Utils/Ubiquity.NET.Runtime.Utils.csproj" />
   <Project Path="Ubiquity.NET.TextUX/Ubiquity.NET.TextUX.csproj" Id="0c58feb7-2b42-431a-9a37-43a8b263add9" />


### PR DESCRIPTION
Added Unit tests for CommandLine
* State of the testing is rather limited due to bugs in the underlying API and design

[This library should minimize exposure to the underlying System.CommandLine so that it is easier to replace it with a different parsing technology as there are a LOT of issues/assumptions]