### PR TITLE
Implemented support for mixed line ending normalization

### DIFF
--- a/src/Ubiquity.NET.Extensions.UT/AssemblyInfo.cs
+++ b/src/Ubiquity.NET.Extensions.UT/AssemblyInfo.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+// In SDK-style projects such as this one, several assembly attributes that were historically
+// defined in this file are now automatically added during build and populated with
+// values defined in project properties. For details of which attributes are included
+// and how to customise this process see: https://aka.ms/assembly-info-properties
+
+// Setting ComVisible to false makes the types in this assembly not visible to COM
+// components. If you need to access a type in this assembly from COM, set the ComVisible
+// attribute to true on that type.
+
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM.
+
+[assembly: Guid("312c3354-ea8c-4819-8823-ac78064c645c")]
+
+// Tests are so trivial they perform better when not individually parallelized.
+// Unfortunately this is an assembly wide choice and not class or method level
+// see: https://github.com/microsoft/testfx/issues/5555#issuecomment-3448956323
+[assembly: Parallelize( Scope = ExecutionScope.ClassLevel )]
+
+// NOTE: use of this and `internal` test classes results in a flurry of
+// error CA1812: '<class name>' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it 'static' (Module in Visual Basic). (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1812)
+// In other words, not worth the bother...
+// [assembly: DiscoverInternals]

--- a/src/Ubiquity.NET.Extensions.UT/DictionaryBuilderTests.cs
+++ b/src/Ubiquity.NET.Extensions.UT/DictionaryBuilderTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+using System;
+using System.Collections.Immutable;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ubiquity.NET.Extensions.UT
+{
+    [TestClass]
+    public sealed class DictionaryBuilderTests
+    {
+        [TestMethod]
+        public void Inintialization_of_KvpArray_is_successfull( )
+        {
+            ImmutableDictionary<string, int> testDictionary = new DictionaryBuilder<string, int>()
+            {
+                ["one"] = 1,
+                ["two"] = 2,
+            }.ToImmutable();
+
+            Assert.AreEqual( 1, testDictionary[ "one" ] );
+            Assert.AreEqual( 2, testDictionary[ "two" ] );
+        }
+
+        [TestMethod]
+        public void Getting_enumerator_from_KvpArrayBuilder_throws( )
+        {
+            var testBuilder = new DictionaryBuilder<string, int>()
+            {
+                ["one"] = 1,
+                ["two"] = 2,
+            };
+
+            Assert.ThrowsExactly<NotImplementedException>( ( ) =>
+            {
+#pragma warning disable IDISP004 // Don't ignore created IDisposable
+                // NOT disposable, no idea where the analyzer gets this from but System.Collections.IEnumerator
+                // does not implement IDisposable. [Methods is supposed to throw anyway]
+                _ = testBuilder.GetEnumerator();
+#pragma warning restore IDISP004 // Don't ignore created IDisposable
+            }
+            , "Syntactic sugar only for initialization" );
+        }
+    }
+}

--- a/src/Ubiquity.NET.Extensions.UT/DisposableActionTests.cs
+++ b/src/Ubiquity.NET.Extensions.UT/DisposableActionTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ubiquity.NET.Extensions.UT
+{
+    [TestClass]
+    public sealed class DisposableActionTests
+    {
+        [TestMethod]
+        public void DisposableAction_CreateNOP_succeeds( )
+        {
+            using var disp = DisposableAction.CreateNOP();
+            Assert.IsNotNull(disp);
+        }
+
+        [TestMethod]
+        public void DisposableAction_with_null_Action_throws( )
+        {
+            var ex = Assert.ThrowsExactly<ArgumentNullException>(static ()=>
+            {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+                // Testing explicit case of null param.
+                using var x = new DisposableAction(null);
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+            } );
+            Assert.IsNotNull( ex );
+            Assert.AreEqual("null", ex.ParamName);
+        }
+
+        [TestMethod]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage( "IDisposableAnalyzers.Correctness", "IDISP017:Prefer using", Justification = "Explicit testing" )]
+        public void DisposableAction_called_correctly()
+        {
+            bool actionCalled = false;
+
+            var raiiAction = new DisposableAction( ()=> actionCalled = true );
+            raiiAction.Dispose(); // Should trigger call to action
+
+            Assert.IsTrue(actionCalled);
+        }
+    }
+}

--- a/src/Ubiquity.NET.Extensions.UT/FluentValidationExtensionsTests.UT.cs
+++ b/src/Ubiquity.NET.Extensions.UT/FluentValidationExtensionsTests.UT.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+using System;
+using System.ComponentModel;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ubiquity.NET.Extensions.UT
+{
+    [TestClass]
+    public sealed class FluentValidationExtensionsTests
+    {
+        [TestMethod]
+        public void ThrowIfNull_throws_expected_exception_when_null( )
+        {
+            var ex = Assert.ThrowsExactly<ArgumentNullException>(()=>
+            {
+                FluentValidationExtensions.ThrowIfNull<string>( null );
+            } );
+            Assert.AreEqual("null", ex.ParamName, "parameter name should match input expression");
+        }
+
+        [TestMethod]
+        public void ThrowIfNull_does_not_throw_on_non_null_input()
+        {
+            const string input = "This is a test";
+
+            Assert.AreSame(input, FluentValidationExtensions.ThrowIfNull(input), "Fluent API should return input value on success" );
+        }
+
+        [TestMethod]
+        public void ThrowIfNull_reports_exception_whith_provided_expression( )
+        {
+            const string exp = "My-Expression";
+            var ex = Assert.ThrowsExactly<ArgumentNullException>(()=>
+            {
+                FluentValidationExtensions.ThrowIfNull<string>( null, exp );
+            } );
+            Assert.AreEqual( exp, ex.ParamName, "parameter name should match input expression" );
+        }
+
+        [TestMethod]
+        public void ThrowIfNotDefined_does_not_throw_for_defined_value()
+        {
+            Assert.AreEqual(TestEnum.Max, FluentValidationExtensions.ThrowIfNotDefined(TestEnum.Max), "Fluent API should return input value on success" );
+        }
+
+        [TestMethod]
+        public void ThrowIfOutOfRange_does_not_throw_for_inrange_values( )
+        {
+            double value = 1.0;
+            double min = 0.0;
+            double max = 2.0;
+
+            Assert.AreEqual(value, FluentValidationExtensions.ThrowIfOutOfRange(value, min, max), "Fluent API should return input value on success");
+        }
+
+        [TestMethod]
+        public void ThrowIfOutOfRange_throws_for_out_of_range_values( )
+        {
+            double value = 2.0;
+            double min = 1.0;
+            double max = 1.5;
+
+            var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(()=>
+            {
+                _ = FluentValidationExtensions.ThrowIfOutOfRange( value, min, max );
+            } );
+            Assert.AreEqual(value, ex.ActualValue);
+            Assert.AreEqual(nameof(value), ex.ParamName);
+        }
+
+        [TestMethod]
+        public void ThrowIfOutOfRange_throws_with_custom_expression_for_out_of_range_values( )
+        {
+            double value = 2.0;
+            double min = 1.0;
+            double max = 1.5;
+
+            const string exp = "My Expression";
+            var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(()=>
+            {
+                _ = FluentValidationExtensions.ThrowIfOutOfRange( value, min, max, exp );
+            } );
+            Assert.AreEqual( value, ex.ActualValue );
+            Assert.AreEqual( exp, ex.ParamName );
+        }
+
+        [TestMethod]
+        public void ThrowIfNotDefined_throws_for_undefined_values( )
+        {
+            var temp = (TestEnum)4;
+            var ex = Assert.ThrowsExactly<InvalidEnumArgumentException>( ( ) =>
+            {
+                FluentValidationExtensions.ThrowIfNotDefined(temp);
+            } );
+            Assert.AreEqual(nameof(temp), ex.ParamName, "parameter name should match input expression" );
+
+            var temp2 = (TestByteEnum)4;
+            var ex2 = Assert.ThrowsExactly<InvalidEnumArgumentException>( ( ) =>
+            {
+                FluentValidationExtensions.ThrowIfNotDefined(temp2);
+            } );
+            Assert.AreEqual( nameof( temp2 ), ex2.ParamName, "parameter name should match input expression" );
+
+            // This still fits an int so the normal constructor that sets paramName is available
+            var temp3 = (TestU64Enum)int.MaxValue;
+            var ex3 = Assert.ThrowsExactly<InvalidEnumArgumentException>( ( ) =>
+            {
+                FluentValidationExtensions.ThrowIfNotDefined(temp3);
+            } );
+            Assert.AreEqual( nameof( temp3 ), ex3.ParamName, "parameter name should match input expression" );
+
+            // This can't fit into an int so, the exception constructor that does not provide paramName is
+            // the only option :( [But at least this scenario is VERY rare in the real world]
+            var temp4 = (TestU64Enum)(UInt64.MaxValue - 1);
+            var ex4 = Assert.ThrowsExactly<InvalidEnumArgumentException>( ( ) =>
+            {
+                FluentValidationExtensions.ThrowIfNotDefined(temp4);
+            } );
+            Assert.IsNull( ex4.ParamName, "parameter name not available for non-int formattable enums" );
+        }
+
+        private enum TestEnum // default underling type is Int32
+        {
+            Zero,
+            One,
+            Two,
+            Max = int.MaxValue
+        }
+
+        private enum TestByteEnum
+            : byte
+        {
+            Zero,
+            One,
+            Two,
+            Max = byte.MaxValue
+        }
+
+        private enum TestU64Enum
+            : UInt64
+        {
+            Zero,
+            One,
+            Two,
+            Max = UInt64.MaxValue
+        }
+    }
+}

--- a/src/Ubiquity.NET.Extensions.UT/GlobalSuppressions.cs
+++ b/src/Ubiquity.NET.Extensions.UT/GlobalSuppressions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Test module" )]

--- a/src/Ubiquity.NET.Extensions.UT/KvpArrayBuilderTests.cs
+++ b/src/Ubiquity.NET.Extensions.UT/KvpArrayBuilderTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ubiquity.NET.Extensions.UT
+{
+    [TestClass]
+    public sealed class KvpArrayBuilderTests
+    {
+        [TestMethod]
+        public void Inintialization_of_KvpArray_is_successfull( )
+        {
+            ImmutableArray<KeyValuePair<string, int>> testArray = new KvpArrayBuilder<string, int>()
+            {
+                ["one"] = 1,
+                ["two"] = 2,
+            }.ToImmutable();
+
+            Assert.AreEqual( "one", testArray[ 0 ].Key);
+            Assert.AreEqual( 1, testArray[ 0 ].Value );
+
+            Assert.AreEqual( "two", testArray[ 1 ].Key );
+            Assert.AreEqual( 2, testArray[ 1 ].Value );
+        }
+
+        [TestMethod]
+        public void Getting_enumerator_from_KvpArrayBuilder_throws( )
+        {
+            var testBuilder = new KvpArrayBuilder<string, int>()
+            {
+                ["one"] = 1,
+                ["two"] = 2,
+            };
+
+            Assert.ThrowsExactly<NotImplementedException>(()=>
+            {
+#pragma warning disable IDISP004 // Don't ignore created IDisposable
+                // NOT disposable, no idea where the analyzer gets this from but System.Collections.IEnumerator
+                // does not implement IDisposable. [Methods is supposed to throw anyway]
+                _ = testBuilder.GetEnumerator();
+#pragma warning restore IDISP004 // Don't ignore created IDisposable
+            }
+            , "Syntactic sugar only for initialization");
+        }
+    }
+}

--- a/src/Ubiquity.NET.Extensions.UT/StringNormalizerTests.cs
+++ b/src/Ubiquity.NET.Extensions.UT/StringNormalizerTests.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ubiquity.NET.Extensions.UT
+{
+    // NOTE: Test output will include special characters for CR and LF characters that makes it easy to visualize
+    // Example:
+    //     Assert.AreEqual failed. Expected string length 51 but was 52. 'expected' expression: 'expectedOutput', 'actual' expression: 'systemNormalizedInput'.
+    // Expected: "This is a line␊This is anotherline␊And..."
+    // But was:  "This is a line␍␊This is anotherline␍An..."
+    // -------------------------^
+
+    // NOTE: In C# the string "line1\nLine2" has exactly what was put in the string
+    //       That is, it contains a SINGLE LF '\n' character. NOT an environment
+    //       specific "newline". Thus, if a string needs to represent an platform specific
+    //       newline sequence it can use `Environment.NewLine` or `string.ReplaceLineEndings()`.
+    //       The docs on `ReplaceLineEndings()` are silent on the point of input forms
+    //       replaced. However, seplunking the code indicates it follows Unicode standard §5.8,
+    //       Recommendation R4 and Table 5-2 (CR, LF, CRLF, NEL, LS, FF, PS). Explicitly excluded
+    //       is VT. Thus, that will normalize ANY newline sequence to the form expected by the
+    //       environment.
+
+    [TestClass]
+    public sealed class StringNormalizerTests
+    {
+        [TestMethod]
+        public void System_line_ending_detected_correctly( )
+        {
+            Assert.AreEqual( OsDefaultLineEnding, StringNormalizer.SystemLineEndings);
+        }
+
+        [TestMethod]
+        public void Normalize_with_default_endings_does_nothing( )
+        {
+            string testInput = "This is a line\nAnd so is this".ReplaceLineEndings(); // Platform sepecific
+            string normalizedOutput = testInput.NormalizeLineEndings(StringNormalizer.SystemLineEndings);
+            Assert.AreSame(testInput, normalizedOutput, "Should return same instance (zero copy)");
+        }
+
+        [TestMethod]
+        public void Normalize_with_alternate_endings_produces_new_string( )
+        {
+            string testInput = "This is a line\nAnd so is this".ReplaceLineEndings(); // Platform sepecific
+            const string expectedOutput = "This is a line\rAnd so is this";
+
+            // CR Only is not the default for any currently supported runtinme for .NET so this
+            // remains a platform neutral test - verify that assumption!
+            // See also: System_line_ending_detected_correctly()
+            Assert.AreNotEqual(LineEndingKind.CarriageReturn, StringNormalizer.SystemLineEndings, "TEST ERROR: CR is default line ending for this runtime!");
+
+            string normalizedOutput = testInput.NormalizeLineEndings(LineEndingKind.CarriageReturn);
+            Assert.AreEqual(expectedOutput, normalizedOutput);
+        }
+
+        [TestMethod]
+        public void Normalize_with_mixed_input_succeeds()
+        {
+            const string mixedInput = "This is a line\r\nThis is anotherline\rAnd aonther line";
+            string expectedOutput = "This is a line\nThis is anotherline\nAnd aonther line".ReplaceLineEndings(); // Platform sepecific
+            string systemNormalizedInput = mixedInput.NormalizeLineEndings(LineEndingKind.MixedOrUnknownEndings, StringNormalizer.SystemLineEndings);
+            Assert.AreEqual(expectedOutput, systemNormalizedInput);
+        }
+
+        // Technincally Mac OS prior to OS X (Lion) use CR, but .NET does not
+        // support those older versions. Thus, this only treats Windows as the
+        // "odd man out", everything else uses LF.
+        private static LineEndingKind OsDefaultLineEnding
+            => OperatingSystem.IsWindows()
+                ? LineEndingKind.CarriageReturnLineFeed
+                : LineEndingKind.LineFeed;
+    }
+}

--- a/src/Ubiquity.NET.Extensions.UT/Ubiquity.NET.Extensions.UT.csproj
+++ b/src/Ubiquity.NET.Extensions.UT/Ubiquity.NET.Extensions.UT.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+      <TargetFramework>net8.0</TargetFramework>
+      <IsPackable>false</IsPackable>
+      <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" />
+      <PackageReference Include="MSTest.TestFramework" />
+      <PackageReference Include="MSTest.TestAdapter" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ubiquity.NET.Extensions\Ubiquity.NET.Extensions.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Ubiquity.NET.Extensions/DisposableAction.cs
+++ b/src/Ubiquity.NET.Extensions/DisposableAction.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Ubiquity.NET.Extensions
@@ -16,13 +17,15 @@ namespace Ubiquity.NET.Extensions
         : IDisposable
     {
         /// <summary>Initializes a new instance of the <see cref="DisposableAction"/> class.</summary>
-        /// <param name="onDispose">Action to run when <see cref="Dispose"/>is called.</param>
-        public DisposableAction( Action onDispose )
+        /// <param name="onDispose">Action to run when <see cref="Dispose"/> is called.</param>
+        /// <param name="exp">Expression for any exceptions; default normally provided by compiler as expression for <paramref name="onDispose"/></param>
+        public DisposableAction( Action onDispose, [CallerArgumentExpression(nameof(onDispose))] string? exp = null )
         {
-            OnDispose = onDispose ?? throw new ArgumentNullException( nameof( onDispose ) );
+            OnDispose = onDispose ?? throw new ArgumentNullException( exp );
         }
 
-        /// <summary>Runs the action provided in the constructor (<see cref="DisposableAction(System.Action)"/>)</summary>
+        /// <summary>Runs the action provided in the constructor (<see cref="DisposableAction(Action, string?)"/>)</summary>
+        /// <exception cref="ObjectDisposedException">This instance is already disposed</exception>
         public void Dispose( )
         {
             var disposeOp = Interlocked.Exchange(ref OnDispose, null);
@@ -30,7 +33,7 @@ namespace Ubiquity.NET.Extensions
             disposeOp!();
         }
 
-        /// <summary>Creates the an implementation of <see cref="IDisposable"/> that does nothing for the "Null Object" pattern</summary>
+        /// <summary>Creates an implementation of <see cref="IDisposable"/> that does nothing for the "Null Object" pattern</summary>
         /// <returns>The <see cref="IDisposable"/> that does nothing on <see cref="IDisposable.Dispose"/></returns>
         /// <remarks>
         /// The instance returned is allocated from the managed heap to ensure that <see cref="IDisposable.Dispose"/> is

--- a/src/Ubiquity.NET.Extensions/KvpArrayBuilder.cs
+++ b/src/Ubiquity.NET.Extensions/KvpArrayBuilder.cs
@@ -69,6 +69,7 @@ namespace Ubiquity.NET.Extensions
 
         /// <inheritdoc/>
         /// <exception cref="NotImplementedException">Always; Do not use this method. It exists only to allow compile time initializer syntax.</exception>
+        [DoesNotReturn]
         public IEnumerator GetEnumerator( )
         {
             // Only implementing IEnumerable because collection initializer

--- a/src/Ubiquity.NET.Llvm.slnx
+++ b/src/Ubiquity.NET.Llvm.slnx
@@ -74,6 +74,7 @@
     <Project Path="Interop/InteropTests/Ubiquity.NET.Llvm.Interop.UT.csproj" />
     <Project Path="Samples/Kaleidoscope/Kaleidoscope.Tests/Kaleidoscope.Tests.csproj" />
     <Project Path="Ubiquity.NET.CommandLine.UT/Ubiquity.NET.CommandLine.UT.csproj" />
+    <Project Path="Ubiquity.NET.Extensions.UT/Ubiquity.NET.Extensions.UT.csproj" Id="8c25ceeb-c564-4983-9f8b-abc749d5db6c" />
     <Project Path="Ubiquity.NET.InteropHelpers.UT/Ubiquity.NET.InteropHelpers.UT.csproj" />
     <Project Path="Ubiquity.NET.Llvm.JIT.Tests/Ubiquity.NET.Llvm.JIT.Tests.csproj" />
     <Project Path="Ubiquity.NET.Llvm.Tests/Ubiquity.NET.Llvm.UT.csproj" />


### PR DESCRIPTION
Implemented #312
* Added support for conversion of mixed line endings
    - This is now the default behavior, explicit conversion is still possible by specifying the source kind directly.
    - This is ONLY allowed on the source of normalization as it is not sensible for a destination.
* Added tests for `Ubiquity.NET.Extensions` to verify new behavior and test existing behavior.