### PR TITLE
Added TextMate grammar for Kaleidoscope

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ the use of the library.
 
 >[!NOTE]
 > Visual Studio Code is NOT officially supported. Such support is welcome as a PR as long as
-> it does not impact the use of VS 2022 nor the automated build. [Obviously this comment
+> it does not impact the use of VS 20xx nor the automated build. [Obviously this comment
 > should be removed if such a PR is made!]
  
 #### Using Visual Studio

--- a/src/Samples/Kaleidoscope/Chapter6/mandel.kls
+++ b/src/Samples/Kaleidoscope/Chapter6/mandel.kls
@@ -1,15 +1,19 @@
+# unary operator to perform a logical NOT
 def unary!(v)
   if v then
     0
   else
     1;
 
+# unary operator to perform a mathematical negation
 def unary-(v)
   0-v;
 
+# Comparison operator
 def binary> 10 (LHS RHS)
   RHS < LHS;
 
+# Logical OR operator
 def binary| 5 (LHS RHS)
   if LHS then
     1
@@ -18,17 +22,21 @@ def binary| 5 (LHS RHS)
   else
     0;
 
+# Logical AND operator
 def binary& 6 (LHS RHS)
   if !LHS then
     0
   else
     !!RHS;
 
+# arithmatic equality test
 def binary== 9 (LHS RHS)
   !(LHS < RHS | LHS > RHS);
 
+# selector operator
 def binary : 1 (x y) y;
 
+# declare access to built-in function
 extern putchard(char);
 
 def printdensity(d)

--- a/src/Samples/Kaleidoscope/TextMate/ReadMe.md
+++ b/src/Samples/Kaleidoscope/TextMate/ReadMe.md
@@ -1,0 +1,27 @@
+﻿# TextMate support
+This folder provides TextMate Grammar support. It is based on the [HighlightJS](../../../../docfx/templates/Ubiquity/public/Kaleidoscope.js)
+grammar used in the documentation template for the site docs. This allows highlighting in
+an editor.
+
+## VisualStudio
+In Visual Studio copies of subfolders of this folder can be placed into the user profile
+folder `.vs/Extensions` to enable syntax highlighting of the Kaleidoscope
+language files.
+
+>[!NOTE]
+> For Windows the user profile is available in an environment varialbe. In PowerShell that
+> is accessed as `$env:userprofile`. In classic CMD prompts it is `%USERPROFILE%`. Normally
+> it is `C:\Users\<UserName>` but can vary depending on how your system is set up.
+
+Example:
+```
+📁 %USERPROFILE%
+└─📁 .vs
+   └─📁 Extensions
+      └─📁 Kaleidoscope
+         └─📁 syntaxes
+            └─📄 Kaleidoscope.plist
+```
+This will enable syntax highlighting for all Kaleidoscope files (.kls) loaded
+after this file is present (any editors without highlighting need to be closed
+and re-opened as the set of contributing highlighters is determined once at file load.)

--- a/src/Samples/Kaleidoscope/TextMate/syntaxes/Kaleidoscope.plist
+++ b/src/Samples/Kaleidoscope/TextMate/syntaxes/Kaleidoscope.plist
@@ -1,0 +1,54 @@
+﻿<plist version="1.0">
+  <dict>
+    <key>uuid</key>
+    <string>6F193C25-558C-4DFF-8807-A304287C8EEE</string>
+    <key>name</key>
+    <string>Kaleidoscope</string>
+    <key>scopeName</key>
+    <string>source.kaleidoscope</string>
+    <key>fileTypes</key>
+    <array>
+      <string>kls</string>
+    </array>
+    <key>patterns</key>
+    <array>
+      <dict>
+        <!-- NOTE: In VS these become tagged as "keyword" unless overridden with a custom definition -->
+        <key>name</key>
+        <string>keyword.control.kaleidoscope</string>
+        <key>match</key>
+        <string>\b(def|extern|if|then|else|for|in|var|unary|binary)\b</string>
+      </dict>
+      <dict>
+        <!-- NOTE: In VS these become tagged as "keyword" unless overridden with a custom definition -->
+        <key>name</key>
+        <string>support.function.kaleidoscope</string>
+        <key>match</key>
+        <string>\b(putchard|printd)\b</string>
+      </dict>
+      <dict>
+        <!-- NOTE: In VS these become tagged as "comment" unless overridden with a custom definition -->
+        <key>name</key>
+        <string>comment.line.number-sign.kaleidoscope</string>
+        <key>begin</key>
+          <string>#</string>
+          <key>end</key>
+          <string>\n</string>
+      </dict>
+      <dict>
+        <!-- NOTE: In VS these become tagged as "number" unless overridden with a custom definition -->
+        <key>name</key>
+        <string>constant.numeric.kaleidoscope</string>
+        <key>match</key>
+        <string>-?\d+(?:[.]\d+)?(?:[eE][-+]?\d+)?</string>
+      </dict>
+      <dict>
+        <!-- NOTE: In VS these become tagged as "identifier" unless overridden with a custom definition -->
+        <key>name</key>
+        <string>variable.other.kaleidoscope</string>
+        <key>match</key>
+        <string>[A-Za-z\$_][0-9A-Za-z\$_]*</string>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/src/Ubiquity.NET.Llvm.slnx
+++ b/src/Ubiquity.NET.Llvm.slnx
@@ -64,6 +64,12 @@
     <Project Path="Samples/Kaleidoscope/Kaleidoscope.Grammar/Kaleidoscope.Grammar.csproj" />
     <Project Path="Samples/Kaleidoscope/Kaleidoscope.Runtime/Kaleidoscope.Runtime.csproj" />
   </Folder>
+  <Folder Name="/Samples/Kaleidoscope/TextMate/">
+    <File Path="Samples/Kaleidoscope/TextMate/ReadMe.md" />
+  </Folder>
+  <Folder Name="/Samples/Kaleidoscope/TextMate/syntaxes/">
+    <File Path="Samples/Kaleidoscope/TextMate/syntaxes/Kaleidoscope.plist" />
+  </Folder>
   <Folder Name="/Tests/">
     <Project Path="Interop/InteropTests/Ubiquity.NET.Llvm.Interop.UT.csproj" />
     <Project Path="Samples/Kaleidoscope/Kaleidoscope.Tests/Kaleidoscope.Tests.csproj" />


### PR DESCRIPTION
Added TextMate grammar for Kaleidoscope
* This allows highlighting in an editor supporting that.
    - VS does but has a [bug](https://developercommunity.visualstudio.com/t/Text-editor-highligts-matches-even-when/10988990) where it doesn't honor "Show selection matches"
* Minor doc readme updates.