### PR TITLE
Added use of global imports to all projects

### DIFF
--- a/src/Interop/LlvmBindingsGenerator/CmdLineArgs.cs
+++ b/src/Interop/LlvmBindingsGenerator/CmdLineArgs.cs
@@ -1,23 +1,18 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.CommandLine.Parsing;
-using System.IO;
-
-using CppSharp;
-
 namespace LlvmBindingsGenerator
 {
     internal partial class CmdLineArgs
     {
         // [Option("-l", Required=true, Description="Root of source with the LLVM headers to parse (Assumes and validates a sub-folder 'include')"]
         // [AcceptExistingFolderOnly]
-        // [Validator( "CmdLineArgs.ValidateIncludeFolder" )]
+        // [Validator( nameof(ValidateIncludeFolder) )]
         public required DirectoryInfo LlvmRoot { get; init; }
 
         // [Option("-e", Required=true, Description="Root of source with the LibLLVM extension headers to parse (Assumes and validates a sub-folder 'include')"]
         // [AcceptExistingFolderOnly]
-        // [Validator( "CmdLineArgs.ValidateIncludeFolder" )]
+        // [Validator( nameof(ValidateIncludeFolder) )]
         public required DirectoryInfo ExtensionsRoot { get; init; }
 
         // [Option("-e", Required=true, Description="Output to place the generated code for handles. No handle source is generated if this is not provided")]

--- a/src/Interop/LlvmBindingsGenerator/CmdLineArgs.g.cs
+++ b/src/Interop/LlvmBindingsGenerator/CmdLineArgs.g.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Parsing;
@@ -45,7 +48,7 @@ namespace LlvmBindingsGenerator
         {
             // description is hard coded and should come from generation attribute on the "CmdLineArgs" type
             // TODO: Check for duplicate options.
-            //       (-?,-h, --help, and --version) are used by default options so nothing should use those values.
+            //       (-?, -h, --help, and --version) are used by default options so nothing should use those values.
             //       Generator/analyzer should validate that so it isn't a runtime hit.
             return new AppControlledDefaultsRootCommand( settings, "LLVM handle wrapper source generator" )
             {

--- a/src/Interop/LlvmBindingsGenerator/Configuration/GeneratorConfig.cs
+++ b/src/Interop/LlvmBindingsGenerator/Configuration/GeneratorConfig.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Collections.Immutable;
-
 namespace LlvmBindingsGenerator.Configuration
 {
     internal class GeneratorConfig

--- a/src/Interop/LlvmBindingsGenerator/Configuration/HandleDetails.cs
+++ b/src/Interop/LlvmBindingsGenerator/Configuration/HandleDetails.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace LlvmBindingsGenerator.Configuration
 {
     /// <summary>Details for a handle</summary>

--- a/src/Interop/LlvmBindingsGenerator/Configuration/IGeneratorConfig.cs
+++ b/src/Interop/LlvmBindingsGenerator/Configuration/IGeneratorConfig.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-
-using LlvmBindingsGenerator.CppSharpExtensions;
-using LlvmBindingsGenerator.Templates;
-
 namespace LlvmBindingsGenerator.Configuration
 {
     /// <summary>Interface for a generator configuration</summary>

--- a/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/ASTContextExtensions.cs
+++ b/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/ASTContextExtensions.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-
-using CppSharp.AST;
-
 namespace LlvmBindingsGenerator
 {
     internal static class ASTContextExtensions

--- a/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/Driver.cs
+++ b/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/Driver.cs
@@ -1,20 +1,8 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-
-using CppSharp;
-using CppSharp.AST;
-using CppSharp.Generators;
-using CppSharp.Parser;
-using CppSharp.Passes;
-using CppSharp.Types;
-using CppSharp.Utils;
-
 using ClangParser = CppSharp.ClangParser;
+using Module = CppSharp.AST.Module;
 
 namespace LlvmBindingsGenerator
 {

--- a/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/ErrorTrackingDiagnostics.cs
+++ b/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/ErrorTrackingDiagnostics.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-
-using CppSharp;
-
 namespace LlvmBindingsGenerator
 {
     internal class ErrorTrackingDiagnostics

--- a/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/FieldExtensions.cs
+++ b/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/FieldExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using CppSharp.AST;
-
 namespace LlvmBindingsGenerator
 {
     internal static class FieldExtensions

--- a/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/ICodeGenerator.cs
+++ b/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/ICodeGenerator.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using LlvmBindingsGenerator.CppSharpExtensions;
-
 namespace LlvmBindingsGenerator
 {
     internal interface ICodeGenerator

--- a/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/ICodeGeneratorTemplateFactory.cs
+++ b/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/ICodeGeneratorTemplateFactory.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Collections.Generic;
-using CppSharp.Generators;
-
 namespace LlvmBindingsGenerator
 {
     internal interface ICodeGeneratorTemplateFactory

--- a/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/IDriver.cs
+++ b/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/IDriver.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-
-using CppSharp;
-using CppSharp.Generators;
-using CppSharp.Parser;
-using CppSharp.Passes;
-
 namespace LlvmBindingsGenerator
 {
     internal interface IDriver

--- a/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/ILibrary.cs
+++ b/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/ILibrary.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Collections.Generic;
-
-using CppSharp.AST;
-
 namespace LlvmBindingsGenerator
 {
     internal interface ILibrary

--- a/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/ITypePrinter2.cs
+++ b/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/ITypePrinter2.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using CppSharp.AST;
-
 namespace LlvmBindingsGenerator
 {
     internal enum TypeNameKind

--- a/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/NativeTypePrinter.cs
+++ b/src/Interop/LlvmBindingsGenerator/CppSharpExtensions/NativeTypePrinter.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Text;
-
-using CppSharp.AST;
-
 namespace LlvmBindingsGenerator
 {
     internal class NativeTypePrinter

--- a/src/Interop/LlvmBindingsGenerator/GlobalNamespaceImports.cs
+++ b/src/Interop/LlvmBindingsGenerator/GlobalNamespaceImports.cs
@@ -13,33 +13,28 @@ For an explanation of the benefits of the language feature see: https://www.hans
 */
 
 global using System;
+global using System.Collections.Generic;
 global using System.Collections.Immutable;
-global using System.Diagnostics;
+global using System.CommandLine.Parsing;
 global using System.Diagnostics.CodeAnalysis;
-global using System.Globalization;
 global using System.IO;
 global using System.Linq;
 global using System.Reflection;
-global using System.Runtime.CompilerServices;
 global using System.Runtime.InteropServices;
-global using System.Runtime.InteropServices.Marshalling;
-global using System.Threading;
+global using System.Text;
 
-global using Ubiquity.NET.Extensions;
-global using Ubiquity.NET.InteropHelpers;
-global using Ubiquity.NET.Llvm.Interop.ABI.libllvm_c;
-global using Ubiquity.NET.Llvm.Interop.ABI.llvm_c;
-global using Ubiquity.NET.Llvm.Interop.ABI.StringMarshaling;
-global using Ubiquity.NET.Llvm.Interop.Properties;
-global using Ubiquity.NET.Versioning;
+global using CppSharp;
+global using CppSharp.AST;
+global using CppSharp.Generators;
+global using CppSharp.Generators.CSharp;
+global using CppSharp.Parser;
+global using CppSharp.Passes;
+global using CppSharp.Types;
+global using CppSharp.Utils;
 
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.OrcJITv2Bindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.TargetRegistrationBindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.ValueBindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Core;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Error;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.ErrorHandling;
+global using LlvmBindingsGenerator.Configuration;
+global using LlvmBindingsGenerator.CppSharpExtensions;
+global using LlvmBindingsGenerator.Passes;
+global using LlvmBindingsGenerator.Templates;
 
-// global using for the NativeMethods type to allow simpler access to the
-// string const for the library name.
-global using static Ubiquity.NET.Llvm.Interop.NativeMethods;
+global using Ubiquity.NET.CommandLine;

--- a/src/Interop/LlvmBindingsGenerator/GlobalSuppressions.cs
+++ b/src/Interop/LlvmBindingsGenerator/GlobalSuppressions.cs
@@ -6,6 +6,4 @@
 // a specific target and scoped to a namespace, type, member, etc.
 */
 
-using System.Diagnostics.CodeAnalysis;
-
 [assembly: SuppressMessage( "", "SA0001: XML comment analysis is disabled due to project configuration", Justification = "Internal tool")]

--- a/src/Interop/LlvmBindingsGenerator/LibLLVMTypePrinter.cs
+++ b/src/Interop/LlvmBindingsGenerator/LibLLVMTypePrinter.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-
-using CppSharp.AST;
-using CppSharp.Generators.CSharp;
-
 namespace LlvmBindingsGenerator
 {
     // CONSIDER: Make this type printer provide the source language name

--- a/src/Interop/LlvmBindingsGenerator/LibLlvmGeneratorLibrary.cs
+++ b/src/Interop/LlvmBindingsGenerator/LibLlvmGeneratorLibrary.cs
@@ -1,13 +1,7 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Collections.Generic;
-using System.IO;
-
-using CppSharp.AST;
-
-using LlvmBindingsGenerator.Configuration;
-using LlvmBindingsGenerator.Passes;
+using Type = CppSharp.AST.Type;
 
 namespace LlvmBindingsGenerator
 {

--- a/src/Interop/LlvmBindingsGenerator/LibLlvmTemplateFactory.cs
+++ b/src/Interop/LlvmBindingsGenerator/LibLlvmTemplateFactory.cs
@@ -1,16 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Collections.Generic;
-using System.Linq;
-
-using CppSharp;
-using CppSharp.Generators;
-using CppSharp.Passes;
-
-using LlvmBindingsGenerator.Configuration;
-using LlvmBindingsGenerator.CppSharpExtensions;
-
 namespace LlvmBindingsGenerator
 {
     // Factory class for the templates needed in code generation

--- a/src/Interop/LlvmBindingsGenerator/Passes/IgnoreDuplicateNamesPass.cs
+++ b/src/Interop/LlvmBindingsGenerator/Passes/IgnoreDuplicateNamesPass.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Collections.Generic;
-
-using CppSharp.AST;
-using CppSharp.Passes;
-
 namespace LlvmBindingsGenerator.Passes
 {
     /// <summary>Translation unit pass to mark duplicate function names as ignored</summary>

--- a/src/Interop/LlvmBindingsGenerator/Passes/IgnoreSystemHeadersPass.cs
+++ b/src/Interop/LlvmBindingsGenerator/Passes/IgnoreSystemHeadersPass.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Collections.Immutable;
-
-using CppSharp;
-using CppSharp.AST;
-using CppSharp.Passes;
-
 namespace LlvmBindingsGenerator.Passes
 {
     /// <summary>Translation unit pass to mark system headers as ignored</summary>

--- a/src/Interop/LlvmBindingsGenerator/Passes/MarkFunctionsInternalPass.cs
+++ b/src/Interop/LlvmBindingsGenerator/Passes/MarkFunctionsInternalPass.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using CppSharp.AST;
-using CppSharp.Passes;
-
 namespace LlvmBindingsGenerator.Passes
 {
     /// <summary>Mark functions as internal or ignored</summary>

--- a/src/Interop/LlvmBindingsGenerator/Passes/ValidateExtensionNamingPass.cs
+++ b/src/Interop/LlvmBindingsGenerator/Passes/ValidateExtensionNamingPass.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Linq;
-
-using CppSharp;
-using CppSharp.AST;
-using CppSharp.Passes;
-
 namespace LlvmBindingsGenerator.Passes
 {
     /// <summary>Translation unit pass to validate that names of all functions in the extension headers have correct prefix</summary>

--- a/src/Interop/LlvmBindingsGenerator/Program.cs
+++ b/src/Interop/LlvmBindingsGenerator/Program.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-
-using CppSharp;
-
-using Ubiquity.NET.CommandLine;
-
 namespace LlvmBindingsGenerator
 {
     internal static partial class Program

--- a/src/Interop/LlvmBindingsGenerator/Properties/AssemblyInfo.cs
+++ b/src/Interop/LlvmBindingsGenerator/Properties/AssemblyInfo.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Reflection;
-using System.Runtime.InteropServices;
-
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.

--- a/src/Interop/LlvmBindingsGenerator/StringExtensions.cs
+++ b/src/Interop/LlvmBindingsGenerator/StringExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.IO;
-
 namespace LlvmBindingsGenerator
 {
     internal static class StringExtensions

--- a/src/Interop/LlvmBindingsGenerator/TemplateCodeGenerator.cs
+++ b/src/Interop/LlvmBindingsGenerator/TemplateCodeGenerator.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using LlvmBindingsGenerator.CppSharpExtensions;
-
 namespace LlvmBindingsGenerator
 {
     /// <summary>Adapter class from a <see cref="ICodeGenTemplate"/> generator to a CppSharp ICodeGenerator</summary>

--- a/src/Interop/LlvmBindingsGenerator/Templates/AssemblyExtensions.cs
+++ b/src/Interop/LlvmBindingsGenerator/Templates/AssemblyExtensions.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Reflection;
-
 namespace LlvmBindingsGenerator.Templates
 {
     internal static class AssemblyExtensions

--- a/src/Interop/LlvmBindingsGenerator/Templates/WrappedHandleTemplate.cs
+++ b/src/Interop/LlvmBindingsGenerator/Templates/WrappedHandleTemplate.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-
-using LlvmBindingsGenerator.Configuration;
-using LlvmBindingsGenerator.CppSharpExtensions;
-
 namespace LlvmBindingsGenerator.Templates
 {
     // Manually maintained partial of the T4 Template generated type

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/ReadMe.md
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/ReadMe.md
@@ -5,8 +5,8 @@ directly. The source generation was too problematic/complex to generalize to the
 where the output was usable "as-is". Additionally, it used marshalling hints via a custom
 YAML configuration file. Ultimately, this file ended up as a foreign language form of the
 marshalling attributes in C# code. So it was mostly abandoned. (It is still used to generate
-the `EXPOORTS.g.def` file, the type specific handle wrappers, and perform some validations
-of the extension code at the native level.)
+the type specific handle wrappers, and perform some validations of the extension code at the
+native level.)
 
 The generator did have one advantage in that it could read the configuration file AND
 validate that the functions listed in it were still in the actual headers (though
@@ -21,35 +21,35 @@ ABI function pointers are represented as real .NET function pointers with an unm
 signature.
 
 ### special consideration for handles
-LLVM handles are just value types that wrap around a runtime `nint` (basically
-a strong typedef for a pointer). Therefore, they are blittable value types and don't
-need any significant marshaling support. All LLVM handle managed projections **CANNOT**
-appear in the signature of an unmanaged function pointer as there is no way to mark
-the marshalling behavior for unmanaged pointers. Implementations of the "callbacks"
-MUST handle marshalling of the ABI types manually. Normally, they will leverage a
-`GCHandle` as the "context", perform marshalling, and forward the results on to the
-managed context object. But implementations are free to deal with things as they need
-to (or have to if no context parameter is available).
+LLVM handles are just value types that wrap around a runtime `nint` (basically a strong
+typedef for a pointer). Therefore, they are blittable value types and don't need any
+significant marshaling support. All LLVM handle managed projections **CANNOT** appear in the
+signature of an unmanaged function pointer as there is no way to mark the marshalling
+behavior for unmanaged pointers. Implementations of the "callbacks" MUST handle marshalling
+of the ABI types manually. Normally, they will leverage a `GCHandle` as the "context",
+perform marshalling, and forward the results on to the managed context object. But
+implementations are free to deal with things as they need to (or have to if no context
+parameter is available).
 
 # General patterns for maintenance of P/Invoke signatures
 The general pattern is that the interop APIs now ALL use the built-in interop source
 generator via the `LibraryImportAttribute` this generates all the marshalling code at
-compile time so the result is AOT compatible. This is leveraged by the types generated
-for each LLVM handle type. Specifically, the default marshalling of handles ensures
-handle types are marshaled safely with `LibraryImportAttribute`. For the global
-handles that is the built-in support for `SafeHandle` derived type handling. For the
-context handles that is covered by the `ContextHandleMarshaller<T>` custom marshalling
-type. The generated types for all context handles marks the type marshalling with the
-`NativeMarshallingAttribute` to ensure it is AOT marshalling ready.
+compile time so the result is AOT compatible. This is leveraged by the types generated for
+each LLVM handle type. Specifically, the default marshalling of handles ensures handle types
+are marshaled safely with `LibraryImportAttribute`. For the global handles that is the
+built-in support for `SafeHandle` derived type handling. For the context handles that is
+covered by the `ContextHandleMarshaller<T>` custom marshalling type. The generated types for
+all context handles marks the type marshalling with the `NativeMarshallingAttribute` to
+ensure it is AOT marshalling ready.
 
 ## Arrays
-Array marshalling requires some careful annotation and interpretation from the native
-code where the type is normally just a pointer. There's nothing in the C/C++ language
-that says anything about the SIZE of the data that pointer points to beyond the size
-of the type pointed to. (i.e., Is `T*` a pointer to one element of type T, an array of
-elements of type `T`? If an array, how many such elements are valid...) Thus,
-marshalling to a runtime with stronger type guarantees requires some care. Reading the
-docs, and sometimes the source code of the implementation.
+Array marshalling requires some careful annotation and interpretation from the native code
+where the type is normally just a pointer. There's nothing in the C/C++ language that says
+anything about the SIZE of the data that pointer points to beyond the size of the type
+pointed to. (i.e., Is `T*` a pointer to one element of type T, an array of elements of type
+`T`? If an array, how many such elements are valid...) Thus, marshalling to a runtime with
+stronger type guarantees requires some care. Reading the docs, and sometimes the source code
+of the implementation.
 
 ### In Arrays
 Input arrays are generally rather simple to declare and use the form:
@@ -64,79 +64,76 @@ filled in by the native code use the following pattern:
 void LLVMSomeApiThatFillsArray(LLVMHandleOfSomeSort h, [Out] UInt32[] elements, int numElements);
 ```
 
-Arrays where the caller is expected to provide a pointer to valid (allocated, but
-likely uninitialized) data that is filled in by native code use the following pattern:
+Arrays where the caller is expected to provide a pointer to valid (allocated, but likely
+uninitialized) data that is filled in by native code use the following pattern:
 ``` C#
 void LLVMSomeApiThatFillsArray(LLVMHandleOfSomeSort h, out UInt32[] elements, int numElements);
 ```
 
 ### Return arrays
-Return arrays are like an out param except that they are the return type. A problem
-with this is that they are **purely** `[Out]` in that the native code must allocate
-the return value and cleanup (if any) of that allocation is left to the caller to
-perform. 
+Return arrays are like an out param except that they are the return type. A problem with
+this is that they are **purely** `[Out]` in that the native code must allocate the return
+value and cleanup (if any) of that allocation is left to the caller to perform.
 
-It is important to note that `[Out] byte[] buf` and `out byte[] buf` are two very
-different declarations and have distinct meanings for the marshalling of these
-parameters. The first expects the **caller** to allocate the memory and it is 'filled
-in' by the callee, the second expects the **callee** to allocate and fill the memory.
-The second implies some form of "contract" on the release of the allocated memory. The
-normal marshaling has no knowledge of such a thing and does not know how to release it
-either. Thus, a custom marshaller is needed for such things.
+It is important to note that `[Out] byte[] buf` and `out byte[] buf` are two very different
+declarations and have distinct meanings for the marshalling of these parameters. The first
+expects the **caller** to allocate the memory and it is 'filled in' by the callee, the
+second expects the **callee** to allocate and fill the memory. The second implies some form
+of "contract" on the release of the allocated memory. The normal marshaling has no knowledge
+of such a thing and does not know how to release it either. Thus, a custom marshaller is
+needed for such things.
 
 #### Special support for SafeHandle arrays
-The built-in marshalling does NOT support arrays of SafeHandles as in parameters
-(retaining ownership [By const ref semantics]) so that is provided as extensions in
-the `Ubiquity.NET.InteropHelpers.RefHandleMarshaller` class. 
+The built-in marshalling does NOT support arrays of SafeHandles as in parameters (retaining
+ownership [By const ref semantics]) so that is provided as extensions in the
+`Ubiquity.NET.InteropHelpers.RefHandleMarshaller` class.
 
 ## Explicit types
-All of the P/Invoke API signatures are created with Explicitly sized values for
-numerics ***and enumerations***. This ensures there is no confusion on the bit length
-of types etc... (For example, [U]Int[64|32|16] is ALWAYS used over any built-in
-wrappers to avoid any potential confusion about the size of types between C# and
-native C/C++)
+All of the P/Invoke API signatures are created with Explicitly sized values for numerics
+***and enumerations***. This ensures there is no confusion on the bit length of types etc...
+(For example, [U]Int[64|32|16] is ALWAYS used over any built-in alias to avoid potential
+confusion about the size of types between C# and native C/C++)
 
 ### Distinction for real LLVMBOOL vs Status
 This library and P/Invoke signatures disambiguate between an actual boolean value
 (`LLVMBool`) and what is really a success or failure status code. As with strings, the
-only way to tell the difference is to read the docs, or sometimes the source... Thus,
-for ALL API signatures an `LLVMStatus` is used for any native code signature `LLVMBool`
-that is documented as behaving like a status and NOT a bool. This prevents mass confusion
-on the intent and helps keep the API surface cleaner and more self documenting. (Does a
-non-zero `LLVMBool` mean it succeeded? Or does it mean there was an error?) Thus all APIs
-need a developer to understand the documentation and set the P/Invoke signature to use
+only way to tell the difference is to read the docs, or sometimes the source... Thus, for
+ALL API signatures an `LLVMStatus` is used for any native code signature `LLVMBool` that is
+documented as behaving like a status and NOT a bool. This prevents mass confusion on the
+intent and helps keep the API surface cleaner and more self documenting. (Does a non-zero
+`LLVMBool` mean it succeeded? Or does it mean there was an error?) Thus all of the interop
+APIs need a developer to understand the documentation and set the P/Invoke signature to use
 `LLVMStatus` for anything that is really a status code and ***NOT*** a proper boolean
 (true/false) value. This library has done that work and ALL signatures using the native
 `LLVMBool` is manually evaluated and the correct form applied to the managed P/Invoke
 signature.
 
 ## Enumerated value naming
-The normal rules of naming enumerated values are suspended for this low level interop
-API. The idea is to keep ALL enumeration names and values as close as possible (if not
-identical) to the underlying native code. This helps in supporting the idea that the
-documentation for the native code is relevant and easier to consume so that the
-documentation for this library focuses ONLY on the interop support provided within it.
+The normal rules of naming enumerated values are suspended for this low level interop API.
+The idea is to keep ALL enumeration names and values as close as possible (if not identical)
+to the underlying native code. This helps in supporting the idea that the documentation for
+the native code is relevant and easier to consume so that the documentation for this library
+focuses ONLY on the interop support provided within it.
 
 ## Calling convention
 All of the P/Invoke APIs use an explicit
-`[UnmanagedCallConv(CallConvs=[typeof(CallConvCdecl)])]` to identify that the APIs use
-the standard "C" ABI calling convention. This is defined by the LLVM-C API.
+`[UnmanagedCallConv(CallConvs=[typeof(CallConvCdecl)])]` to identify that the APIs use the
+standard "C" ABI calling convention. This is defined by the LLVM-C API.
 
 ### Future optimization
-At some point in the future it might be worth adding the ability to suppress GC
-transitions as an optimization. Application of that requires great care and
-understanding of the GC and native implementation to ensure it is safe to do. This is
-strictly a performance optimization that has NO impact on callers so is left for
-future enhancement as applicable.
+At some point in the future it might be worth adding the ability to suppress GC transitions
+as an optimization. Application of that requires great care and understanding of the GC and
+native implementation to ensure it is safe to do. This is strictly a performance
+optimization that has NO impact on callers so is left for future enhancement as applicable.
 
 ## Special handling of strings
 >[!NOTE]
 > All native strings are assumed encoded as UTF8. This is the most common/compatible
 > assumption to make. Sadly, LLVM itself is silent on the point.
 
-Since the handle types all have AOT marshalling support (built-in or generated) the
-APIs ALL use them directly. Leaving the only "tricky part" of strings. LLVM has come a
-long way and unified most string use to one of three forms.
+Since the handle types all have AOT marshalling support (built-in or generated) the APIs ALL
+use them directly. Leaving the only "tricky part" of strings. LLVM has come a long way and
+unified most string use to one of three forms.
 
 1) Raw pointer aliases as a native string
     1) These are owned by the implementation and assumed invalid after the container
@@ -148,52 +145,51 @@ long way and unified most string use to one of three forms.
 
 #1 is handled by using `LazyEncodedString` which always makes a copy of the native data
 These are ALWAYS copied from the native form at point of use. Thus any use of them will
-incur a performance hit as the memory is allocated/pinned, copied. This does, however,
-mean that there is no ambiguity about the validity or lifetime of an otherwise alias
-pointer. The built-in/BCL marshalling assumes that ALL native strings are allocated
-via `CoTaskMemAlloc()` and therefore require a release. But that is ***NEVER*** the
-case with LLVM and usually not true of interop with arbitrary C/C++ code.
+incur a performance hit as the memory is allocated/pinned, copied. This does, however, mean
+that there is no ambiguity about the validity or lifetime of an otherwise alias pointer. The
+built-in/BCL marshalling assumes that ALL native strings are allocated via `CoTaskMemAlloc()`
+and therefore require a release. But that is ***NEVER*** the case with LLVM and usually not
+true of interop with arbitrary C/C++ code.
 
 #2 is handled by marking the occurrence with `MarshalUsing(typeof( DisposeMessageMarshaller )`
 and a parameter or return signature of `LazyEncodedString`. (Or directly to `string'
 if the results of the API is never expected in a call to a native API. Normally this
 is only used for some form of `ToString` semantics API)
 
-#3 is handled similar to #2 except that it uses an internal handle type
-`ErrorMessageString`. This handle is internal as the ONLY use of such a string is from
-an `LLVMErrorRef` and the ownership semantics of such a thing are very unique. The
-LLVMErrorRef code will lazy initialize the `ErrorMessage` string to prevent any
-construction of the string in the native library until needed. Thus, all of the
-complexity is handled within the `LLVMErrorRef` type so that it is fairly easy and
-unsurprising to use from upper layers of managed code.
+#3 is handled similar to #2 except that it uses an internal handle type `ErrorMessageString`.
+This handle is internal as the ONLY use of such a string is from an `LLVMErrorRef` and the
+ownership semantics of the underlying string handle are ***very*** "strange". The
+`LLVMErrorRef` code will lazy initialize the `ErrorMessage` string to prevent any
+construction of the string in the native library until needed. Thus, all of the complexity
+is handled within the `LLVMErrorRef` type so that it is fairly easy and unsurprising to use
+from upper layers of managed code.
 
 >[!IMPORTANT]
-> It is worth stressing the point here that there is NO WAY to know which string type
-> to use based on only the header files and API signatures they contain. One ***MUST***
-> read the documentation for the API to know (and occasionally dig into the source code,
-> as it often isn't documented what the requirements are!). This is one of the greatest
-> problems with any form of automated interop code generator. It can only scan the
-> headers and knows nothing about the documentation or intended semantics. This is why,
-> previously this was all done in a custom YAML file. But as this library and LLVM
-> grew that became unmaintainable and downright silly as it was basically just
-> describing the marshalling behavior in a foreign language. At best the tool could
-> generate anything where there is no potential for ambiguity and leave the rest
-> marked in a way a developer could find it. (The implementation in this repo has
-> chosen to ignore signatures for generation entirely so it is all maintained
-> "by hand" now)
+> It is worth stressing the point here that there is NO WAY to know which string type to use
+> based on only the header files and API signatures they contain. One ***MUST*** read the
+> documentation for the API to know (and occasionally dig into the source code, as it often
+> isn't documented what the requirements are!). This is one of the greatest problems with
+> any form of automated interop code generator. It can only scan the headers and knows
+> nothing about the documentation or intended semantics. This is why, previously this was
+> all done in a custom YAML file. But as this library and LLVM grew that became
+> unmaintainable and downright silly as it was basically just describing the marshalling
+> behavior in a foreign language. At best the tool could generate anything where there is no
+> potential for ambiguity and leave the rest marked in a way a developer could find it. (The
+> implementation in this repo has chosen to ignore signatures for generation entirely so it
+> is all maintained "by hand" now)
 
 ### String lengths
-Sadly, the LLVM-C API is across the map on types used for the length of a string in
-the `C` APIs. It is any one of `size_t, int, unsigned`. That is, there is no consistent
-standard on that point. Thus, the interop code deals with things as `size_t` and
-downcasts with `checked()` to ensure conversion failures trigger an exception. Since,
-`size_t` is NOT hard defined to any particular size by the language `nuint` is used
-as the size of a native pointer is generally equivalent.^1^
+Sadly, the LLVM-C API is across the map on types used for the length of a string in the `C`
+APIs. It is any one of `size_t, int, unsigned`. That is, there is no consistent standard on
+that point in LLVM-C. Thus, the interop code deals with things as `size_t` and downcasts
+with `checked()` to ensure conversion failures trigger an exception. Since, `size_t` is NOT
+hard defined to any particular size by the language `nuint` is used as the size of a native
+pointer is generally equivalent.^1^
 
 #### APIs accepting a length for a String
-APIs that accept a string are wrapped at the interop layer using `LazyEncodedString`
-where the length is provided by the wrapper so callers don't need to worry about it.
-Generally this takes the form like in the following example:
+APIs that accept a string are wrapped at the interop layer using `LazyEncodedString` where
+the length is provided by the wrapper so callers don't need to worry about it. Generally,
+this takes the form like in the following example:
 ``` C#
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
 public static uint LLVMGetSyncScopeID(LLVMContextRefAlias C, LazyEncodedString Name)
@@ -209,11 +205,11 @@ private static unsafe partial uint LLVMGetSyncScopeID(LLVMContextRefAlias C, Laz
 > The imported API is declared as private because a local `partial` function is NOT
 > allowed in the language.
 
-Sometimes an API will return a pointer AND include an out parameter for the length
-of a string. These require great care as they do NOT guarantee that the string is
-terminated! Only that the length is valid. Thus, the implementation of wrappers for 
-such APIs follow a pattern of hiding the length out parameter to produce a
-`LazyEncodedString` as in the following example:
+Sometimes an API will return a pointer AND include an out parameter for the length of a
+string. These require great care as they do NOT guarantee that the string is terminated!
+Only that the length is valid. Thus, the implementation of wrappers for such APIs follow a
+pattern of hiding the length out parameter to produce a `LazyEncodedString` as in the
+following example:
 
 ``` C#
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -231,17 +227,17 @@ public static LazyEncodedString LLVMGetStringAttributeKind(LLVMAttributeRef A)
 private static unsafe partial byte* LLVMGetStringAttributeKind(LLVMAttributeRef A, out uint Length);
 ```
 >[!IMPORTANT]
-> It is very tempting to simply ignore the out length and assume the returned pointer
-> is for a terminated string. Most of the time it will be, but some times it isn't!
-> There are no guarantees either way. Thus, the implementation of this library will
-> handle the subtleties and provide a `LazyEncodedString` from the pointer and length.
+> It is very tempting to simply ignore the out length and assume the returned pointer is for
+> a terminated string. Most of the time it will be, but some times it isn't! There are no
+> guarantees either way. Thus, the implementation of this library will handle the subtleties
+> and provide a `LazyEncodedString` from the pointer and length.
 
 >[!IMPORTANT]
-> It is also tempting to blindly cast the length to the `int` needed for a span and
-> that will mostly work - until it doesn't, and then all hell breaks lose with weird
-> and difficult to track behavior. By applying a `checked()` to the conversions ANY
-> overflows are caught and triggered at the point of the problem. It is unlikely these
-> will ever hit as strings that large are generally unmanageable at runtime anyway.
+> It is also tempting to blindly cast the length to the `int` needed for a span and that
+> will mostly work - until it doesn't, and then all hell breaks lose with weird and
+> difficult to track behavior. By applying a `checked()` to the conversions ANY overflows
+> are caught and triggered at the point of the problem. It is unlikely these will ever hit
+> as strings that large are generally unmanageable at runtime anyway.
 
 ---
 ^1^ While it is plausible to create an ISO `C` compliant compiler implementation and

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/StringMarshaling/LLVMErrorRef.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/StringMarshaling/LLVMErrorRef.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Error;
-
 namespace Ubiquity.NET.Llvm.Interop.ABI.StringMarshaling
 {
     /// <summary>Global LLVM object handle for an error</summary>

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ILibLlvm.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ILibLlvm.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using Ubiquity.NET.Versioning;
-
 namespace Ubiquity.NET.Llvm.Interop
 {
     /// <summary>Interface to the core LLVM library itself</summary>

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/LLVMValueRefExtensions.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/LLVMValueRefExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.ValueBindings;
-
 namespace Ubiquity.NET.Llvm.Interop
 {
     // This does NOT use the new C# 14 extension syntax due to several reasons

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/Library.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/Library.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using Ubiquity.NET.Versioning;
-
-using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.TargetRegistrationBindings;
-using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Core;
-using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.ErrorHandling;
-
 namespace Ubiquity.NET.Llvm.Interop
 {
     /// <summary>Provides support for various LLVM static state initialization and manipulation</summary>

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/SymbolStringPoolEntryRefExtension.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/SymbolStringPoolEntryRefExtension.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using Ubiquity.NET.Extensions;
-
 namespace Ubiquity.NET.Llvm.Interop
 {
     // This does NOT use the new C# 14 extension syntax due to several reasons

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/SymbolStringPoolExtension.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/SymbolStringPoolExtension.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Linq;
-
-using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.OrcJITv2Bindings;
-
 namespace Ubiquity.NET.Llvm.Interop
 {
     // This does NOT use the new C# 14 extension syntax due to several reasons

--- a/src/Ubiquity.NET.ANTLR.Utils/AntlrParseErrorListenerAdapter.cs
+++ b/src/Ubiquity.NET.ANTLR.Utils/AntlrParseErrorListenerAdapter.cs
@@ -1,16 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections.Immutable;
-using System.IO;
-
-using Antlr4.Runtime;
-using Antlr4.Runtime.Misc;
-
-using Ubiquity.NET.Extensions;
-using Ubiquity.NET.Runtime.Utils;
-
 namespace Ubiquity.NET.ANTLR.Utils
 {
     /// <summary>Adapter to translate ANTLR error listeners to an <see cref="IParseErrorListener"/></summary>

--- a/src/Ubiquity.NET.ANTLR.Utils/AntlrUtilities.cs
+++ b/src/Ubiquity.NET.ANTLR.Utils/AntlrUtilities.cs
@@ -1,17 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Text;
-
-using Antlr4.Runtime;
-using Antlr4.Runtime.Misc;
-using Antlr4.Runtime.Tree;
-
-using static System.Math;
-
 namespace Ubiquity.NET.ANTLR.Utils
 {
     /// <summary>Utility functions for extending ANTLR types</summary>
@@ -33,7 +22,7 @@ namespace Ubiquity.NET.ANTLR.Utils
 
             int startChar = ruleContext.Start.StartIndex;
             int endChar = ruleContext.Stop.StopIndex - 1;
-            return Interval.Of( Min( startChar, endChar ), Max( startChar, endChar ) );
+            return Interval.Of( Math.Min( startChar, endChar ), Math.Max( startChar, endChar ) );
         }
 
         /// <summary>Gets the source <see cref="ICharStream"/> from a recognizer if it is available</summary>

--- a/src/Ubiquity.NET.ANTLR.Utils/DebugTraceListener.cs
+++ b/src/Ubiquity.NET.ANTLR.Utils/DebugTraceListener.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics;
-
-using Antlr4.Runtime;
-using Antlr4.Runtime.Tree;
-
 namespace Ubiquity.NET.ANTLR.Utils
 {
     /// <summary>Provides debug <see cref="Trace.TraceInformation(string)"/> notification of all rule processing while parsing</summary>

--- a/src/Ubiquity.NET.ANTLR.Utils/GlobalNamespaceImports.cs
+++ b/src/Ubiquity.NET.ANTLR.Utils/GlobalNamespaceImports.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+/*
+NOTE:
+While the MsBuild `ImplicitUsings` property is banned from this repo, the C# language feature of global usings is NOT.
+The build property will auto include an invisible and undiscoverable (without looking up obscure documentation)
+set of namespaces that is NOT consistent or controlled by the developer. THAT is what is BAD/BROKEN about that feature.
+By banning it's use and then providing a `GlobalNamespaceImports.cs` source file with ONLY global using statements ALL of
+that is eliminated. Such use of the language feature restores FULL control and visibility of the namespaces to the developer,
+where it belongs. For a good explanation of this problem see: https://rehansaeed.com/the-problem-with-csharp-10-implicit-usings/.
+For an explanation of the benefits of the language feature see: https://www.hanselman.com/blog/implicit-usings-in-net-6
+*/
+
+global using System;
+global using System.Collections.Generic;
+global using System.Collections.Immutable;
+global using System.Diagnostics;
+global using System.Globalization;
+global using System.IO;
+global using System.Text;
+
+global using Antlr4.Runtime;
+global using Antlr4.Runtime.Misc;
+global using Antlr4.Runtime.Tree;
+
+global using Ubiquity.NET.Extensions;
+global using Ubiquity.NET.Runtime.Utils;

--- a/src/Ubiquity.NET.ANTLR.Utils/LocationExtensions.cs
+++ b/src/Ubiquity.NET.ANTLR.Utils/LocationExtensions.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-
-using Antlr4.Runtime;
-using Antlr4.Runtime.Tree;
-
-using Ubiquity.NET.Extensions;
-
 namespace Ubiquity.NET.ANTLR.Utils
 {
     /// <summary>Utility class to provide extensions for translation of ANTLR location data into a <see cref="SourceRange"/></summary>

--- a/src/Ubiquity.NET.CommandLine/AppControlledDefaultsRootCommand.cs
+++ b/src/Ubiquity.NET.CommandLine/AppControlledDefaultsRootCommand.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.CommandLine;
-using System.CommandLine.Help;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-
 namespace Ubiquity.NET.CommandLine
 {
     /// <summary>Extension of <see cref="RootCommand"/> that allows app control of defaults that are otherwise forced</summary>

--- a/src/Ubiquity.NET.CommandLine/ArgsParsing.cs
+++ b/src/Ubiquity.NET.CommandLine/ArgsParsing.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.CommandLine;
-using System.CommandLine.Help;
-using System.CommandLine.Invocation;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-
 namespace Ubiquity.NET.CommandLine
 {
     /// <summary>Results of invoking the default handlers for <see cref="HelpOption"/> or <see cref="VersionOption"/></summary>

--- a/src/Ubiquity.NET.CommandLine/ArgumentExceptionReporter.cs
+++ b/src/Ubiquity.NET.CommandLine/ArgumentExceptionReporter.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Text;
-
 namespace Ubiquity.NET.CommandLine
 {
     /// <summary>Implementation of <see cref="IDiagnosticReporter"/> that throws <see cref="ArgumentException"/> for any errors reported.</summary>

--- a/src/Ubiquity.NET.CommandLine/CmdLineSettings.cs
+++ b/src/Ubiquity.NET.CommandLine/CmdLineSettings.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.CommandLine;
-using System.CommandLine.Completions;
-using System.CommandLine.Parsing;
-
 namespace Ubiquity.NET.CommandLine
 {
     /// <summary>Flags to determine the default Options for an <see cref="AppControlledDefaultsRootCommand"/></summary>

--- a/src/Ubiquity.NET.CommandLine/ColoredConsoleReporter.cs
+++ b/src/Ubiquity.NET.CommandLine/ColoredConsoleReporter.cs
@@ -1,14 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
-
-using AnsiCodes;
-
-using Ubiquity.NET.Extensions;
-
 namespace Ubiquity.NET.CommandLine
 {
     /// <summary>Implementation of <see cref="IDiagnosticReporter"/> that uses colorized console output</summary>

--- a/src/Ubiquity.NET.CommandLine/ConsoleReporter.cs
+++ b/src/Ubiquity.NET.CommandLine/ConsoleReporter.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Ubiquity.NET.CommandLine
 {
     /// <summary>Implementation of <see cref="IDiagnosticReporter"/> that reports messages to a <see cref="Console"/></summary>

--- a/src/Ubiquity.NET.CommandLine/DiagnosticMessage.cs
+++ b/src/Ubiquity.NET.CommandLine/DiagnosticMessage.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Linq;
-
-using Ubiquity.NET.Extensions;
-
 namespace Ubiquity.NET.CommandLine
 {
     /// <summary>Tool Message category</summary>

--- a/src/Ubiquity.NET.CommandLine/DiagnosticMessageCollection.cs
+++ b/src/Ubiquity.NET.CommandLine/DiagnosticMessageCollection.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Text;
-
 namespace Ubiquity.NET.CommandLine
 {
     /// <summary>Reporter that collects diagnostic information without reporting it in any UI/UX</summary>

--- a/src/Ubiquity.NET.CommandLine/DiagnosticReporterExtensions.cs
+++ b/src/Ubiquity.NET.CommandLine/DiagnosticReporterExtensions.cs
@@ -1,15 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Runtime.CompilerServices;
-
-using Ubiquity.NET.CommandLine.InterpolatedStringHandlers;
-using Ubiquity.NET.Extensions;
-
 namespace Ubiquity.NET.CommandLine
 {
     /// <summary>Extensions to <see cref="IDiagnosticReporter"/> for specific message levels</summary>

--- a/src/Ubiquity.NET.CommandLine/GlobalNamespaceImports.cs
+++ b/src/Ubiquity.NET.CommandLine/GlobalNamespaceImports.cs
@@ -13,33 +13,23 @@ For an explanation of the benefits of the language feature see: https://www.hans
 */
 
 global using System;
+global using System.Collections;
+global using System.Collections.Generic;
 global using System.Collections.Immutable;
-global using System.Diagnostics;
+global using System.CommandLine;
+global using System.CommandLine.Completions;
+global using System.CommandLine.Help;
+global using System.CommandLine.Invocation;
+global using System.CommandLine.Parsing;
+global using System.ComponentModel;
 global using System.Diagnostics.CodeAnalysis;
 global using System.Globalization;
 global using System.IO;
 global using System.Linq;
-global using System.Reflection;
 global using System.Runtime.CompilerServices;
-global using System.Runtime.InteropServices;
-global using System.Runtime.InteropServices.Marshalling;
-global using System.Threading;
+global using System.Text;
 
+global using AnsiCodes;
+
+global using Ubiquity.NET.CommandLine.InterpolatedStringHandlers;
 global using Ubiquity.NET.Extensions;
-global using Ubiquity.NET.InteropHelpers;
-global using Ubiquity.NET.Llvm.Interop.ABI.libllvm_c;
-global using Ubiquity.NET.Llvm.Interop.ABI.llvm_c;
-global using Ubiquity.NET.Llvm.Interop.ABI.StringMarshaling;
-global using Ubiquity.NET.Llvm.Interop.Properties;
-global using Ubiquity.NET.Versioning;
-
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.OrcJITv2Bindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.TargetRegistrationBindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.ValueBindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Core;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Error;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.ErrorHandling;
-
-// global using for the NativeMethods type to allow simpler access to the
-// string const for the library name.
-global using static Ubiquity.NET.Llvm.Interop.NativeMethods;

--- a/src/Ubiquity.NET.CommandLine/ICommandLineOptions.cs
+++ b/src/Ubiquity.NET.CommandLine/ICommandLineOptions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.CommandLine;
-
 namespace Ubiquity.NET.CommandLine
 {
     /// <summary>Interface for a root command in command line parsing</summary>

--- a/src/Ubiquity.NET.CommandLine/IDiagnosticReporter.cs
+++ b/src/Ubiquity.NET.CommandLine/IDiagnosticReporter.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Text;
-
 namespace Ubiquity.NET.CommandLine
 {
     /// <summary>Interface for UX message reporting</summary>

--- a/src/Ubiquity.NET.CommandLine/InterpolatedStringHandlers/DiagnosticReporterInterpolatedStringHandler.cs
+++ b/src/Ubiquity.NET.CommandLine/InterpolatedStringHandlers/DiagnosticReporterInterpolatedStringHandler.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Runtime.CompilerServices;
-using System.Text;
-
 namespace Ubiquity.NET.CommandLine.InterpolatedStringHandlers
 {
     /// <summary>Interpolated string handler for an <see cref="IDiagnosticReporter"/></summary>

--- a/src/Ubiquity.NET.CommandLine/InterpolatedStringHandlers/ErrorReportingInterpolatedStringHandler.cs
+++ b/src/Ubiquity.NET.CommandLine/InterpolatedStringHandlers/ErrorReportingInterpolatedStringHandler.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using System.Text;
-
 namespace Ubiquity.NET.CommandLine.InterpolatedStringHandlers
 {
     /// <summary>Interpolated string handler for an <see cref="IDiagnosticReporter"/> using a fixed <see cref="MsgLevel.Error"/></summary>

--- a/src/Ubiquity.NET.CommandLine/InterpolatedStringHandlers/InformationReportingInterpolatedStringHandler.cs
+++ b/src/Ubiquity.NET.CommandLine/InterpolatedStringHandlers/InformationReportingInterpolatedStringHandler.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using System.Text;
-
 namespace Ubiquity.NET.CommandLine.InterpolatedStringHandlers
 {
     /// <summary>Interpolated string handler for an <see cref="IDiagnosticReporter"/> using a fixed <see cref="MsgLevel.Information"/></summary>

--- a/src/Ubiquity.NET.CommandLine/InterpolatedStringHandlers/VerboseReportingInterpolatedStringHandler.cs
+++ b/src/Ubiquity.NET.CommandLine/InterpolatedStringHandlers/VerboseReportingInterpolatedStringHandler.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using System.Text;
-
 namespace Ubiquity.NET.CommandLine.InterpolatedStringHandlers
 {
     /// <summary>Interpolated string handler for an <see cref="IDiagnosticReporter"/> using a fixed <see cref="MsgLevel.Verbose"/></summary>

--- a/src/Ubiquity.NET.CommandLine/InterpolatedStringHandlers/WarningReportingInterpolatedStringHandler.cs
+++ b/src/Ubiquity.NET.CommandLine/InterpolatedStringHandlers/WarningReportingInterpolatedStringHandler.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using System.Text;
-
 namespace Ubiquity.NET.CommandLine.InterpolatedStringHandlers
 {
     /// <summary>Interpolated string handler for an <see cref="IDiagnosticReporter"/> using a fixed <see cref="MsgLevel.Warning"/></summary>

--- a/src/Ubiquity.NET.CommandLine/ParseResultExtensions.cs
+++ b/src/Ubiquity.NET.CommandLine/ParseResultExtensions.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.CommandLine;
-using System.CommandLine.Help;
-using System.CommandLine.Parsing;
-using System.Linq;
-
 namespace Ubiquity.NET.CommandLine
 {
     // This does NOT use the new C# 14 extension syntax due to several reasons

--- a/src/Ubiquity.NET.CommandLine/ReportingSettings.cs
+++ b/src/Ubiquity.NET.CommandLine/ReportingSettings.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.CommandLine;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Text;
-
 namespace Ubiquity.NET.CommandLine
 {
     // internal extension for IDiagnosticReporter

--- a/src/Ubiquity.NET.CommandLine/SymbolValidationExtensions.cs
+++ b/src/Ubiquity.NET.CommandLine/SymbolValidationExtensions.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.CommandLine;
-using System.CommandLine.Parsing;
-using System.IO;
-using System.Runtime.CompilerServices;
-
 namespace Ubiquity.NET.CommandLine
 {
     /// <summary>Utility class to provide extensions for validation of options and arguments</summary>

--- a/src/Ubiquity.NET.CommandLine/TextWriterReporter.cs
+++ b/src/Ubiquity.NET.CommandLine/TextWriterReporter.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Text;
-
 namespace Ubiquity.NET.CommandLine
 {
     /// <summary>Base class for reporting diagnostics via an instance of <see cref="TextWriter"/></summary>

--- a/src/Ubiquity.NET.Extensions/AssemblyExtensions.cs
+++ b/src/Ubiquity.NET.Extensions/AssemblyExtensions.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-
 namespace Ubiquity.NET.Extensions
 {
     // This does NOT use the new C# 14 extension syntax due to several reasons

--- a/src/Ubiquity.NET.Extensions/DictionaryBuilder.cs
+++ b/src/Ubiquity.NET.Extensions/DictionaryBuilder.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Ubiquity.NET.Extensions
 {
     /// <summary>Simple type to support direct creation of an immutable array via <see cref="ImmutableDictionary{TKey, TValue}.Builder"/></summary>

--- a/src/Ubiquity.NET.Extensions/DisposableAction.cs
+++ b/src/Ubiquity.NET.Extensions/DisposableAction.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Runtime.CompilerServices;
-using System.Threading;
-
 namespace Ubiquity.NET.Extensions
 {
     /// <summary>Disposable type that runs a specified action on dispose</summary>

--- a/src/Ubiquity.NET.Extensions/FluentValidationExtensions.cs
+++ b/src/Ubiquity.NET.Extensions/FluentValidationExtensions.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Runtime.CompilerServices;
-
 namespace Ubiquity.NET.Extensions
 {
     // This does NOT use the new C# 14 extension syntax due to several reasons

--- a/src/Ubiquity.NET.Extensions/GlobalNamespaceImports.cs
+++ b/src/Ubiquity.NET.Extensions/GlobalNamespaceImports.cs
@@ -13,33 +13,14 @@ For an explanation of the benefits of the language feature see: https://www.hans
 */
 
 global using System;
+global using System.Collections;
+global using System.Collections.Generic;
 global using System.Collections.Immutable;
+global using System.ComponentModel;
 global using System.Diagnostics;
 global using System.Diagnostics.CodeAnalysis;
 global using System.Globalization;
 global using System.IO;
-global using System.Linq;
 global using System.Reflection;
 global using System.Runtime.CompilerServices;
-global using System.Runtime.InteropServices;
-global using System.Runtime.InteropServices.Marshalling;
 global using System.Threading;
-
-global using Ubiquity.NET.Extensions;
-global using Ubiquity.NET.InteropHelpers;
-global using Ubiquity.NET.Llvm.Interop.ABI.libllvm_c;
-global using Ubiquity.NET.Llvm.Interop.ABI.llvm_c;
-global using Ubiquity.NET.Llvm.Interop.ABI.StringMarshaling;
-global using Ubiquity.NET.Llvm.Interop.Properties;
-global using Ubiquity.NET.Versioning;
-
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.OrcJITv2Bindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.TargetRegistrationBindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.ValueBindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Core;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Error;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.ErrorHandling;
-
-// global using for the NativeMethods type to allow simpler access to the
-// string const for the library name.
-global using static Ubiquity.NET.Llvm.Interop.NativeMethods;

--- a/src/Ubiquity.NET.Extensions/KvpArrayBuilder.cs
+++ b/src/Ubiquity.NET.Extensions/KvpArrayBuilder.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Ubiquity.NET.Extensions
 {
     /// <summary>Simple type to support dictionary style creation of an immutable array of KeyValue pairs via <see cref="ImmutableArray{T}.Builder"/></summary>

--- a/src/Ubiquity.NET.Extensions/MustUseReturnValueAttribute.cs
+++ b/src/Ubiquity.NET.Extensions/MustUseReturnValueAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-
 namespace Ubiquity.NET.Extensions
 {
     /// <summary>`MustUseRetVal` analyzer compatible attribute</summary>

--- a/src/Ubiquity.NET.Extensions/ProcessInfo.cs
+++ b/src/Ubiquity.NET.Extensions/ProcessInfo.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Reflection;
-
 namespace Ubiquity.NET.Extensions
 {
     /// <summary>Process related extensions/support</summary>

--- a/src/Ubiquity.NET.Extensions/SourcePosition.cs
+++ b/src/Ubiquity.NET.Extensions/SourcePosition.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Ubiquity.NET.Extensions
 {
     /// <summary>Represents a single point position in a source input</summary>

--- a/src/Ubiquity.NET.Extensions/SourceRange.cs
+++ b/src/Ubiquity.NET.Extensions/SourceRange.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-
 namespace Ubiquity.NET.Extensions
 {
     /// <summary>Abstraction to hold a source location range as a pair of <see cref="SourcePosition"/> values</summary>

--- a/src/Ubiquity.NET.Extensions/StringNormalizer.cs
+++ b/src/Ubiquity.NET.Extensions/StringNormalizer.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Ubiquity.NET.Extensions
 {
     /// <summary>The kind of line endings for a string of characters</summary>

--- a/src/Ubiquity.NET.InteropHelpers/CStringHandle.cs
+++ b/src/Ubiquity.NET.InteropHelpers/CStringHandle.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
-using System.Threading;
-
 namespace Ubiquity.NET.InteropHelpers
 {
     /// <summary>Abstract base class for types that represents a native string</summary>

--- a/src/Ubiquity.NET.InteropHelpers/EncodingExtensions.cs
+++ b/src/Ubiquity.NET.InteropHelpers/EncodingExtensions.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Runtime.InteropServices;
-using System.Text;
-
 namespace Ubiquity.NET.InteropHelpers
 {
     /// <summary>Utility extensions for the <see cref="Encoding"/> class</summary>

--- a/src/Ubiquity.NET.InteropHelpers/ExecutionEncodingStringMarshaller.cs
+++ b/src/Ubiquity.NET.InteropHelpers/ExecutionEncodingStringMarshaller.cs
@@ -1,14 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-using System.Text;
-
 namespace Ubiquity.NET.InteropHelpers
 {
     /// <summary>Represents a marshaller for native strings using <see cref="Encoding"/>.</summary>

--- a/src/Ubiquity.NET.InteropHelpers/GlobalNamespaceImports.cs
+++ b/src/Ubiquity.NET.InteropHelpers/GlobalNamespaceImports.cs
@@ -13,33 +13,17 @@ For an explanation of the benefits of the language feature see: https://www.hans
 */
 
 global using System;
-global using System.Collections.Immutable;
+global using System.Buffers;
+global using System.Collections.Generic;
 global using System.Diagnostics;
 global using System.Diagnostics.CodeAnalysis;
-global using System.Globalization;
-global using System.IO;
-global using System.Linq;
+global using System.Numerics;
 global using System.Reflection;
+global using System.Resources;
 global using System.Runtime.CompilerServices;
 global using System.Runtime.InteropServices;
 global using System.Runtime.InteropServices.Marshalling;
+global using System.Text;
 global using System.Threading;
 
 global using Ubiquity.NET.Extensions;
-global using Ubiquity.NET.InteropHelpers;
-global using Ubiquity.NET.Llvm.Interop.ABI.libllvm_c;
-global using Ubiquity.NET.Llvm.Interop.ABI.llvm_c;
-global using Ubiquity.NET.Llvm.Interop.ABI.StringMarshaling;
-global using Ubiquity.NET.Llvm.Interop.Properties;
-global using Ubiquity.NET.Versioning;
-
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.OrcJITv2Bindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.TargetRegistrationBindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.ValueBindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Core;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Error;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.ErrorHandling;
-
-// global using for the NativeMethods type to allow simpler access to the
-// string const for the library name.
-global using static Ubiquity.NET.Llvm.Interop.NativeMethods;

--- a/src/Ubiquity.NET.InteropHelpers/LazyEncodedString.cs
+++ b/src/Ubiquity.NET.InteropHelpers/LazyEncodedString.cs
@@ -1,18 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Numerics;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
-using System.Text;
-using System.Threading;
-
 namespace Ubiquity.NET.InteropHelpers
 {
     /// <summary>Lazily encoded string with implicit casting to a read only span of bytes or a normal managed string</summary>

--- a/src/Ubiquity.NET.InteropHelpers/LazyEncodedStringMarshaller.cs
+++ b/src/Ubiquity.NET.InteropHelpers/LazyEncodedStringMarshaller.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Buffers;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices.Marshalling;
-
 namespace Ubiquity.NET.InteropHelpers
 {
     /// <summary>Represents a marshaller for <see cref="LazyEncodedString"/>.</summary>

--- a/src/Ubiquity.NET.InteropHelpers/NativeContext.cs
+++ b/src/Ubiquity.NET.InteropHelpers/NativeContext.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
-
-using Ubiquity.NET.Extensions;
-
 namespace Ubiquity.NET.InteropHelpers
 {
     // This does NOT use the new C# 14 extension syntax due to several reasons

--- a/src/Ubiquity.NET.InteropHelpers/NativeLibraryHandle.cs
+++ b/src/Ubiquity.NET.InteropHelpers/NativeLibraryHandle.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
-using System.Runtime.InteropServices;
-
 namespace Ubiquity.NET.InteropHelpers
 {
     /// <summary>Safe handle for a <see cref="NativeLibrary"/></summary>

--- a/src/Ubiquity.NET.InteropHelpers/Properties/AssemblyInfo.cs
+++ b/src/Ubiquity.NET.InteropHelpers/Properties/AssemblyInfo.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Resources;
-using System.Runtime.InteropServices;
-
 // In SDK-style projects such as this one, several assembly attributes that were historically
 // defined in this file are now automatically added during build and populated with
 // values defined in project properties. For details of which attributes are included

--- a/src/Ubiquity.NET.InteropHelpers/RefHandleMarshaller.cs
+++ b/src/Ubiquity.NET.InteropHelpers/RefHandleMarshaller.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Buffers;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-
 namespace Ubiquity.NET.InteropHelpers
 {
     /// <summary>Performs custom marshalling of handle arrays as in parameters</summary>

--- a/src/Ubiquity.NET.InteropHelpers/UnexpectedNullHandleException.cs
+++ b/src/Ubiquity.NET.InteropHelpers/UnexpectedNullHandleException.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-
 namespace Ubiquity.NET.InteropHelpers
 {
     /// <summary>Exception thrown when an underlying Native API `handle` is unexpectedly <see langword="null"/></summary>

--- a/src/Ubiquity.NET.Llvm/Blake3Hash.cs
+++ b/src/Ubiquity.NET.Llvm/Blake3Hash.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Security.Cryptography;
-
 using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Blake3;
 
 namespace Ubiquity.NET.Llvm

--- a/src/Ubiquity.NET.Llvm/GlobalNamespaceImports.cs
+++ b/src/Ubiquity.NET.Llvm/GlobalNamespaceImports.cs
@@ -29,6 +29,7 @@ global using System.IO;
 global using System.Linq;
 global using System.Runtime.CompilerServices;
 global using System.Runtime.InteropServices;
+global using System.Security.Cryptography;
 global using System.Text;
 global using System.Threading;
 

--- a/src/Ubiquity.NET.Llvm/OrcJITv2/MaterializationUnit.cs
+++ b/src/Ubiquity.NET.Llvm/OrcJITv2/MaterializationUnit.cs
@@ -4,8 +4,6 @@
 // Elements ARE ordered correctly, analyzer has dumb defaults and doesn't allow override of order
 #pragma warning disable SA1202 // Elements should be ordered by access
 
-using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Orc;
-
 namespace Ubiquity.NET.Llvm.OrcJITv2
 {
     /// <summary>Abstract base class for an LLVM ORC JIT v2 Materialization Unit</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/AnonymousNameProvider.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/AnonymousNameProvider.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Provides anonymous names as a sequence of strings with an enumerated integral suffix</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/AstNode.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/AstNode.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Collections.Generic;
-
-using Ubiquity.NET.Extensions;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Common abstract base implementation of <see cref="IAstNode"/></summary>

--- a/src/Ubiquity.NET.Runtime.Utils/AstNodeExtensions.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/AstNodeExtensions.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections.Immutable;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Extensions for IAstNode</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/AstVisitorBase.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/AstVisitorBase.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <inheritdoc cref="AstVisitorBase{TResult, TArg}"/>

--- a/src/Ubiquity.NET.Runtime.Utils/CodeGeneratorException.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/CodeGeneratorException.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Exception to represent an error in the code generation of a DSL</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/ErrorNode.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/ErrorNode.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using Ubiquity.NET.CommandLine;
-using Ubiquity.NET.Extensions;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Represents an IAstNode where an error occurred in the parse</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/ErrorNodeCollector.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/ErrorNodeCollector.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Collections.Immutable;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>AST visitor that collects all errors for a given node</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/GlobalNamespaceImports.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/GlobalNamespaceImports.cs
@@ -13,33 +13,21 @@ For an explanation of the benefits of the language feature see: https://www.hans
 */
 
 global using System;
+global using System.CodeDom.Compiler;
+global using System.Collections;
+global using System.Collections.Generic;
 global using System.Collections.Immutable;
-global using System.Diagnostics;
 global using System.Diagnostics.CodeAnalysis;
 global using System.Globalization;
 global using System.IO;
 global using System.Linq;
-global using System.Reflection;
 global using System.Runtime.CompilerServices;
-global using System.Runtime.InteropServices;
-global using System.Runtime.InteropServices.Marshalling;
+global using System.Text;
 global using System.Threading;
+global using System.Threading.Tasks;
+global using System.Xml.Linq;
 
+global using Ubiquity.NET.CommandLine;
 global using Ubiquity.NET.Extensions;
 global using Ubiquity.NET.InteropHelpers;
-global using Ubiquity.NET.Llvm.Interop.ABI.libllvm_c;
-global using Ubiquity.NET.Llvm.Interop.ABI.llvm_c;
-global using Ubiquity.NET.Llvm.Interop.ABI.StringMarshaling;
-global using Ubiquity.NET.Llvm.Interop.Properties;
-global using Ubiquity.NET.Versioning;
-
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.OrcJITv2Bindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.TargetRegistrationBindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.ValueBindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Core;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Error;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.ErrorHandling;
-
-// global using for the NativeMethods type to allow simpler access to the
-// string const for the library name.
-global using static Ubiquity.NET.Llvm.Interop.NativeMethods;
+global using Ubiquity.NET.SrcGeneration.CSharp;

--- a/src/Ubiquity.NET.Runtime.Utils/IAstNode.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/IAstNode.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Collections.Generic;
-
-using Ubiquity.NET.Extensions;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Root interface for nodes in the Abstract Syntax Tree</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/ICodeGenerator.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/ICodeGenerator.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Interface for a Kaleidoscope code generator</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/IParseErrorReporter.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/IParseErrorReporter.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Interface for a logger of parse errors</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/IParser.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/IParser.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.IO;
-
 // CONSIDER: Adaptation that accepts IParsesErrorReporter as a param argument to the parse APIs instead of relying on
 //           an implementation to "hold" one.
 

--- a/src/Ubiquity.NET.Runtime.Utils/IVisualizer.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/IVisualizer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.Xml.Linq;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Interface to process the results of a parse for "visualization"</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/NullNode.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/NullNode.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Threading;
-
-using Ubiquity.NET.Extensions;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Null Object pattern implementation for AST Nodes</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/ParseErrorCollector.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/ParseErrorCollector.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections.Immutable;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Implementation of <see cref="IParseErrorListener"/> to collect any errors that occur during a parse</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/ParseErrorDiagnosticAdapter.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/ParseErrorDiagnosticAdapter.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Globalization;
-
-using Ubiquity.NET.CommandLine;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Adapter to redirect calls to <see cref="IParseErrorReporter"/> to a given <see cref="IDiagnosticReporter"/></summary>

--- a/src/Ubiquity.NET.Runtime.Utils/REPLBase.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/REPLBase.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Common core implementation of a Read, Evaluate, Print Loop (REPL)</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/ReadyStateManager.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/ReadyStateManager.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Defines state for the UI for REPL parsing to show a prompt to the user</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/ScopeStack.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/ScopeStack.cs
@@ -1,18 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.CodeDom.Compiler;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.IO;
-using System.Text;
-
-using Ubiquity.NET.Extensions;
-using Ubiquity.NET.InteropHelpers;
-using Ubiquity.NET.SrcGeneration.CSharp;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Simple implementation of common Variable scoping</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/SyntaxError.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/SyntaxError.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-
-using Ubiquity.NET.Extensions;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Enumeration to indicate the source of an error during parse</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/TextReaderExtensions.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/TextReaderExtensions.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Utility class to provide extensions for REPL Loop and other scenarios requiring Async processing of text input</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/Utilities.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/Utilities.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Text;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Utility class to provide general functionality that would be "free standing" functions if allowed in the C# language</summary>

--- a/src/Ubiquity.NET.Runtime.Utils/VisualizationKind.cs
+++ b/src/Ubiquity.NET.Runtime.Utils/VisualizationKind.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-
 namespace Ubiquity.NET.Runtime.Utils
 {
     /// <summary>Enumeration to define the kinds of diagnostic intermediate data to generate from a runtime/language AST</summary>

--- a/src/Ubiquity.NET.SrcGeneration/CSharp/CSharpLanguage.cs
+++ b/src/Ubiquity.NET.SrcGeneration/CSharp/CSharpLanguage.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections.Immutable;
-
 namespace Ubiquity.NET.SrcGeneration.CSharp
 {
     /// <summary>Support for generating source files in the C# language</summary>
@@ -104,9 +101,12 @@ namespace Ubiquity.NET.SrcGeneration.CSharp
         {
             ArgumentNullException.ThrowIfNull( self );
 
+            // always replace invalid characters
+            // TODO: more sophisticated Regex that matches anything NOT a valid identifier char
+            string retVal = self.Replace( " ", "_", StringComparison.Ordinal );
             return KeyWords.Contains( self )
-                    ? $"@{self}"
-                    : self.Replace( " ", "_", StringComparison.Ordinal );
+                    ? $"@{retVal}"
+                    : retVal;
         }
     }
 }

--- a/src/Ubiquity.NET.SrcGeneration/CSharp/IndentedTextWriterCsExtensions.cs
+++ b/src/Ubiquity.NET.SrcGeneration/CSharp/IndentedTextWriterCsExtensions.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.CodeDom.Compiler;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Ubiquity.NET.SrcGeneration.CSharp
 {
     /// <summary>Extensions to <see cref="IndentedTextWriter"/> to support C# source generation</summary>

--- a/src/Ubiquity.NET.SrcGeneration/CSharp/TextWriterCsExtension.cs
+++ b/src/Ubiquity.NET.SrcGeneration/CSharp/TextWriterCsExtension.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-
 namespace Ubiquity.NET.SrcGeneration.CSharp
 {
     /// <summary>Utility extensions for a <see cref="TextWriter"/> specific to the C# language</summary>

--- a/src/Ubiquity.NET.SrcGeneration/GlobalNamespaceImports.cs
+++ b/src/Ubiquity.NET.SrcGeneration/GlobalNamespaceImports.cs
@@ -13,33 +13,12 @@ For an explanation of the benefits of the language feature see: https://www.hans
 */
 
 global using System;
+global using System.CodeDom.Compiler;
+global using System.Collections.Generic;
 global using System.Collections.Immutable;
-global using System.Diagnostics;
 global using System.Diagnostics.CodeAnalysis;
-global using System.Globalization;
 global using System.IO;
 global using System.Linq;
-global using System.Reflection;
-global using System.Runtime.CompilerServices;
-global using System.Runtime.InteropServices;
-global using System.Runtime.InteropServices.Marshalling;
-global using System.Threading;
+global using System.Xml.Linq;
 
 global using Ubiquity.NET.Extensions;
-global using Ubiquity.NET.InteropHelpers;
-global using Ubiquity.NET.Llvm.Interop.ABI.libllvm_c;
-global using Ubiquity.NET.Llvm.Interop.ABI.llvm_c;
-global using Ubiquity.NET.Llvm.Interop.ABI.StringMarshaling;
-global using Ubiquity.NET.Llvm.Interop.Properties;
-global using Ubiquity.NET.Versioning;
-
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.OrcJITv2Bindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.TargetRegistrationBindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.libllvm_c.ValueBindings;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Core;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.Error;
-global using static Ubiquity.NET.Llvm.Interop.ABI.llvm_c.ErrorHandling;
-
-// global using for the NativeMethods type to allow simpler access to the
-// string const for the library name.
-global using static Ubiquity.NET.Llvm.Interop.NativeMethods;

--- a/src/Ubiquity.NET.SrcGeneration/IndentedTextWriterExtensions.cs
+++ b/src/Ubiquity.NET.SrcGeneration/IndentedTextWriterExtensions.cs
@@ -1,12 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.CodeDom.Compiler;
-using System.Diagnostics.CodeAnalysis;
-
-using Ubiquity.NET.Extensions;
-
 namespace Ubiquity.NET.SrcGeneration
 {
     /// <summary>Extensions to <see cref="IndentedTextWriter"/> to support C# source generation</summary>

--- a/src/Ubiquity.NET.SrcGeneration/ReadMe.md
+++ b/src/Ubiquity.NET.SrcGeneration/ReadMe.md
@@ -68,7 +68,7 @@ While other languages are possible this is the only one currently "built-in".
 * `TextWriterCsExtension` to provide more extensions to a `TextWriter` that are specific to
   the C# language.
     * Method to write an attribute line
-    * Method to write (without new line) and attribute
+    * Method to write (without new line) an attribute
     * Method to write an XML Doc comment `summary` tag.
     * Method to write an XML Doc comment `remarks` tag.
     * Method to write an XML Doc comment `summary` and  `remarks` tags with optional default

--- a/src/Ubiquity.NET.SrcGeneration/StringExtensions.cs
+++ b/src/Ubiquity.NET.SrcGeneration/StringExtensions.cs
@@ -1,14 +1,6 @@
 ﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Xml.Linq;
-
-using Ubiquity.NET.Extensions;
-
 namespace Ubiquity.NET.SrcGeneration
 {
     // TODO: What version of the language?


### PR DESCRIPTION
Added use of global imports to all projects
- The MSBuild `ImplicitUsings` is banned but the C# language of `global using` is not. This updates projects to use the C# feature without the MSBuild problems.
* Additional doc updates.