### PR TITLE
Remove partial keyword manually added to generated resource

### DIFF
--- a/src/Ubiquity.NET.Extensions/Properties/Resources.Designer.cs
+++ b/src/Ubiquity.NET.Extensions/Properties/Resources.Designer.cs
@@ -19,10 +19,10 @@ namespace Ubiquity.NET.Extensions.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal partial class Resources {
+    internal class Resources {
         
         private static global::System.Resources.ResourceManager resourceMan;
         


### PR DESCRIPTION
Remove partial keyword manually added to generated resource
* This isn't needed as `extension` keyword is useable for that even down level
   - Though the generated sources should use a `partial` class to allow extensions without the newer keyword (Kinda what `partial` was invented for!)