### PR TITLE
Minor docs/Markdown updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,6 +27,11 @@ indent_style = space
 indent_size = 2
 tab_width = 2
 
+[*.md]
+# mark left margion for split screen preview of markdown files
+# requires: https://marketplace.visualstudio.com/items?itemName=PaulHarrington.EditorGuidelinesPreview
+guidelines = 92
+
 # match ISO standard requirement for C/C++
 [*.c,*.h,*.cpp]
 insert_final_newline = true

--- a/src/Samples/Kaleidoscope/Kaleidoscope-Overview.md
+++ b/src/Samples/Kaleidoscope/Kaleidoscope-Overview.md
@@ -13,12 +13,13 @@ follow along both tutorials to see how the various LLVM concepts are projected i
 >[!NOTE]
 > The samples are all setup to include `<PublishAot>True</PublishAot>` and therefore
 > support AOT code generation. To use that you only need to run
-> `dotnet publish <project path> -r win-x64` to build the native standalone version
+> `dotnet publish <project path> -r <RID>` to build the native standalone version
 > of the app. This demonstrates that the libraries are AOT compatible. While this makes
-> things run faster as no JIT used, everything is already native code, it has the
+> things run faster as no JIT is used, everything is already native code, it has the
 > drawback of making the app RID specific. That is, you must AOT build for EVERY
->supported RID target. Thus, every use must make a choice and there is no single
-> "one size fits all" answer.
+> supported RID target. Each usage case must make a choice and there is no single
+> "one size fits all" answer. Thus, the samples and the library itself allow for, but
+> ***Do NOT*** require AOT builds.
 
 ## Overview
 Kaleidoscope is a simple functional language that is used to illustrate numerous real

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/ANTLR/Kaleidoscope-ParseTreeVisitor.md
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/ANTLR/Kaleidoscope-ParseTreeVisitor.md
@@ -3,24 +3,28 @@ uid: Kaleidoscope-ParseTreeVisitor
 ---
 
 # Kaleidoscope Parse Tree Visitors
-The Ubiquity.NET.Llvm Kaleidoscope tutorials all use ANTLR4 to parse the Kaleidoscope language When ANTLR processes the
-language grammar description to generate the lexer and parser it also generates a base "visitor" class for applying
-the [Visitor pattern](https://en.wikipedia.org/wiki/Visitor_pattern) to the parse tree. This is the primary mechanism
-for generating the [AST](xref:Kaleidoscope-AST) for these examples. The AST transformation classes derive from the ANTLR
-generated base visitor class.
+The Ubiquity.NET.Llvm Kaleidoscope tutorials all use ANTLR4 to parse the Kaleidoscope
+language When ANTLR processes the grammar description to generate the lexer and parser it
+also generates a base "visitor" class for applying the [Visitor pattern](https://en.wikipedia.org/wiki/Visitor_pattern)
+to the parse tree. This is the primary mechanism for generating the [AST](xref:Kaleidoscope-AST)
+for these examples. The AST transformation classes derive from the ANTLR generated base
+visitor class.
 
-There are only a few top level rules in the grammar to consider (although each has many sub rules).
+There are only a few top level rules in the grammar to consider (although each has many
+sub-rules).
 
 [!code-antlr[repl](Kaleidoscope.g4?start=181&end=187)]
 
-The parse tree consist of a tree of nodes generated for each rule in the grammar. The rule classes are generated at
-build time when the antlr grammar file is parsed. The C# target for ANTLR4 will generate the rule classes with the
-partial keyword, allowing the application code to add application specific support to the rule classes, and thus to
-the parse tree. For Kaleidoscope, this is used to provide simpler access to the information parsed from the Kaleidoscope
-language input simplifying generation of the AST. For simplicity and clarity of understanding each of the extended partial
-classes are placed into their own source file.
+The parse tree consist of a tree of nodes generated for each rule in the grammar. The rule
+classes are generated at build time when the ANTLR grammar file is parsed. The C# target for
+ANTLR4 will generate the rule classes with the partial keyword, allowing the application
+code to add application specific support to the rule classes, and thus to the parse tree.
+For Kaleidoscope, this is used to provide simpler access to the information parsed from the
+Kaleidoscope language input simplifying generation of the AST. For simplicity and clarity of
+understanding each of the extended partial classes are placed into their own source file.
 
-Generally speaking, the use of ANTLR and the ParseTree is a hidden internal implementation detail of the Ubiquity.NET.Llvm
-Kaleidoscope tutorials. The actual code generation deals only with the AST so the parsing could be done with some
-other technology. (Though with all the functionality that ANTLR4 provides it would take a strong argument to justify
-something else)
+Generally speaking, the use of ANTLR and the ParseTree is a hidden internal implementation
+detail of the Ubiquity.NET.Llvm Kaleidoscope tutorials. The actual code generation deals
+only with the AST so the parsing could be done with some other technology. (Though with all
+the functionality that ANTLR4 provides it would take a strong argument to justify something
+else)

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/ANTLR/Kaleidoscope-Parsetree-examples.md
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/ANTLR/Kaleidoscope-Parsetree-examples.md
@@ -13,9 +13,9 @@ uid: Kaleidoscope-Parsetree-examples
 ![Parse Tree](./parsetree-simpleexp-1.svg)
 
 >[!NOTE]
->The small circle in the upper left corner of the Expression nodes is the precedence value at
->the entry to the rule. ANTLR uses a precedence climbing algorithm so this number indicates
->the precedence for the expression in relation to others.
+>The small circle in the upper left corner of the Expression nodes is the precedence
+>value at the entry to the rule. ANTLR uses a precedence climbing algorithm so this number
+>indicates the precedence for the expression in relation to others.
 
 >[!NOTE]
 >The parse tree for the expression has 5 children that are in evaluation order. That is,


### PR DESCRIPTION
* Mostly validates new machine config.
* Added editorconfig setting for a guideline in markdown files.
    * Simplifies visualizing limits of lines without split screen "preview" showing. This makes editing markdown files easier and keeps them all releatively consistent. * It's just a "guideline" no hard rule! Anything can go past it but that should be kept to a bare minimun (Some things like links are allowed to go longer)