### PR TITLE
Enabled SidexSide support for multiple VS instances

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,6 +5,6 @@
         "allowPrerelease": false
     },
     "msbuild-sdks": {
-        "Microsoft.Build.NoTargets": "3.7.56"
+        "Microsoft.Build.NoTargets": "3.7.134"
     }
 }


### PR DESCRIPTION
Enabled SidexSide support for multiple VS instances
- Now that VS 2026 is released it's not a pre-release so is found by `vswhere` calls in the PowerShell script. The scripts assume only one instance is found so would choke when multiple were found.
    - Solution was to add `-latest` to `vswhere` calls
* Updated version of `Microsoft.Build.NoTargets`