### PR TITLE
Renamed `KaleidoscopeReadEvaluatePrintLoopBase` -> `ReadEvaluatePrintLoopBase`

### DIFF
--- a/src/Samples/Kaleidoscope/Chapter2/ReplEngine.cs
+++ b/src/Samples/Kaleidoscope/Chapter2/ReplEngine.cs
@@ -11,7 +11,7 @@ using Ubiquity.NET.Runtime.Utils;
 namespace Kaleidoscope.Chapter2
 {
     internal class ReplEngine
-        : KaleidoscopeReadEvaluatePrintLoopBase<IAstNode>
+        : ReadEvaluatePrintLoopBase<IAstNode>
     {
         public ReplEngine( )
             : base( LanguageLevel.MutableVariables )

--- a/src/Samples/Kaleidoscope/Chapter3.5/ReplEngine.cs
+++ b/src/Samples/Kaleidoscope/Chapter3.5/ReplEngine.cs
@@ -12,7 +12,7 @@ using Ubiquity.NET.Runtime.Utils;
 namespace Kaleidoscope.Chapter3_5
 {
     internal class ReplEngine
-        : KaleidoscopeReadEvaluatePrintLoopBase<Value>
+        : ReadEvaluatePrintLoopBase<Value>
     {
         public ReplEngine( )
             : base( LanguageLevel.SimpleExpressions )

--- a/src/Samples/Kaleidoscope/Chapter3/ReplEngine.cs
+++ b/src/Samples/Kaleidoscope/Chapter3/ReplEngine.cs
@@ -12,7 +12,7 @@ using Ubiquity.NET.Runtime.Utils;
 namespace Kaleidoscope.Chapter3
 {
     internal class ReplEngine
-        : KaleidoscopeReadEvaluatePrintLoopBase<Value>
+        : ReadEvaluatePrintLoopBase<Value>
     {
         public ReplEngine( )
             : base( LanguageLevel.SimpleExpressions )

--- a/src/Samples/Kaleidoscope/Chapter4/ReplEngine.cs
+++ b/src/Samples/Kaleidoscope/Chapter4/ReplEngine.cs
@@ -12,7 +12,7 @@ using Ubiquity.NET.Runtime.Utils;
 namespace Kaleidoscope.Chapter4
 {
     internal class ReplEngine
-        : KaleidoscopeReadEvaluatePrintLoopBase<Value>
+        : ReadEvaluatePrintLoopBase<Value>
     {
         public ReplEngine( )
             : base( LanguageLevel.SimpleExpressions )
@@ -41,8 +41,15 @@ namespace Kaleidoscope.Chapter4
 
             case Function function:
 #if SAVE_LLVM_IR
-                string safeFileName = Utilities.GetSafeFileName( function.Name );
-                _ = function.ParentModule.WriteToTextFile( System.IO.Path.ChangeExtension( safeFileName, "ll" ), out string _ );
+                if(function.Name is not null)
+                {
+                    string safeFileName = Utilities.GetSafeFileName( function.Name );
+                    string finalPath = System.IO.Path.ChangeExtension( safeFileName, "ll" );
+                    if(!function.ParentModule.WriteToTextFile( finalPath, out string errMessage ))
+                    {
+                        Console.Error.WriteLine($"ERROR saving output file '{finalPath}': {errMessage}");
+                    }
+                }
 #endif
                 break;
 

--- a/src/Samples/Kaleidoscope/Chapter5/ReplEngine.cs
+++ b/src/Samples/Kaleidoscope/Chapter5/ReplEngine.cs
@@ -12,7 +12,7 @@ using Ubiquity.NET.Runtime.Utils;
 namespace Kaleidoscope.Chapter5
 {
     internal class ReplEngine
-        : KaleidoscopeReadEvaluatePrintLoopBase<Value>
+        : ReadEvaluatePrintLoopBase<Value>
     {
         public ReplEngine( )
             : base( LanguageLevel.ControlFlow )
@@ -41,8 +41,15 @@ namespace Kaleidoscope.Chapter5
 
             case Function function:
 #if SAVE_LLVM_IR
-                string safeFileName = Utilities.GetSafeFileName( function.Name );
-                _ = function.ParentModule.WriteToTextFile( System.IO.Path.ChangeExtension( safeFileName, "ll" ), out string _ );
+                if(function.Name is not null)
+                {
+                    string safeFileName = Utilities.GetSafeFileName( function.Name );
+                    string finalPath = System.IO.Path.ChangeExtension( safeFileName, "ll" );
+                    if(!function.ParentModule.WriteToTextFile( finalPath, out string errMessage ))
+                    {
+                        Console.Error.WriteLine($"ERROR saving output file '{finalPath}': {errMessage}");
+                    }
+                }
 #endif
                 break;
 

--- a/src/Samples/Kaleidoscope/Chapter6/ReplEngine.cs
+++ b/src/Samples/Kaleidoscope/Chapter6/ReplEngine.cs
@@ -12,7 +12,7 @@ using Ubiquity.NET.Runtime.Utils;
 namespace Kaleidoscope.Chapter6
 {
     internal class ReplEngine
-        : KaleidoscopeReadEvaluatePrintLoopBase<Value>
+        : ReadEvaluatePrintLoopBase<Value>
     {
         public ReplEngine( )
             : base( LanguageLevel.UserDefinedOperators )
@@ -41,8 +41,15 @@ namespace Kaleidoscope.Chapter6
 
             case Function function:
 #if SAVE_LLVM_IR
-                string safeFileName = Utilities.GetSafeFileName( function.Name );
-                _ = function.ParentModule.WriteToTextFile( System.IO.Path.ChangeExtension( safeFileName, "ll" ), out string _ );
+                if(function.Name is not null)
+                {
+                    string safeFileName = Utilities.GetSafeFileName( function.Name );
+                    string finalPath = System.IO.Path.ChangeExtension( safeFileName, "ll" );
+                    if(!function.ParentModule.WriteToTextFile( finalPath, out string errMessage ))
+                    {
+                        Console.Error.WriteLine($"ERROR saving output file '{finalPath}': {errMessage}");
+                    }
+                }
 #endif
                 break;
 

--- a/src/Samples/Kaleidoscope/Chapter7.1/ReplEngine.cs
+++ b/src/Samples/Kaleidoscope/Chapter7.1/ReplEngine.cs
@@ -12,7 +12,7 @@ using Ubiquity.NET.Runtime.Utils;
 namespace Kaleidoscope.Chapter71
 {
     internal class ReplEngine
-        : KaleidoscopeReadEvaluatePrintLoopBase<Value>
+        : ReadEvaluatePrintLoopBase<Value>
     {
         public ReplEngine( )
             : base( LanguageLevel.MutableVariables )
@@ -41,8 +41,15 @@ namespace Kaleidoscope.Chapter71
 
             case Function function:
 #if SAVE_LLVM_IR
-                string safeFileName = Utilities.GetSafeFileName( function.Name );
-                _ = function.ParentModule.WriteToTextFile( System.IO.Path.ChangeExtension( safeFileName, "ll" ), out string _ );
+                if(function.Name is not null)
+                {
+                    string safeFileName = Utilities.GetSafeFileName( function.Name );
+                    string finalPath = System.IO.Path.ChangeExtension( safeFileName, "ll" );
+                    if(!function.ParentModule.WriteToTextFile( finalPath, out string errMessage ))
+                    {
+                        Console.Error.WriteLine($"ERROR saving output file '{finalPath}': {errMessage}");
+                    }
+                }
 #endif
                 break;
 

--- a/src/Samples/Kaleidoscope/Chapter7/ReplEngine.cs
+++ b/src/Samples/Kaleidoscope/Chapter7/ReplEngine.cs
@@ -12,7 +12,7 @@ using Ubiquity.NET.Runtime.Utils;
 namespace Kaleidoscope.Chapter7
 {
     internal class ReplEngine
-        : KaleidoscopeReadEvaluatePrintLoopBase<Value>
+        : ReadEvaluatePrintLoopBase<Value>
     {
         public ReplEngine( )
             : base( LanguageLevel.MutableVariables )
@@ -41,8 +41,15 @@ namespace Kaleidoscope.Chapter7
 
             case Function function:
 #if SAVE_LLVM_IR
-                string safeFileName = Utilities.GetSafeFileName( function.Name );
-                _ = function.ParentModule.WriteToTextFile( System.IO.Path.ChangeExtension( safeFileName, "ll" ), out string _ );
+                if(function.Name is not null)
+                {
+                    string safeFileName = Utilities.GetSafeFileName( function.Name );
+                    string finalPath = System.IO.Path.ChangeExtension( safeFileName, "ll" );
+                    if(!function.ParentModule.WriteToTextFile( finalPath, out string errMessage ))
+                    {
+                        Console.Error.WriteLine($"ERROR saving output file '{finalPath}': {errMessage}");
+                    }
+                }
 #endif
                 break;
 

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Runtime/ReadEvaluatePrintLoopBase.cs
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Runtime/ReadEvaluatePrintLoopBase.cs
@@ -15,8 +15,8 @@ namespace Kaleidoscope.Runtime
 {
     /// <summary>REPL Loop implementation for the Kaleidoscope language</summary>
     /// <typeparam name="T">Type of values produced by the evaluation stage</typeparam>
-    public abstract class KaleidoscopeReadEvaluatePrintLoopBase<T>
-        : REPLBase<T>
+    public abstract class ReadEvaluatePrintLoopBase<T>
+        : Ubiquity.NET.Runtime.Utils.REPLBase<T>
     {
         /// <summary>Gets the Kaleidoscope language level for this instance</summary>
         public LanguageLevel LanguageFeatureLevel { get; }
@@ -64,23 +64,23 @@ namespace Kaleidoscope.Runtime
             await Run( input, parser, generator, cancelToken );
         }
 
-        /// <summary>Initializes a new instance of the <see cref="KaleidoscopeReadEvaluatePrintLoopBase{T}"/> class.</summary>
+        /// <summary>Initializes a new instance of the <see cref="ReadEvaluatePrintLoopBase{T}"/> class.</summary>
         /// <param name="level">Language level supported by this REPL instance</param>
         /// <remarks>
         /// This is protected to prevent use by anything other than a derived type.
         /// </remarks>
-        protected KaleidoscopeReadEvaluatePrintLoopBase( LanguageLevel level )
+        protected ReadEvaluatePrintLoopBase( LanguageLevel level )
             : this(level, new ParseErrorDiagnosticAdapter(new ColoredConsoleReporter(), "KLS"))
         {
         }
 
-        /// <summary>Initializes a new instance of the <see cref="KaleidoscopeReadEvaluatePrintLoopBase{T}"/> class.</summary>
+        /// <summary>Initializes a new instance of the <see cref="ReadEvaluatePrintLoopBase{T}"/> class.</summary>
         /// <param name="level">Language level supported by this REPL instance</param>
         /// <param name="logger">Logger to report any issues parsing the input.</param>
         /// <remarks>
         /// This is protected to prevent use by anything other than a derived type.
         /// </remarks>
-        protected KaleidoscopeReadEvaluatePrintLoopBase( LanguageLevel level, IParseErrorReporter logger )
+        protected ReadEvaluatePrintLoopBase( LanguageLevel level, IParseErrorReporter logger )
             : base( logger )
         {
             LanguageFeatureLevel = level;


### PR DESCRIPTION
Renamed `KaleidoscopeReadEvaluatePrintLoopBase` -> `ReadEvaluatePrintLoopBase`
* No point in duplicating the language name as it is already part of the FQN via the namesace