### PR TITLE
Added support to indicate if function redifitinion is supported.

### DIFF
--- a/src/Samples/Kaleidoscope/Chapter7.1/ReplEngine.cs
+++ b/src/Samples/Kaleidoscope/Chapter7.1/ReplEngine.cs
@@ -14,8 +14,9 @@ namespace Kaleidoscope.Chapter71
     internal class ReplEngine
         : ReadEvaluatePrintLoopBase<Value>
     {
+        // This uses Lazy JIT evaluation so redefinition is not supported.
         public ReplEngine( )
-            : base( LanguageLevel.MutableVariables )
+            : base( LanguageLevel.MutableVariables, functionRedfinitionIsAnError: true )
         {
         }
 

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/AST/AstBuilder.cs
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/AST/AstBuilder.cs
@@ -133,15 +133,27 @@ namespace Kaleidoscope.Grammar.AST
                                                );
 
             // only add valid definitions to the runtime state.
-            if(errors.Length == 0)
-            {
-                RuntimeState.FunctionDefinitions.AddOrReplaceItem( retVal );
-            }
-            else
+            if(errors.Length > 0)
             {
                 // remove the prototype implicitly added for this definition
                 // as the definition has errors
                 RuntimeState.FunctionDeclarations.Remove( sig );
+            }
+            else
+            {
+                if(RuntimeState.SupportsRedefinition)
+                {
+                    RuntimeState.FunctionDefinitions.AddOrReplaceItem( retVal );
+                }
+                else
+                {
+                    if(RuntimeState.FunctionDefinitions.Contains(retVal.Name))
+                    {
+                        return new ErrorNode(retVal.Location, (int)DiagnosticCode.RedclarationNotSupported, "Duplicate function name, redefinitions not allowed." );
+                    }
+
+                    RuntimeState.FunctionDefinitions.Add( retVal );
+                }
             }
 
             return retVal;

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/AST/DiagnosticCode.cs
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/AST/DiagnosticCode.cs
@@ -42,5 +42,8 @@ namespace Kaleidoscope.Grammar.AST
 
         /// <summary>Parse was cancelled</summary>
         ParseCanceled = 2000,
+
+        /// <summary>Re-declaration is not supported in the runtime</summary>
+        RedclarationNotSupported,
     }
 }

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/DynamicRuntimeState.cs
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/DynamicRuntimeState.cs
@@ -34,15 +34,39 @@ namespace Kaleidoscope.Grammar
     /// </remarks>
     public class DynamicRuntimeState
     {
-        /// <summary>Initializes a new instance of the <see cref="DynamicRuntimeState"/> class.</summary>
-        /// <param name="languageLevel">Language level supported for this instance</param>
+        /// <remarks>This overload supports function re-definition for the normal case</remarks>
+        /// <inheritdoc cref="DynamicRuntimeState.DynamicRuntimeState(LanguageLevel, bool)"/>
         public DynamicRuntimeState( LanguageLevel languageLevel )
+            : this(languageLevel, functionRedefinitionIsAnError: false)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="DynamicRuntimeState"/> class.</summary>
+        /// <param name="functionRedefinitionIsAnError">Flag to indicate if function definitions are an error</param>
+        /// <param name="languageLevel">Language level supported for this instance</param>
+        /// <remarks>
+        /// <see cref="SupportsRedefinition"/> is used to indicate if this language implementation supports
+        /// redefinition of functions. This is ordinarily allowed for interactive languages but if an extreme
+        /// lazy JIT is used, the asynchronous nature of materialization makes it a very difficult (maybe
+        /// impossible) task to accomplish. So Such runtimes will generally not support re-definition.
+        /// </remarks>
+        public DynamicRuntimeState( LanguageLevel languageLevel, bool functionRedefinitionIsAnError = false )
         {
             LanguageLevel = languageLevel;
+            SupportsRedefinition = !functionRedefinitionIsAnError;
         }
 
         /// <summary>Gets or sets the Language level the application supports</summary>
         public LanguageLevel LanguageLevel { get; set; }
+
+        /// <summary>Gets a value indicating whether this runtime supports redefinition of functions</summary>
+        /// <remarks>
+        /// Extreme Lazy JIT realization does not support redifinition at this point. It's s complicated problem
+        /// that is not entirely clear how to solve using the LLVM-C API. Thus, it is currently not supported. This
+        /// is generally not an issue as such lazy JIT execution is ordinarily not used for an interactive runtime
+        /// where function re-definition is used.
+        /// </remarks>
+        public bool SupportsRedefinition { get; init; }
 
         /// <summary>Gets a collection of function definitions parsed but not yet generated</summary>
         /// <remarks>

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/Parser.cs
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/Parser.cs
@@ -30,7 +30,16 @@ namespace Kaleidoscope.Grammar
         /// <param name="level"><see cref="LanguageLevel"/> for the parser</param>
         /// <param name="visualizer">Visualizer to use for the parse (Includes possible error nodes)</param>
         public Parser( LanguageLevel level, IVisualizer? visualizer = null )
-            : this( new DynamicRuntimeState( level ), visualizer )
+            : this( new DynamicRuntimeState( level, functionRedefinitionIsAnError: false ), visualizer )
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="Parser"/> class.</summary>
+        /// <param name="level"><see cref="LanguageLevel"/> for the parser</param>
+        /// <param name="functionRedefinitionIsAnError">flag to indicate if redefinition of a function is an error</param>
+        /// <param name="visualizer">Visualizer to use for the parse (Includes possible error nodes)</param>
+        public Parser( LanguageLevel level, bool functionRedefinitionIsAnError, IVisualizer? visualizer = null )
+            : this( new DynamicRuntimeState( level, functionRedefinitionIsAnError ), visualizer )
         {
         }
 

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Tests/Kaleidoscope.Tests.csproj
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Tests/Kaleidoscope.Tests.csproj
@@ -34,6 +34,9 @@
         <None Update="mandel.kls">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Update="Redefinition.kls">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
         <None Update="SimpleExpressions.kls">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Tests/Redefinition.kls
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Tests/Redefinition.kls
@@ -1,0 +1,9 @@
+# This is intended as a test case to identify issues with redefinition of
+# symbols in a LazyJIT scenario. (Either it works or is at least flagged
+# as an error before triggering an error deep in LLVM.
+
+def foo(a b) a*a + 2*a*b + b*b;
+
+# Ideally, this second definition should replace the first, or produce
+# an error not crash with a non-string LLVMErrorRef...
+def foo(a b) a*a + 2*a*b;

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Tests/TestContextTextWriter.cs
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Tests/TestContextTextWriter.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Kaleidoscope.Tests
 {
-    // Used as a target to output text of the runs to the test context
+    // Adapter - Used as a target to output text of the runs to the test context
     internal class TestContextTextWriter
         : TextWriter
     {

--- a/src/Ubiquity.NET.Llvm/OrcJITv2/MaterializationUnit.cs
+++ b/src/Ubiquity.NET.Llvm/OrcJITv2/MaterializationUnit.cs
@@ -4,12 +4,19 @@
 // Elements ARE ordered correctly, analyzer has dumb defaults and doesn't allow override of order
 #pragma warning disable SA1202 // Elements should be ordered by access
 
+using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Orc;
+
 namespace Ubiquity.NET.Llvm.OrcJITv2
 {
     /// <summary>Abstract base class for an LLVM ORC JIT v2 Materialization Unit</summary>
     public abstract class MaterializationUnit
         : DisposableObject
     {
+        /// <remarks>
+        /// For this class, this is an idempotent method. This allows MOVE semantics for native
+        /// code to function and callers remain oblivious. Callers should always call this for
+        /// correctness if it was succesfully moved to native code then such a call is a NOP.
+        /// </remarks>
         /// <inheritdoc/>
         protected override void Dispose( bool disposing )
         {
@@ -22,6 +29,7 @@ namespace Ubiquity.NET.Llvm.OrcJITv2
             base.Dispose( disposing );
         }
 
+        /// <summary>This will set the internal handle to a default state; makeing <see cref="Dispose"/> a NOP</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void InvalidateAfterMove( )
         {


### PR DESCRIPTION
Added support to indicate if function redifitinion is supported.
* For LazyJIT re-definition is NOT supported.
    - If it is possible to do, the solution , using only LLVM-C API, is far from obvious.
        - The asynchronous nature of resolution makes it a VERY complex problem. Fortunately, redefinition is a feature of dynamic runtimes that don't normally use lazy code execution so it's mostly an acedemic excercise. This implementation deals with it as an error at the AST generation with an error. The `DynamicRuntimeState` is used to indicate if the runtime supports re-definitions.
* Minor doc comment updates