### PR TITLE
Added overloads to `IDiagnosticReporter` that accept a simple message string without any formatting etc...

### DIFF
--- a/src/Ubiquity.NET.CommandLine/DiagnosticReporterExtensions.cs
+++ b/src/Ubiquity.NET.CommandLine/DiagnosticReporterExtensions.cs
@@ -365,6 +365,18 @@ namespace Ubiquity.NET.CommandLine
         {
             Error(self, code: null, location, origin: null, subCategory: null, handler);
         }
+
+        // doc comments don't inherit param correctly, see: https://github.com/dotnet/roslyn/issues/67326#issuecomment-3452843800
+
+        /// <inheritdoc cref="Error(IDiagnosticReporter, string?, SourceRange, Uri?, string?, ErrorReportingInterpolatedStringHandler)" path="/summary"/>
+        /// <param name="self">Reporter to report message to</param>
+        /// <param name="msg">Message to report</param>
+        /// <param name="location">Location in the origin that this message refers to</param>
+        /// <inheritdoc cref="Error(IDiagnosticReporter, string?, SourceRange, Uri?, string?, ErrorReportingInterpolatedStringHandler)" path="/remarks"/>
+        public static void Error(this IDiagnosticReporter self, string msg, SourceRange location = default)
+        {
+            Error(self, code: null, location, origin: null, subCategory: null, formatProvider: null, msg /*, args...*/);
+        }
         #endregion
 
         #region MsgLevel.Warning
@@ -469,6 +481,18 @@ namespace Ubiquity.NET.CommandLine
             )
         {
             Warning(self, code: null, location, origin: null, subCategory: null, handler);
+        }
+
+        // doc comments don't inherit param correctly, see: https://github.com/dotnet/roslyn/issues/67326#issuecomment-3452843800
+
+        /// <inheritdoc cref="Warning(IDiagnosticReporter, string?, SourceRange, Uri?, string?, WarningReportingInterpolatedStringHandler)" path="/summary"/>
+        /// <param name="self">Reporter to report message to</param>
+        /// <param name="msg">Message to report</param>
+        /// <param name="location">Location in the origin that this message refers to</param>
+        /// <inheritdoc cref="Warning(IDiagnosticReporter, string?, SourceRange, Uri?, string?, WarningReportingInterpolatedStringHandler)" path="/remarks"/>
+        public static void Warning( this IDiagnosticReporter self, string msg, SourceRange location = default )
+        {
+            Warning( self, code: null, location, origin: null, subCategory: null, formatProvider: null, msg /*, args...*/);
         }
         #endregion
 
@@ -575,6 +599,19 @@ namespace Ubiquity.NET.CommandLine
         {
             Information(self, code: null, location, origin: null, subCategory: null, handler);
         }
+
+        // doc comments don't inherit param correctly, see: https://github.com/dotnet/roslyn/issues/67326#issuecomment-3452843800
+
+        /// <inheritdoc cref="Information(IDiagnosticReporter, string?, SourceRange, Uri?, string?, InformationReportingInterpolatedStringHandler)" path="/summary"/>
+        /// <param name="self">Reporter to report message to</param>
+        /// <param name="msg">Message to report</param>
+        /// <param name="location">Location in the origin that this message refers to</param>
+        /// <inheritdoc cref="Information(IDiagnosticReporter, string?, SourceRange, Uri?, string?, InformationReportingInterpolatedStringHandler)" path="/remarks"/>
+        public static void Information( this IDiagnosticReporter self, string msg, SourceRange location = default )
+        {
+            Information( self, code: null, location, origin: null, subCategory: null, formatProvider: null, msg /*, args...*/);
+        }
+
         #endregion
 
         #region MsgLevel.Verbose
@@ -679,6 +716,18 @@ namespace Ubiquity.NET.CommandLine
             )
         {
             Verbose(self, code: null, location, origin: null, subCategory: null, handler);
+        }
+
+        // doc comments don't inherit param correctly, see: https://github.com/dotnet/roslyn/issues/67326#issuecomment-3452843800
+
+        /// <inheritdoc cref="Verbose(IDiagnosticReporter, string?, SourceRange, Uri?, string?, VerboseReportingInterpolatedStringHandler)" path="/summary"/>
+        /// <param name="self">Reporter to report message to</param>
+        /// <param name="msg">Message to report</param>
+        /// <param name="location">Location in the origin that this message refers to</param>
+        /// <inheritdoc cref="Verbose(IDiagnosticReporter, string?, SourceRange, Uri?, string?, VerboseReportingInterpolatedStringHandler)" path="/remarks"/>
+        public static void Verbose( this IDiagnosticReporter self, string msg, SourceRange location = default )
+        {
+            Verbose( self, code: null, location, origin: null, subCategory: null, formatProvider: null, msg /*, args...*/);
         }
         #endregion
     }

--- a/src/Ubiquity.NET.SrcGeneration/CSharp/CSharpLanguage.cs
+++ b/src/Ubiquity.NET.SrcGeneration/CSharp/CSharpLanguage.cs
@@ -100,7 +100,7 @@ namespace Ubiquity.NET.SrcGeneration.CSharp
         /// <summary>Makes an identifier (Escaping a language keyword)</summary>
         /// <param name="self">identifier string to convert</param>
         /// <returns>Syntactically valid identifier</returns>
-        public static string MakeIdentifier( string self )
+        public static string MakeIdentifier( this string self )
         {
             ArgumentNullException.ThrowIfNull( self );
 

--- a/src/Ubiquity.NET.SrcGeneration/CSharp/TextWriterCsExtension.cs
+++ b/src/Ubiquity.NET.SrcGeneration/CSharp/TextWriterCsExtension.cs
@@ -44,7 +44,7 @@ namespace Ubiquity.NET.SrcGeneration.CSharp
         /// <summary>Writes an XML Doc comment summary</summary>
         /// <param name="self">The writer to write to</param>
         /// <param name="description">Text to include in the summary (Nothing is written if this is <see langword="null"/> </param>
-        public static void WriteSummary(this TextWriter self, string? description )
+        public static void WriteSummaryComment(this TextWriter self, string? description )
         {
             ArgumentNullException.ThrowIfNull( self );
 
@@ -92,7 +92,7 @@ namespace Ubiquity.NET.SrcGeneration.CSharp
         /// is used as the summary. If <paramref name="defaultSummary"/> is also empty or all Whitespace then nothing
         /// is output.
         /// </remarks>
-        public static void WriteSummaryAndRemarks( this TextWriter self, string? txt, string defaultSummary = "" )
+        public static void WriteSummaryAndRemarksComments( this TextWriter self, string? txt, string defaultSummary = "" )
         {
             ArgumentNullException.ThrowIfNull( self );
 


### PR DESCRIPTION
Added overloads to `IDiagnosticReporter` that accept a simple message string without any formatting etc...
* Implements #311
* Additional refactoring from real-world consumer
    - `Ubiquity.NET.SrcGeneration.CSharp.MakeIdentifier()` is now a proper extension method.
        - This got lost in shift away from use of `extension` keyword.
* Unified and clarified use of functions that write comments by including `Comment[s]` in the name.