### PR TITLE
Removed all forward language and runtime versioning

### DIFF
--- a/src/Interop/InteropTests/Ubiquity.NET.Llvm.Interop.UT.csproj
+++ b/src/Interop/InteropTests/Ubiquity.NET.Llvm.Interop.UT.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <!--Until C#14 and the "field" and "extension" keywords are available use the preview language -->
-        <LangVersion>preview</LangVersion>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/Interop/LlvmBindingsGenerator/Configuration/HandleDetails.cs
+++ b/src/Interop/LlvmBindingsGenerator/Configuration/HandleDetails.cs
@@ -24,6 +24,7 @@ namespace LlvmBindingsGenerator.Configuration
         /// <summary>Gets the name of the disposer for the handle (if any)</summary>
         public string? Disposer { get; init; }
 
+#if NET9_0_OR_GREATER
         /// <summary>Gets a value indicating whether this handle has an alias type</summary>
         /// <remarks>
         /// If <see cref="Disposer"/> is <see langword="null"/> or all whitespace then the return is always <see langword="false"/> [Ignoring
@@ -34,5 +35,19 @@ namespace LlvmBindingsGenerator.Configuration
             get => !string.IsNullOrWhiteSpace(Disposer) && (field);
             init;
         }
+#else
+        /// <summary>Gets a value indicating whether this handle has an alias type</summary>
+        /// <remarks>
+        /// If <see cref="Disposer"/> is <see langword="null"/> or all whitespace then the return is always <see langword="false"/> [Ignoring
+        /// any value it is initialized with]
+        /// </remarks>
+        public bool Alias
+        {
+            get => !string.IsNullOrWhiteSpace( Disposer ) && (AliasBackingField);
+            init => AliasBackingField = value;
+        }
+
+        private readonly bool AliasBackingField;
+#endif
     }
 }

--- a/src/Interop/LlvmBindingsGenerator/LlvmBindingsGenerator.csproj
+++ b/src/Interop/LlvmBindingsGenerator/LlvmBindingsGenerator.csproj
@@ -5,8 +5,6 @@
         <!-- Dependent library (CppSharp) ONLY supports x64 targets -->
         <PlatformTarget>x64</PlatformTarget>
         <TargetFramework>net8.0</TargetFramework>
-        <!--Until C#14 and the "field" and "extension" keywords are available use the preview language -->
-        <LangVersion>preview</LangVersion>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
         <SignAssembly>False</SignAssembly>

--- a/src/Interop/Ubiquity.NET.Llvm.Interop/Ubiquity.NET.Llvm.Interop.csproj
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/Ubiquity.NET.Llvm.Interop.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <!--Until C#14 and the "field" and "extension" keywords are available use the preview language -->
-        <LangVersion>preview</LangVersion>
         <Nullable>enable</Nullable>
 
         <!-- TODO: additional RIDs as supported in native library -->

--- a/src/Samples/CodeGenWithDebugInfo/CodeGenWithDebugInfo.csproj
+++ b/src/Samples/CodeGenWithDebugInfo/CodeGenWithDebugInfo.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <OutputType>exe</OutputType>
         <OutputTypeEx>exe</OutputTypeEx>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/src/Samples/Kaleidoscope/Chapter2/Chapter2.csproj
+++ b/src/Samples/Kaleidoscope/Chapter2/Chapter2.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <AssemblyName>kls2</AssemblyName>
         <RootNamespace>Kaleidoscope</RootNamespace>
         <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Samples/Kaleidoscope/Chapter3.5/Chapter3.5.csproj
+++ b/src/Samples/Kaleidoscope/Chapter3.5/Chapter3.5.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <AssemblyName>kls3.5</AssemblyName>
         <RootNamespace>Kaleidoscope</RootNamespace>
         <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Samples/Kaleidoscope/Chapter3/Chapter3.csproj
+++ b/src/Samples/Kaleidoscope/Chapter3/Chapter3.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <AssemblyName>kls3</AssemblyName>
         <RootNamespace>Kaleidoscope</RootNamespace>
         <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Samples/Kaleidoscope/Chapter4/Chapter4.csproj
+++ b/src/Samples/Kaleidoscope/Chapter4/Chapter4.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <AssemblyName>kls4</AssemblyName>
         <RootNamespace>Kaleidoscope</RootNamespace>
         <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Samples/Kaleidoscope/Chapter5/Chapter5.csproj
+++ b/src/Samples/Kaleidoscope/Chapter5/Chapter5.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <AssemblyName>kls5</AssemblyName>
         <RootNamespace>Kaleidoscope</RootNamespace>
         <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Samples/Kaleidoscope/Chapter6/Chapter6.csproj
+++ b/src/Samples/Kaleidoscope/Chapter6/Chapter6.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <AssemblyName>kls6</AssemblyName>
         <RootNamespace>Kaleidoscope</RootNamespace>
         <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Samples/Kaleidoscope/Chapter7.1/Chapter7.1.csproj
+++ b/src/Samples/Kaleidoscope/Chapter7.1/Chapter7.1.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <AssemblyName>kls7.1</AssemblyName>
         <RootNamespace>Kaleidoscope</RootNamespace>
         <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Samples/Kaleidoscope/Chapter7/Chapter7.csproj
+++ b/src/Samples/Kaleidoscope/Chapter7/Chapter7.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <AssemblyName>kls7</AssemblyName>
         <RootNamespace>Kaleidoscope</RootNamespace>
         <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Samples/Kaleidoscope/Chapter8/Chapter8.csproj
+++ b/src/Samples/Kaleidoscope/Chapter8/Chapter8.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <AssemblyName>kls8</AssemblyName>
         <RootNamespace>Kaleidoscope</RootNamespace>
         <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Samples/Kaleidoscope/Chapter9/Chapter9.csproj
+++ b/src/Samples/Kaleidoscope/Chapter9/Chapter9.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <AssemblyName>kls9</AssemblyName>
         <RootNamespace>Kaleidoscope</RootNamespace>
         <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/AST/FunctionCallExpression.cs
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/AST/FunctionCallExpression.cs
@@ -14,12 +14,27 @@ namespace Kaleidoscope.Grammar.AST
         : AstNode
         , IExpression
     {
+#if !NET9_0_OR_GREATER
         /// <summary>Initializes a new instance of the <see cref="FunctionCallExpression"/> class.</summary>
         /// <param name="location">Location of the node in the source input</param>
         /// <param name="functionPrototype">Prototype of the function to call</param>
         /// <param name="args">Arguments to provide to the function</param>
+        public FunctionCallExpression( SourceRange location, Prototype functionPrototype, params IExpression[] args )
+            : this(location, functionPrototype, (IEnumerable<IExpression>)args)
+        {
+        }
+#endif
+
+        /// <summary>Initializes a new instance of the <see cref="FunctionCallExpression"/> class.</summary>
+        /// <param name="location">Location of the node in the source input</param>
+        /// <param name="functionPrototype">Prototype of the function to call</param>
+        /// <param name="args">Arguments to provide to the function</param>
+#if NET9_0_OR_GREATER
         public FunctionCallExpression( SourceRange location, Prototype functionPrototype, params IEnumerable<IExpression> args )
-            : base( location )
+#else
+        public FunctionCallExpression( SourceRange location, Prototype functionPrototype, IEnumerable<IExpression> args )
+#endif
+    : base( location )
         {
             FunctionPrototype = functionPrototype;
             Arguments = [ .. args ];

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/Kaleidoscope.Grammar.csproj
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Grammar/Kaleidoscope.Grammar.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ForceAntlr4GeneratedCodeInternal>true</ForceAntlr4GeneratedCodeInternal>
         <IsAotCompatible>True</IsAotCompatible>

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Runtime/Kaleidoscope.Runtime.csproj
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Runtime/Kaleidoscope.Runtime.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <IsAotCompatible>True</IsAotCompatible>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Tests/BasicTests.cs
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Tests/BasicTests.cs
@@ -37,7 +37,7 @@ namespace Kaleidoscope.Tests
             var parser = new Parser( LanguageLevel.MutableVariables );
 
             // Create sequence of parsed AST nodes to feed the loop
-            var nodes = from stmt in rdr.ToStatements( _=>{ }, RuntimeContext.CancellationTokenSource.Token )
+            var nodes = from stmt in rdr.ToStatements( _=>{ }, RuntimeContext.CancellationToken )
                         select parser.Parse( stmt );
 
             // Read, Parse, Print loop

--- a/src/Samples/Kaleidoscope/Kaleidoscope.Tests/Kaleidoscope.Tests.csproj
+++ b/src/Samples/Kaleidoscope/Kaleidoscope.Tests/Kaleidoscope.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/Samples/OrcV2VeryLazy/OrcV2VeryLazy.csproj
+++ b/src/Samples/OrcV2VeryLazy/OrcV2VeryLazy.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <Nullable>enable</Nullable>
         <PublishAot>true</PublishAot>
         <InvariantGlobalization>true</InvariantGlobalization>

--- a/src/Ubiquity.NET.Llvm.JIT.Tests/OrcJitTests.cs
+++ b/src/Ubiquity.NET.Llvm.JIT.Tests/OrcJitTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/Ubiquity.NET.Llvm.JIT.Tests/Ubiquity.NET.Llvm.JIT.Tests.csproj
+++ b/src/Ubiquity.NET.Llvm.JIT.Tests/Ubiquity.NET.Llvm.JIT.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <IsPackable>false</IsPackable>
         <RunSettingsFilePath>$(BuildRootDir)\src\x64.runsettings</RunSettingsFilePath>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/Ubiquity.NET.Llvm.Tests/ModuleTests.cs
+++ b/src/Ubiquity.NET.Llvm.Tests/ModuleTests.cs
@@ -492,6 +492,7 @@ namespace Ubiquity.NET.Llvm.UT
 
             var clonedGlobal = clone.GetNamedGlobal( globalName );
             Assert.IsNotNull( clonedGlobal );
+            Assert.IsNotNull( clonedGlobal.Comdat );
             Assert.IsFalse( clonedGlobal.Comdat.IsNull );
 
             Assert.AreEqual( globalName, clonedGlobal.Comdat!.Name, "Name of the comdat on the cloned global should match the one set in the original module" );
@@ -529,6 +530,7 @@ namespace Ubiquity.NET.Llvm.UT
 
             Assert.IsTrue( clone.TryGetFunction( globalName, out Function? clonedGlobal ) );
             Assert.IsNotNull( clonedGlobal );
+            Assert.IsNotNull( clonedGlobal.Comdat );
             Assert.IsFalse( clonedGlobal.Comdat.IsNull );
             Assert.AreEqual( globalName, clonedGlobal.Comdat!.Name, "Name of the comdat on the cloned global should match the one set in the original module" );
             Assert.AreEqual( ComdatKind.Any, module.Comdats[ globalName ].Kind );

--- a/src/Ubiquity.NET.Llvm.Tests/TestObjectFile.cs
+++ b/src/Ubiquity.NET.Llvm.Tests/TestObjectFile.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -28,6 +29,7 @@ namespace Ubiquity.NET.Llvm.UT
         private const string TestObjFileName = "TestObjectFile.o";
         private const string TestSrcFileName = "test.c";
 
+        [SuppressMessage("Maintainability", "CA1506: Avoid excessive class coupling", Justification = "test class")]
         [ClassInitialize]
         public static void Initialize( TestContext ctx )
         {
@@ -150,7 +152,7 @@ namespace Ubiquity.NET.Llvm.UT
         }
 
         private static InstructionBuilder CreateFunctionAndGetBuilder(
-            IDIBuilder diBuilder,
+            DIBuilder diBuilder,
             Module module,
             DebugBasicType doubleType,
             LazyEncodedString name,

--- a/src/Ubiquity.NET.Llvm.Tests/Ubiquity.NET.Llvm.UT.csproj
+++ b/src/Ubiquity.NET.Llvm.Tests/Ubiquity.NET.Llvm.UT.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>13</LangVersion>
         <IsPackable>false</IsPackable>
         <RunSettingsFilePath>$(BuildRootDir)\src\x64.runsettings</RunSettingsFilePath>
     </PropertyGroup>

--- a/src/Ubiquity.NET.Llvm.slnx
+++ b/src/Ubiquity.NET.Llvm.slnx
@@ -72,6 +72,7 @@
   </Folder>
   <Folder Name="/Tests/">
     <Project Path="Analyzers/RepositoryVerifier.UT/RepositoryVerifier.UT.csproj" />
+    <Project Path="Interop/InteropTests/Ubiquity.NET.Llvm.Interop.UT.csproj" />
     <Project Path="Samples/Kaleidoscope/Kaleidoscope.Tests/Kaleidoscope.Tests.csproj" />
     <Project Path="Ubiquity.NET.Llvm.JIT.Tests/Ubiquity.NET.Llvm.JIT.Tests.csproj" />
     <Project Path="Ubiquity.NET.Llvm.Tests/Ubiquity.NET.Llvm.UT.csproj" />

--- a/src/Ubiquity.NET.Llvm/Comdat.cs
+++ b/src/Ubiquity.NET.Llvm/Comdat.cs
@@ -32,12 +32,7 @@ namespace Ubiquity.NET.Llvm
     /// Comdats it owns are invalidated. Using a Comdat instance after the module is disposed results in
     /// an effective NOP.
     /// </remarks>
-    [SuppressMessage( "Style", "IDE0250:Make struct 'readonly'", Justification = "NO, it can't be, the Kind setter is NOT readonly" )]
-#if NET9_0_OR_GREATER
-    public readonly ref struct Comdat // IEquatabe<T> only supports ref struct in .NET 9.0 or greater
-#else
-    public readonly struct Comdat
-#endif
+    public class Comdat
         : IEquatable<Comdat>
     {
         /// <summary>Gets the name of the <see cref="Comdat"/></summary>
@@ -46,7 +41,7 @@ namespace Ubiquity.NET.Llvm
         #region IEquatable<Comdat>
 
         /// <inheritdoc/>
-        public bool Equals( Comdat other ) => Handle.Equals( other.Handle );
+        public bool Equals( Comdat? other ) => other is not null && Handle.Equals( other.Handle );
 
         /// <inheritdoc/>
         public override int GetHashCode( ) => Handle.GetHashCode();
@@ -67,7 +62,7 @@ namespace Ubiquity.NET.Llvm
         /// <param name="left">Left side of comparison</param>
         /// <param name="right">Right side of comparison</param>
         /// <returns><see langword="true"/> if <paramref name="left"/> is not equal to <paramref name="right"/></returns>
-        public static bool operator !=( Comdat left, Comdat right ) => !(left == right);
+        public static bool operator !=( Comdat left, Comdat right ) => !left.Equals( right );
         #endregion
 
         /// <summary>Gets a value indicating whether this instance represents a NULL/Invalid <see cref="Comdat"/></summary>

--- a/src/Ubiquity.NET.Llvm/ComdatCollection.cs
+++ b/src/Ubiquity.NET.Llvm/ComdatCollection.cs
@@ -7,14 +7,15 @@ namespace Ubiquity.NET.Llvm
 {
     /// <summary>Collection of Comdats in a module</summary>
     /// <remarks>
-    /// This is a 'ref struct' to ensure that ownership of the collection
-    /// remains with the module itself and this is only used to iterate
-    /// over the individual items. It is not allowed to store this as it
-    /// references the owning module and ultimately the Comdat values themselves
-    /// are owned in the native code layer and only "projected" to managed
-    /// here.
+    /// This is would ideally be a 'ref struct' to ensure that ownership of the
+    /// collection remains with the module itself and this is only used to iterate
+    /// over the individual items. Unfortunately the support for that is not available
+    /// in all runtimes and not supported fully in the ecosystem of tools yet. It is
+    /// not allowed to store this as it references the owning module and ultimately the
+    /// Comdat values themselves are owned in the native code layer and only "projected"
+    /// to managed here.
     /// </remarks>
-    public readonly ref struct ComdatCollection
+    public sealed class ComdatCollection
         : IEnumerable<Comdat>
     {
         /// <summary>Gets a count of comdats in the associated module</summary>
@@ -80,7 +81,7 @@ namespace Ubiquity.NET.Llvm
 
             WithGlobalObjects( go =>
             {
-                if(!go.Comdat.IsNull && go.Comdat.Name == key)
+                if(!(go.Comdat is null || go.Comdat.IsNull) && go.Comdat.Name == key)
                 {
                     go.Comdat = default;
                 }

--- a/src/Ubiquity.NET.Llvm/Context.cs
+++ b/src/Ubiquity.NET.Llvm/Context.cs
@@ -80,34 +80,77 @@ namespace Ubiquity.NET.Llvm
         /// <inheritdoc/>
         public ITypeRef GetIntType( uint bitWidth ) => Impl.GetIntType( bitWidth );
 
+#if NET9_0_OR_GREATER
         /// <inheritdoc/>
         public IFunctionType GetFunctionType( ITypeRef returnType, params IEnumerable<ITypeRef> args ) => Impl.GetFunctionType( returnType, args );
+#else
 
         /// <inheritdoc/>
-        public IFunctionType GetFunctionType( bool isVarArgs, ITypeRef returnType, params IEnumerable<ITypeRef> args ) => Impl.GetFunctionType( isVarArgs, returnType, args );
+        public IFunctionType GetFunctionType( ITypeRef returnType, IEnumerable<ITypeRef> args ) => Impl.GetFunctionType( returnType, args );
+#endif
 
+#if NET9_0_OR_GREATER
+        /// <inheritdoc/>
+        public IFunctionType GetFunctionType( bool isVarArgs, ITypeRef returnType, params IEnumerable<ITypeRef> args ) => Impl.GetFunctionType( isVarArgs, returnType, args );
+#else
+        /// <inheritdoc/>
+        public IFunctionType GetFunctionType( bool isVarArgs, ITypeRef returnType, IEnumerable<ITypeRef> args ) => Impl.GetFunctionType( isVarArgs, returnType, args );
+#endif
+
+#if NET9_0_OR_GREATER
         /// <inheritdoc/>
         public DebugFunctionType CreateFunctionType( IDIBuilder diBuilder, IDebugType<ITypeRef, DIType> retType, params IEnumerable<IDebugType<ITypeRef, DIType>> argTypes )
             => Impl.CreateFunctionType( diBuilder, retType, argTypes );
+#else
+        /// <inheritdoc/>
+        public DebugFunctionType CreateFunctionType( IDIBuilder diBuilder, IDebugType<ITypeRef, DIType> retType, IEnumerable<IDebugType<ITypeRef, DIType>> argTypes )
+            => Impl.CreateFunctionType( diBuilder, retType, argTypes );
+#endif
 
+#if NET9_0_OR_GREATER
         /// <inheritdoc/>
         public DebugFunctionType CreateFunctionType( IDIBuilder diBuilder, bool isVarArg, IDebugType<ITypeRef, DIType> retType, params IEnumerable<IDebugType<ITypeRef, DIType>> argTypes )
             => Impl.CreateFunctionType( diBuilder, isVarArg, retType, argTypes );
+#else
+        /// <inheritdoc/>
+        public DebugFunctionType CreateFunctionType( IDIBuilder diBuilder, bool isVarArg, IDebugType<ITypeRef, DIType> retType, IEnumerable<IDebugType<ITypeRef, DIType>> argTypes )
+            => Impl.CreateFunctionType( diBuilder, isVarArg, retType, argTypes );
+#endif
 
+#if NET9_0_OR_GREATER
         /// <inheritdoc/>
         public Constant CreateConstantStruct( bool packed, params IEnumerable<Constant> values ) => Impl.CreateConstantStruct( packed, values );
+#else
+        /// <inheritdoc/>
+        public Constant CreateConstantStruct( bool packed, IEnumerable<Constant> values ) => Impl.CreateConstantStruct( packed, values );
+#endif
 
+#if NET9_0_OR_GREATER
         /// <inheritdoc/>
         public Constant CreateNamedConstantStruct( IStructType type, params IEnumerable<Constant> values ) => Impl.CreateNamedConstantStruct( type, values );
+#else
+        /// <inheritdoc/>
+        public Constant CreateNamedConstantStruct( IStructType type, IEnumerable<Constant> values ) => Impl.CreateNamedConstantStruct( type, values );
+#endif
 
         /// <inheritdoc/>
         public IStructType CreateStructType( LazyEncodedString name ) => Impl.CreateStructType( name );
 
+#if NET9_0_OR_GREATER
         /// <inheritdoc/>
         public IStructType CreateStructType( bool packed, params IEnumerable<ITypeRef> elements ) => Impl.CreateStructType( packed, elements );
+#else
+        /// <inheritdoc/>
+        public IStructType CreateStructType( bool packed, params ITypeRef[] elements ) => Impl.CreateStructType( packed, elements );
+#endif
 
+#if NET9_0_OR_GREATER
         /// <inheritdoc/>
         public IStructType CreateStructType( LazyEncodedString name, bool packed, params IEnumerable<ITypeRef> elements ) => Impl.CreateStructType( name, packed, elements );
+#else
+        /// <inheritdoc/>
+        public IStructType CreateStructType( LazyEncodedString name, bool packed, params ITypeRef[] elements ) => Impl.CreateStructType( name, packed, elements );
+#endif
 
         /// <inheritdoc/>
         public MDString CreateMetadataString( LazyEncodedString? value ) => Impl.CreateMetadataString( value );
@@ -252,7 +295,7 @@ namespace Ubiquity.NET.Llvm
             get => Impl.DiscardValueNames;
             set => Impl.DiscardValueNames = value;
         }
-        #endregion
+#endregion
 
         /// <summary>Gets a value indicating whether this instance is already disposed</summary>
         public bool IsDisposed => Handle.IsNull;
@@ -284,7 +327,11 @@ namespace Ubiquity.NET.Llvm
             Handle = h;
 
             // Create the implementation from this handle
+#if NET10_0_OR_GREATER
             Impl = new( LLVMContextRef.FromABI(Handle ) );
+#else
+            ImplBackingField = new( LLVMContextRef.FromABI( Handle ) );
+#endif
         }
 
         [SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP008:Don't assign member with injected and created disposables", Justification = "Constructor uses move semantics")]
@@ -296,6 +343,7 @@ namespace Ubiquity.NET.Llvm
             Handle = default;
         }
 
+#if NET10_0_OR_GREATER
         private ContextAlias Impl
         {
             get
@@ -304,5 +352,17 @@ namespace Ubiquity.NET.Llvm
                 return field;
             }
         }
+#else
+        private ContextAlias Impl
+        {
+            get
+            {
+                ObjectDisposedException.ThrowIf( IsDisposed, this );
+                return ImplBackingField;
+            }
+        }
+
+        private readonly ContextAlias ImplBackingField;
+#endif
     }
 }

--- a/src/Ubiquity.NET.Llvm/ContextAlias.cs
+++ b/src/Ubiquity.NET.Llvm/ContextAlias.cs
@@ -176,12 +176,20 @@ namespace Ubiquity.NET.Llvm
             };
         }
 
+#if NET9_0_OR_GREATER
         public IFunctionType GetFunctionType( ITypeRef returnType, params IEnumerable<ITypeRef> args )
+#else
+        public IFunctionType GetFunctionType( ITypeRef returnType, IEnumerable<ITypeRef> args )
+#endif
         {
             return GetFunctionType( isVarArgs: false, returnType, args );
         }
 
+#if NET9_0_OR_GREATER
         public IFunctionType GetFunctionType( bool isVarArgs, ITypeRef returnType, params IEnumerable<ITypeRef> args )
+#else
+        public IFunctionType GetFunctionType( bool isVarArgs, ITypeRef returnType, IEnumerable<ITypeRef> args )
+#endif
         {
             ArgumentNullException.ThrowIfNull( returnType );
             ArgumentNullException.ThrowIfNull( args );
@@ -221,11 +229,19 @@ namespace Ubiquity.NET.Llvm
             return CreateFunctionType( diBuilder, isVarArg, retType, (IEnumerable<IDebugType<ITypeRef, DIType>>)argTypes );
         }
 
+#if NET9_0_OR_GREATER
         public DebugFunctionType CreateFunctionType( IDIBuilder diBuilder
                                                    , bool isVarArg
                                                    , IDebugType<ITypeRef, DIType> retType
                                                    , params IEnumerable<IDebugType<ITypeRef, DIType>> argTypes
                                                    )
+#else
+        public DebugFunctionType CreateFunctionType( IDIBuilder diBuilder
+                                                   , bool isVarArg
+                                                   , IDebugType<ITypeRef, DIType> retType
+                                                   , IEnumerable<IDebugType<ITypeRef, DIType>> argTypes
+                                                   )
+#endif
         {
             ArgumentNullException.ThrowIfNull( retType );
             ArgumentNullException.ThrowIfNull( argTypes );
@@ -269,7 +285,11 @@ namespace Ubiquity.NET.Llvm
             return new DebugFunctionType( llvmType, diBuilder, DebugInfoFlags.None, retType, argTypes );
         }
 
+#if NET9_0_OR_GREATER
         public Constant CreateConstantStruct( bool packed, params IEnumerable<Constant> values )
+#else
+        public Constant CreateConstantStruct( bool packed, IEnumerable<Constant> values )
+#endif
         {
             ArgumentNullException.ThrowIfNull( values );
 
@@ -283,7 +303,11 @@ namespace Ubiquity.NET.Llvm
             return CreateNamedConstantStruct( type, (IEnumerable<Constant>)values );
         }
 
+#if NET9_0_OR_GREATER
         public Constant CreateNamedConstantStruct( IStructType type, params IEnumerable<Constant> values )
+#else
+        public Constant CreateNamedConstantStruct( IStructType type, IEnumerable<Constant> values )
+#endif
         {
             ArgumentNullException.ThrowIfNull( type );
             ArgumentNullException.ThrowIfNull( values );
@@ -332,7 +356,11 @@ namespace Ubiquity.NET.Llvm
             return (IStructType)handle.CreateType();
         }
 
+#if NET9_0_OR_GREATER
         public IStructType CreateStructType( bool packed, params IEnumerable<ITypeRef> elements )
+#else
+        public IStructType CreateStructType( bool packed, params ITypeRef[] elements )
+#endif
         {
             ArgumentNullException.ThrowIfNull( elements );
 
@@ -341,7 +369,11 @@ namespace Ubiquity.NET.Llvm
             return (IStructType)handle.CreateType();
         }
 
+#if NET9_0_OR_GREATER
         public IStructType CreateStructType( LazyEncodedString name, bool packed, params IEnumerable<ITypeRef> elements )
+#else
+        public IStructType CreateStructType( LazyEncodedString name, bool packed, params ITypeRef[] elements )
+#endif
         {
             ArgumentNullException.ThrowIfNull( name );
             ArgumentNullException.ThrowIfNull( elements );

--- a/src/Ubiquity.NET.Llvm/DataLayout.cs
+++ b/src/Ubiquity.NET.Llvm/DataLayout.cs
@@ -163,7 +163,11 @@ namespace Ubiquity.NET.Llvm
 
             // Implementation is an alias handle, which is a value type that is
             // essentially a "typedef" for the opaque handle [nint, (void*)]
+#if NET10_0_OR_GREATER
             Impl = new( Handle );
+#else
+            ImplBackingField = new( Handle );
+#endif
         }
 
         internal LLVMTargetDataRef Handle { get; private set; }
@@ -174,6 +178,7 @@ namespace Ubiquity.NET.Llvm
             Handle = default;
         }
 
+#if NET10_0_OR_GREATER
         private DataLayoutAlias Impl
         {
             get
@@ -184,5 +189,17 @@ namespace Ubiquity.NET.Llvm
 
             set;
         }
+#else
+        private DataLayoutAlias Impl
+        {
+            get
+            {
+                ObjectDisposedException.ThrowIf( IsDisposed, this );
+                return ImplBackingField;
+            }
+        }
+
+        private readonly DataLayoutAlias ImplBackingField;
+#endif
     }
 }

--- a/src/Ubiquity.NET.Llvm/DebugInfo/DIBuilder.cs
+++ b/src/Ubiquity.NET.Llvm/DebugInfo/DIBuilder.cs
@@ -292,9 +292,13 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         {
             return Impl.GetOrCreateArray( elements );
         }
-
+#if NET9_0_OR_GREATER
         /// <inheritdoc/>
         public DITypeArray GetOrCreateTypeArray( params IEnumerable<DIType> types )
+#else
+        /// <inheritdoc/>
+        public DITypeArray GetOrCreateTypeArray( IEnumerable<DIType> types )
+#endif
         {
             return Impl.GetOrCreateTypeArray( types );
         }
@@ -377,8 +381,13 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             return Impl.InsertValue( value, varInfo, expression, location, insertAtEnd );
         }
 
+#if NET9_0_OR_GREATER
         /// <inheritdoc/>
         public DIExpression CreateExpression( params IEnumerable<ExpressionOp> operations )
+#else
+        /// <inheritdoc/>
+        public DIExpression CreateExpression( IEnumerable<ExpressionOp> operations )
+#endif
         {
             return Impl.CreateExpression( operations );
         }
@@ -394,7 +403,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         {
             return Impl.CreateReplaceableCompositeType( tag, name, scope, file, line, lang, sizeInBits, alignBits, flags, uniqueId );
         }
-        #endregion
+#endregion
 
         /// <summary>Gets a value indicating whether this instance is already disposed</summary>
         public bool IsDisposed => Handle.IsNull;
@@ -409,8 +418,11 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             Handle = allowUnresolved
                    ? LLVMCreateDIBuilder( unownedModuleHandle )
                    : LLVMCreateDIBuilderDisallowUnresolved( unownedModuleHandle );
-
+#if NET10_0_OR_GREATER
             Impl = new(Handle, owningModule);
+#else
+            ImplBackingField = new( Handle, owningModule );
+#endif
         }
 
         #region IGlobalHandleOwner<LLVMDIBuilderRef> (Pattern)
@@ -424,6 +436,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             Handle = default;
         }
 
+#if NET10_0_OR_GREATER
         private DIBuilderAlias Impl
         {
             get
@@ -432,6 +445,18 @@ namespace Ubiquity.NET.Llvm.DebugInfo
                 return field;
             }
         }
-        #endregion
+#else
+        private DIBuilderAlias Impl
+        {
+            get
+            {
+                ObjectDisposedException.ThrowIf( IsDisposed, this );
+                return ImplBackingField;
+            }
+        }
+
+        private readonly DIBuilderAlias ImplBackingField;
+#endif
+#endregion
     }
 }

--- a/src/Ubiquity.NET.Llvm/DebugInfo/DIBuilderAlias.cs
+++ b/src/Ubiquity.NET.Llvm/DebugInfo/DIBuilderAlias.cs
@@ -716,9 +716,13 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             var tuple = (MDTuple) handle.CreateMetadata()!;
             return new DINodeArray( tuple );
         }
-
+#if NET9_0_OR_GREATER
         /// <inheritdoc/>
         public DITypeArray GetOrCreateTypeArray( params IEnumerable<DIType> types )
+#else
+        /// <inheritdoc/>
+        public DITypeArray GetOrCreateTypeArray( IEnumerable<DIType> types )
+#endif
         {
             var buf = types.Select( t => t?.Handle ?? default ).ToArray( );
             var handle = LLVMDIBuilderGetOrCreateTypeArray( Handle.ThrowIfInvalid(), buf );
@@ -791,7 +795,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
                                                                     , lineNo
                                                                     , type?.Handle ?? default
                                                                     , isLocalToUnit
-                                                                    , expression?.Handle ?? CreateExpression( ).Handle
+                                                                    , expression?.Handle ?? this.CreateExpression( ).Handle
                                                                     , declaration?.Handle ?? default
                                                                     , bitAlign
                                                                     );
@@ -842,7 +846,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// <inheritdoc/>
         public DebugRecord InsertDeclare( Value storage, DILocalVariable varInfo, DILocation location, Instruction insertBefore )
         {
-            return InsertDeclare( storage, varInfo, CreateExpression(), location, insertBefore );
+            return InsertDeclare( storage, varInfo, this.CreateExpression(), location, insertBefore );
         }
 
         /// <inheritdoc/>
@@ -873,7 +877,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// <inheritdoc/>
         public DebugRecord InsertDeclare( Value storage, DILocalVariable varInfo, DILocation location, BasicBlock insertAtEnd )
         {
-            return InsertDeclare( storage, varInfo, CreateExpression(), location, insertAtEnd );
+            return InsertDeclare( storage, varInfo, this.CreateExpression(), location, insertAtEnd );
         }
 
         /// <inheritdoc/>
@@ -929,7 +933,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             var handle = LLVMDIBuilderInsertDbgValueRecordBefore( Handle.ThrowIfInvalid()
                                                                 , value.Handle
                                                                 , varInfo.Handle
-                                                                , expression?.Handle ?? CreateExpression( ).Handle
+                                                                , expression?.Handle ?? this.CreateExpression( ).Handle
                                                                 , location.Handle
                                                                 , insertBefore.Handle
                                                                 );
@@ -974,7 +978,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             var handle = LLVMDIBuilderInsertDeclareRecordAtEnd( Handle.ThrowIfInvalid()
                                                               , value.Handle
                                                               , varInfo.Handle
-                                                              , expression?.Handle ?? CreateExpression( ).Handle
+                                                              , expression?.Handle ?? this.CreateExpression( ).Handle
                                                               , location.Handle
                                                               , insertAtEnd.BlockHandle
                                                               );
@@ -982,8 +986,13 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             return new( handle.ThrowIfInvalid() )!;
         }
 
+#if NET9_0_OR_GREATER
         /// <inheritdoc/>
         public DIExpression CreateExpression( params IEnumerable<ExpressionOp> operations )
+#else
+        /// <inheritdoc/>
+        public DIExpression CreateExpression( IEnumerable<ExpressionOp> operations )
+#endif
         {
             UInt64[ ] args = [ .. operations.Cast<UInt64>( ) ];
             var handle = LLVMDIBuilderCreateExpression( Handle.ThrowIfInvalid(), args );

--- a/src/Ubiquity.NET.Llvm/DebugInfo/DebugFunctionType.cs
+++ b/src/Ubiquity.NET.Llvm/DebugInfo/DebugFunctionType.cs
@@ -32,6 +32,25 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         : DebugType<IFunctionType, DISubroutineType>
         , IFunctionType
     {
+#if !NET9_0_OR_GREATER
+        /// <summary>Initializes a new instance of the <see cref="DebugFunctionType"/> class.</summary>
+        /// <param name="llvmType">Native LLVM function signature</param>
+        /// <param name="diBuilder">Debug information builder to use in creating this instance</param>
+        /// <param name="debugFlags"><see cref="DebugInfoFlags"/> for this signature</param>
+        /// <param name="retType">Return type for the function</param>
+        /// <param name="argTypes">Potentially empty set of argument types for the signature</param>
+        public DebugFunctionType( IFunctionType llvmType
+                                , IDIBuilder diBuilder
+                                , DebugInfoFlags debugFlags
+                                , IDebugType<ITypeRef, DIType> retType
+                                , params IDebugType<ITypeRef, DIType>[] argTypes
+                                )
+            : this(llvmType, diBuilder, debugFlags, retType, (IEnumerable<IDebugType<ITypeRef, DIType>>)argTypes )
+        {
+        }
+#endif
+
+#if NET9_0_OR_GREATER
         /// <summary>Initializes a new instance of the <see cref="DebugFunctionType"/> class.</summary>
         /// <param name="llvmType">Native LLVM function signature</param>
         /// <param name="diBuilder">Debug information builder to use in creating this instance</param>
@@ -44,6 +63,20 @@ namespace Ubiquity.NET.Llvm.DebugInfo
                                 , IDebugType<ITypeRef, DIType> retType
                                 , params IEnumerable<IDebugType<ITypeRef, DIType>> argTypes
                                 )
+#else
+        /// <summary>Initializes a new instance of the <see cref="DebugFunctionType"/> class.</summary>
+        /// <param name="llvmType">Native LLVM function signature</param>
+        /// <param name="diBuilder">Debug information builder to use in creating this instance</param>
+        /// <param name="debugFlags"><see cref="DebugInfoFlags"/> for this signature</param>
+        /// <param name="retType">Return type for the function</param>
+        /// <param name="argTypes">Potentially empty set of argument types for the signature</param>
+        public DebugFunctionType( IFunctionType llvmType
+                                , IDIBuilder diBuilder
+                                , DebugInfoFlags debugFlags
+                                , IDebugType<ITypeRef, DIType> retType
+                                , IEnumerable<IDebugType<ITypeRef, DIType>> argTypes
+                                )
+#endif
             : base( llvmType.ThrowIfNull()
                   , diBuilder.CreateSubroutineType( debugFlags
                                                   , retType.ThrowIfNull().DebugInfoType

--- a/src/Ubiquity.NET.Llvm/DebugInfo/DebugStructType.cs
+++ b/src/Ubiquity.NET.Llvm/DebugInfo/DebugStructType.cs
@@ -178,12 +178,18 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// <summary>Gets the Source/Debug name</summary>
         public string SourceName => DebugInfoType?.Name ?? string.Empty;
 
+#if NET9_0_OR_GREATER
         /// <inheritdoc/>
         public void SetBody( bool packed, params IEnumerable<ITypeRef> elements )
+#else
+        /// <inheritdoc/>
+        public void SetBody( bool packed, params ITypeRef[] elements )
+#endif
         {
             NativeType.SetBody( packed, elements );
         }
 
+#if NET9_0_OR_GREATER
         /// <summary>Set the body of a type</summary>
         /// <param name="packed">Flag to indicate if the body elements are packed (e.g. no padding)</param>
         /// <param name="diBuilder">To construct the debug information for this instance</param>
@@ -200,6 +206,24 @@ namespace Ubiquity.NET.Llvm.DebugInfo
                            , DebugInfoFlags debugFlags
                            , params IEnumerable<DebugMemberInfo> debugElements
                            )
+#else
+        /// <summary>Set the body of a type</summary>
+        /// <param name="packed">Flag to indicate if the body elements are packed (e.g. no padding)</param>
+        /// <param name="diBuilder">To construct the debug information for this instance</param>
+        /// <param name="scope">Scope containing this type</param>
+        /// <param name="file">File containing the type</param>
+        /// <param name="line">Line in <paramref name="file"/> for this type</param>
+        /// <param name="debugFlags">Debug flags for this type</param>
+        /// <param name="debugElements">Descriptors for all the elements in the type</param>
+        public void SetBody( bool packed
+                           , IDIBuilder diBuilder
+                           , DIScope? scope
+                           , DIFile? file
+                           , uint line
+                           , DebugInfoFlags debugFlags
+                           , IEnumerable<DebugMemberInfo> debugElements
+                           )
+#endif
         {
             var debugMembersArray = debugElements as IList<DebugMemberInfo> ?? [ .. debugElements ];
             var nativeElements = debugMembersArray.Select( e => e.DebugType.NativeType );

--- a/src/Ubiquity.NET.Llvm/IContext.cs
+++ b/src/Ubiquity.NET.Llvm/IContext.cs
@@ -151,19 +151,37 @@ namespace Ubiquity.NET.Llvm
         /// <returns>Integer <see cref="ITypeRef"/> for the specified width</returns>
         ITypeRef GetIntType( uint bitWidth );
 
+#if NET9_0_OR_GREATER
         /// <summary>Get an LLVM Function type (e.g. signature)</summary>
         /// <param name="returnType">Return type of the function</param>
         /// <param name="args">Potentially empty set of function argument types</param>
         /// <returns>Signature type for the specified signature</returns>
         IFunctionType GetFunctionType( ITypeRef returnType, params IEnumerable<ITypeRef> args );
+#else
+        /// <summary>Get an LLVM Function type (e.g. signature)</summary>
+        /// <param name="returnType">Return type of the function</param>
+        /// <param name="args">Potentially empty set of function argument types</param>
+        /// <returns>Signature type for the specified signature</returns>
+        IFunctionType GetFunctionType( ITypeRef returnType, IEnumerable<ITypeRef> args );
+#endif
 
+#if NET9_0_OR_GREATER
         /// <summary>Get an LLVM Function type (e.g. signature)</summary>
         /// <param name="isVarArgs">Flag to indicate if the method supports C/C++ style VarArgs</param>
         /// <param name="returnType">Return type of the function</param>
         /// <param name="args">Potentially empty set of function argument types</param>
         /// <returns>Signature type for the specified signature</returns>
         IFunctionType GetFunctionType( bool isVarArgs, ITypeRef returnType, params IEnumerable<ITypeRef> args );
+#else
+        /// <summary>Get an LLVM Function type (e.g. signature)</summary>
+        /// <param name="isVarArgs">Flag to indicate if the method supports C/C++ style VarArgs</param>
+        /// <param name="returnType">Return type of the function</param>
+        /// <param name="args">Potentially empty set of function argument types</param>
+        /// <returns>Signature type for the specified signature</returns>
+        IFunctionType GetFunctionType( bool isVarArgs, ITypeRef returnType, IEnumerable<ITypeRef> args );
+#endif
 
+#if NET9_0_OR_GREATER
         /// <summary>Creates a FunctionType with Debug information</summary>
         /// <param name="diBuilder"><see cref="DIBuilder"/>to use to create the debug information</param>
         /// <param name="retType">Return type of the function</param>
@@ -173,7 +191,19 @@ namespace Ubiquity.NET.Llvm
                                             , IDebugType<ITypeRef, DIType> retType
                                             , params IEnumerable<IDebugType<ITypeRef, DIType>> argTypes
                                             );
+#else
+        /// <summary>Creates a FunctionType with Debug information</summary>
+        /// <param name="diBuilder"><see cref="DIBuilder"/>to use to create the debug information</param>
+        /// <param name="retType">Return type of the function</param>
+        /// <param name="argTypes">Argument types of the function</param>
+        /// <returns>Function signature</returns>
+        DebugFunctionType CreateFunctionType( IDIBuilder diBuilder
+                                            , IDebugType<ITypeRef, DIType> retType
+                                            , IEnumerable<IDebugType<ITypeRef, DIType>> argTypes
+                                            );
+#endif
 
+#if NET9_0_OR_GREATER
         /// <summary>Creates a FunctionType with Debug information</summary>
         /// <param name="diBuilder"><see cref="DIBuilder"/>to use to create the debug information</param>
         /// <param name="isVarArg">Flag to indicate if this function is variadic</param>
@@ -185,7 +215,21 @@ namespace Ubiquity.NET.Llvm
                                             , IDebugType<ITypeRef, DIType> retType
                                             , params IEnumerable<IDebugType<ITypeRef, DIType>> argTypes
                                             );
+#else
+        /// <summary>Creates a FunctionType with Debug information</summary>
+        /// <param name="diBuilder"><see cref="DIBuilder"/>to use to create the debug information</param>
+        /// <param name="isVarArg">Flag to indicate if this function is variadic</param>
+        /// <param name="retType">Return type of the function</param>
+        /// <param name="argTypes">Argument types of the function</param>
+        /// <returns>Function signature</returns>
+        DebugFunctionType CreateFunctionType( IDIBuilder diBuilder
+                                            , bool isVarArg
+                                            , IDebugType<ITypeRef, DIType> retType
+                                            , IEnumerable<IDebugType<ITypeRef, DIType>> argTypes
+                                            );
+#endif
 
+#if NET9_0_OR_GREATER
         /// <summary>Creates a constant structure from a set of values</summary>
         /// <param name="packed">Flag to indicate if the structure is packed and no alignment should be applied to the members</param>
         /// <param name="values">Set of values to use in forming the structure</param>
@@ -203,7 +247,27 @@ namespace Ubiquity.NET.Llvm
         /// </note>
         /// </remarks>
         Constant CreateConstantStruct( bool packed, params IEnumerable<Constant> values );
+#else
+        /// <summary>Creates a constant structure from a set of values</summary>
+        /// <param name="packed">Flag to indicate if the structure is packed and no alignment should be applied to the members</param>
+        /// <param name="values">Set of values to use in forming the structure</param>
+        /// <returns>Newly created <see cref="Constant"/></returns>
+        /// <remarks>
+        /// <note type="note">The actual concrete return type depends on the parameters provided and will be one of the following:
+        /// <list type="table">
+        /// <listheader>
+        /// <term><see cref="Constant"/> derived type</term><description>Description</description>
+        /// </listheader>
+        /// <item><term>ConstantAggregateZero</term><description>If all the member values are zero constants</description></item>
+        /// <item><term>UndefValue</term><description>If all the member values are UndefValue</description></item>
+        /// <item><term>ConstantStruct</term><description>All other cases</description></item>
+        /// </list>
+        /// </note>
+        /// </remarks>
+        Constant CreateConstantStruct( bool packed, IEnumerable<Constant> values );
+#endif
 
+#if NET9_0_OR_GREATER
         /// <summary>Creates a constant instance of a specified structure type from a set of values</summary>
         /// <param name="type">Type of the structure to create</param>
         /// <param name="values">Set of values to use in forming the structure</param>
@@ -221,6 +285,25 @@ namespace Ubiquity.NET.Llvm
         /// </note>
         /// </remarks>
         Constant CreateNamedConstantStruct( IStructType type, params IEnumerable<Constant> values );
+#else
+        /// <summary>Creates a constant instance of a specified structure type from a set of values</summary>
+        /// <param name="type">Type of the structure to create</param>
+        /// <param name="values">Set of values to use in forming the structure</param>
+        /// <returns>Newly created <see cref="Constant"/></returns>
+        /// <remarks>
+        /// <note type="note">The actual concrete return type depends on the parameters provided and will be one of the following:
+        /// <list type="table">
+        /// <listheader>
+        /// <term><see cref="Constant"/> derived type</term><description>Description</description>
+        /// </listheader>
+        /// <item><term>ConstantAggregateZero</term><description>If all the member values are zero constants</description></item>
+        /// <item><term>UndefValue</term><description>If all the member values are UndefValue</description></item>
+        /// <item><term>ConstantStruct</term><description>All other cases</description></item>
+        /// </list>
+        /// </note>
+        /// </remarks>
+        Constant CreateNamedConstantStruct( IStructType type, IEnumerable<Constant> values );
+#endif
 
         /// <summary>Create an opaque structure type (e.g. a forward reference)</summary>
         /// <param name="name">Name of the type (use <see cref="LazyEncodedString.Empty"/> for anonymous types)</param>
@@ -233,6 +316,7 @@ namespace Ubiquity.NET.Llvm
         /// <returns>New type</returns>
         IStructType CreateStructType( LazyEncodedString name );
 
+#if NET9_0_OR_GREATER
         /// <summary>Create an anonymous structure type (e.g. Tuple)</summary>
         /// <param name="packed">Flag to indicate if the structure is "packed"</param>
         /// <param name="elements">Types of the fields of the structure</param>
@@ -240,7 +324,17 @@ namespace Ubiquity.NET.Llvm
         /// <see cref="IStructType"/> with the specified body defined.
         /// </returns>
         IStructType CreateStructType( bool packed, params IEnumerable<ITypeRef> elements );
+#else
+        /// <summary>Create an anonymous structure type (e.g. Tuple)</summary>
+        /// <param name="packed">Flag to indicate if the structure is "packed"</param>
+        /// <param name="elements">Types of the fields of the structure</param>
+        /// <returns>
+        /// <see cref="IStructType"/> with the specified body defined.
+        /// </returns>
+        IStructType CreateStructType( bool packed, params ITypeRef[] elements );
+#endif
 
+#if NET9_0_OR_GREATER
         /// <summary>Creates a new structure type in this <see cref="ContextAlias"/></summary>
         /// <param name="name">Name of the structure (use <see cref="LazyEncodedString.Empty"/> for anonymous types)</param>
         /// <param name="packed">Flag indicating if the structure is packed</param>
@@ -252,6 +346,19 @@ namespace Ubiquity.NET.Llvm
         /// If the elements argument list is empty then a complete 0 sized struct is created
         /// </remarks>
         IStructType CreateStructType( LazyEncodedString name, bool packed, params IEnumerable<ITypeRef> elements );
+#else
+        /// <summary>Creates a new structure type in this <see cref="ContextAlias"/></summary>
+        /// <param name="name">Name of the structure (use <see cref="LazyEncodedString.Empty"/> for anonymous types)</param>
+        /// <param name="packed">Flag indicating if the structure is packed</param>
+        /// <param name="elements">Types for the structures elements in layout order</param>
+        /// <returns>
+        /// <see cref="IStructType"/> with the specified body defined.
+        /// </returns>
+        /// <remarks>
+        /// If the elements argument list is empty then a complete 0 sized struct is created
+        /// </remarks>
+        IStructType CreateStructType( LazyEncodedString name, bool packed, params ITypeRef[] elements );
+#endif
 
         /// <summary>Creates a metadata string from the given string</summary>
         /// <param name="value">string to create as metadata</param>
@@ -393,8 +500,99 @@ namespace Ubiquity.NET.Llvm
         TargetBinary OpenBinary( LazyEncodedString path );
     }
 
-    internal static class ContextExtensions
+    /// <summary>Utility class to provide extensions to <see cref="IContext"/></summary>
+    /// <remarks>
+    /// This is used mostly to provide support for legacy runtimes that don't have the `params IEnumerable` language feature.
+    /// In such a case, this provides extensions that allow use of a parmas array and then re-directs to the enumerable
+    /// form of the function. This allows source compat of consumers while not trying to leverage support beyond what
+    /// is supported by the runtime.
+    /// </remarks>
+    public static class ContextExtensions
     {
+#if !NET9_0_OR_GREATER
+        /// <summary>Get an LLVM Function type (e.g. signature)</summary>
+        /// <param name="self">Instance of context to get a function type</param>
+        /// <param name="returnType">Return type of the function</param>
+        /// <param name="args">Potentially empty set of function argument types</param>
+        /// <returns>Signature type for the specified signature</returns>
+        public static IFunctionType GetFunctionType(this IContext self, ITypeRef returnType, params ITypeRef[] args )
+        {
+            // this seems redundant but for older runtimes it does an implict cast to IEnumerable
+            return self.GetFunctionType( returnType, args );
+        }
+
+        /// <summary>Get an LLVM Function type (e.g. signature)</summary>
+        /// <param name="self">Context instance to get the function from</param>
+        /// <param name="isVarArgs">Flag to indicate if the method supports C/C++ style VarArgs</param>
+        /// <param name="returnType">Return type of the function</param>
+        /// <param name="args">Potentially empty set of function argument types</param>
+        /// <returns>Signature type for the specified signature</returns>
+        public static IFunctionType GetFunctionType( this IContext self, bool isVarArgs, ITypeRef returnType, params ITypeRef[] args )
+        {
+            // this seems redundant but for older runtimes it does an implict cast to IEnumerable
+            return self.GetFunctionType( isVarArgs, returnType, args );
+        }
+
+        /// <summary>Creates a FunctionType with Debug information</summary>
+        /// <param name="self">Context instance to get the function from</param>
+        /// <param name="diBuilder"><see cref="DIBuilder"/>to use to create the debug information</param>
+        /// <param name="retType">Return type of the function</param>
+        /// <param name="argTypes">Argument types of the function</param>
+        /// <returns>Function signature</returns>
+        public static DebugFunctionType CreateFunctionType( this IContext self
+                                                          , IDIBuilder diBuilder
+                                                          , IDebugType<ITypeRef, DIType> retType
+                                                          , params IDebugType<ITypeRef, DIType>[] argTypes
+                                                          )
+        {
+            return self.CreateFunctionType(diBuilder, retType, argTypes);
+        }
+
+        /// <summary>Creates a constant structure from a set of values</summary>
+        /// <param name="self">Context instance to get the function from</param>
+        /// <param name="packed">Flag to indicate if the structure is packed and no alignment should be applied to the members</param>
+        /// <param name="values">Set of values to use in forming the structure</param>
+        /// <returns>Newly created <see cref="Constant"/></returns>
+        /// <remarks>
+        /// <note type="note">The actual concrete return type depends on the parameters provided and will be one of the following:
+        /// <list type="table">
+        /// <listheader>
+        /// <term><see cref="Constant"/> derived type</term><description>Description</description>
+        /// </listheader>
+        /// <item><term>ConstantAggregateZero</term><description>If all the member values are zero constants</description></item>
+        /// <item><term>UndefValue</term><description>If all the member values are UndefValue</description></item>
+        /// <item><term>ConstantStruct</term><description>All other cases</description></item>
+        /// </list>
+        /// </note>
+        /// </remarks>
+        public static Constant CreateConstantStruct(this IContext self, bool packed, params Constant[] values )
+        {
+            return self.CreateConstantStruct(packed, values);
+        }
+
+        /// <summary>Creates a constant instance of a specified structure type from a set of values</summary>
+        /// <param name="self">Context instance to get the function from</param>
+        /// <param name="type">Type of the structure to create</param>
+        /// <param name="values">Set of values to use in forming the structure</param>
+        /// <returns>Newly created <see cref="Constant"/></returns>
+        /// <remarks>
+        /// <note type="note">The actual concrete return type depends on the parameters provided and will be one of the following:
+        /// <list type="table">
+        /// <listheader>
+        /// <term><see cref="Constant"/> derived type</term><description>Description</description>
+        /// </listheader>
+        /// <item><term>ConstantAggregateZero</term><description>If all the member values are zero constants</description></item>
+        /// <item><term>UndefValue</term><description>If all the member values are UndefValue</description></item>
+        /// <item><term>ConstantStruct</term><description>All other cases</description></item>
+        /// </list>
+        /// </note>
+        /// </remarks>
+        public static Constant CreateNamedConstantStruct( this IContext self, IStructType type, params Constant[] values )
+        {
+            return self.CreateNamedConstantStruct(type, values);
+        }
+#endif
+
         // TODO: Is this needed? Owned handles are implicitly castable to the unowned forms
         internal static LLVMContextRefAlias GetUnownedHandle( this IContext self )
         {

--- a/src/Ubiquity.NET.Llvm/Instructions/InstructionBuilder.cs
+++ b/src/Ubiquity.NET.Llvm/Instructions/InstructionBuilder.cs
@@ -332,12 +332,21 @@ namespace Ubiquity.NET.Llvm.Instructions
             return Value.FromHandle<ReturnInstruction>( handle )!;
         }
 
+#if NET9_0_OR_GREATER
         /// <summary>Creates a call function</summary>
         /// <param name="func">Function to call</param>
         /// <param name="args">Arguments to pass to the function</param>
         /// <returns><see cref="CallInstruction"/></returns>
         /// <exception cref="ArgumentException">One of the parameters to this function is invalid</exception>
         public CallInstruction Call( Function func, params IEnumerable<Value> args ) => Call( func, args.ToList().AsReadOnly() );
+#else
+        /// <summary>Creates a call function</summary>
+        /// <param name="func">Function to call</param>
+        /// <param name="args">Arguments to pass to the function</param>
+        /// <returns><see cref="CallInstruction"/></returns>
+        /// <exception cref="ArgumentException">One of the parameters to this function is invalid</exception>
+        public CallInstruction Call( Function func, params Value[] args ) => Call( func, args.ToList().AsReadOnly() );
+#endif
 
         /// <summary>Creates a call function</summary>
         /// <param name="func">Function to call</param>
@@ -349,6 +358,7 @@ namespace Ubiquity.NET.Llvm.Instructions
             return Call(func.Signature, func, args);
         }
 
+#if NET9_0_OR_GREATER
         /// <summary>Creates a call instruction</summary>
         /// <param name="signature">Function signature of the target</param>
         /// <param name="target">Target of the function call (Must be invocable as <paramref name="signature"/>)</param>
@@ -357,6 +367,16 @@ namespace Ubiquity.NET.Llvm.Instructions
         /// <exception cref="ArgumentException">One of the parameters to this function is invalid</exception>
         public CallInstruction Call( IFunctionType signature, Value target, params IEnumerable<Value> args )
             => Call(signature, target, args.ToList().AsReadOnly() );
+#else
+        /// <summary>Creates a call instruction</summary>
+        /// <param name="signature">Function signature of the target</param>
+        /// <param name="target">Target of the function call (Must be invocable as <paramref name="signature"/>)</param>
+        /// <param name="args">Arguments to the function call (Must match types and number of <paramref name="signature"/>)</param>
+        /// <returns>Instruction created</returns>
+        /// <exception cref="ArgumentException">One of the parameters to this function is invalid</exception>
+        public CallInstruction Call( IFunctionType signature, Value target, params Value[] args )
+            => Call( signature, target, (IReadOnlyList<Value>)args );
+#endif
 
         /// <summary>Creates a call instruction</summary>
         /// <param name="signature">Function signature of the target</param>
@@ -1663,7 +1683,7 @@ namespace Ubiquity.NET.Llvm.Instructions
                 : llvmArgs;
         }
 
-        #pragma warning disable IDE0060
+#pragma warning disable IDE0060
         // TODO: Either validate parameter 'index' or remove it...
         private static void ValidateStructGepArgs( Value pointer, uint index )
         {
@@ -1674,7 +1694,7 @@ namespace Ubiquity.NET.Llvm.Instructions
                 throw new ArgumentException( Resources.Pointer_value_expected, nameof( pointer ) );
             }
         }
-        #pragma warning restore IDE0060
+#pragma warning restore IDE0060
 
         private IModule GetModuleOrThrow( )
         {

--- a/src/Ubiquity.NET.Llvm/ModuleAlias.cs
+++ b/src/Ubiquity.NET.Llvm/ModuleAlias.cs
@@ -549,6 +549,7 @@ namespace Ubiquity.NET.Llvm
             return func;
         }
 
+#if NET9_0_OR_GREATER
         /// <inheritdoc/>
         public Function CreateFunction( IDIBuilder diBuilder
                                       , LazyEncodedString name
@@ -556,6 +557,16 @@ namespace Ubiquity.NET.Llvm
                                       , IDebugType<ITypeRef, DIType> returnType
                                       , params IEnumerable<IDebugType<ITypeRef, DIType>> argumentTypes
                                       )
+#else
+        /// <inheritdoc/>
+        public Function CreateFunction( IDIBuilder diBuilder
+                                      , LazyEncodedString name
+                                      , bool isVarArg
+                                      , IDebugType<ITypeRef, DIType> returnType
+                                      , IEnumerable<IDebugType<ITypeRef, DIType>> argumentTypes
+                                      )
+
+#endif
         {
             IFunctionType signature = Context.CreateFunctionType( diBuilder, isVarArg, returnType, argumentTypes );
             return CreateFunction( name, signature );
@@ -613,7 +624,7 @@ namespace Ubiquity.NET.Llvm
         {
             return LLVMStripModuleDebugInfo(Handle);
         }
-        #endregion
+#endregion
 
         internal ModuleAlias( LLVMModuleRefAlias handle )
         {

--- a/src/Ubiquity.NET.Llvm/OrcJITv2/ObjectLayer.cs
+++ b/src/Ubiquity.NET.Llvm/OrcJITv2/ObjectLayer.cs
@@ -85,6 +85,7 @@ namespace Ubiquity.NET.Llvm.OrcJITv2
         {
         }
 
+#if NET10_0
         internal LLVMOrcObjectLayerRef Handle
         {
             get;
@@ -101,5 +102,25 @@ namespace Ubiquity.NET.Llvm.OrcJITv2
                 field = value;
             }
         }
+#else
+        internal LLVMOrcObjectLayerRef Handle
+        {
+            get => HandleBackingField;
+
+            // Only accessible from derived types, since the modifier of this property is `internal` that
+            // means `internal` AND `protected`
+            private protected set
+            {
+                if(!HandleBackingField.IsNull)
+                {
+                    throw new InvalidOperationException( "INTERNAL: Setting handle multiple times is not allowed!" );
+                }
+
+                HandleBackingField = value;
+            }
+        }
+
+        private LLVMOrcObjectLayerRef HandleBackingField;
+#endif
     }
 }

--- a/src/Ubiquity.NET.Llvm/Types/StructType.cs
+++ b/src/Ubiquity.NET.Llvm/Types/StructType.cs
@@ -30,17 +30,28 @@ namespace Ubiquity.NET.Llvm.Types
         /// <summary>Gets a value indicating whether the structure is packed (e.g. no automatic alignment padding between elements)</summary>
         bool IsPacked { get; }
 
+#if NET9_0_OR_GREATER
         /// <summary>Sets the body of the structure</summary>
         /// <param name="packed">Flag to indicate if the body elements are packed (e.g. no padding)</param>
         /// <param name="elements">Types of each element (may be empty)</param>
         void SetBody( bool packed, params IEnumerable<ITypeRef> elements );
+#else
+        /// <summary>Sets the body of the structure</summary>
+        /// <param name="packed">Flag to indicate if the body elements are packed (e.g. no padding)</param>
+        /// <param name="elements">Types of each element (may be empty)</param>
+        void SetBody( bool packed, params ITypeRef[] elements );
+#endif
     }
 
     internal sealed class StructType
         : TypeRef
         , IStructType
     {
+#if NET9_0_OR_GREATER
         public void SetBody( bool packed, params IEnumerable<ITypeRef> elements )
+#else
+        public void SetBody( bool packed, params ITypeRef[] elements )
+#endif
         {
             LLVMTypeRef[ ] llvmArgs = [ .. elements.Select( e => e.GetTypeRef() ) ];
             LLVMStructSetBody( Handle, llvmArgs, (uint)llvmArgs.Length, packed );

--- a/src/Ubiquity.NET.Llvm/Ubiquity.NET.Llvm.csproj
+++ b/src/Ubiquity.NET.Llvm/Ubiquity.NET.Llvm.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <!--Until C#14 and the "field" and "extension" keywords are available use the preview language -->
-        <LangVersion>preview</LangVersion>
         <Nullable>enable</Nullable>
 
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Ubiquity.NET.Llvm/Values/AttributeContainerExtensions.cs
+++ b/src/Ubiquity.NET.Llvm/Values/AttributeContainerExtensions.cs
@@ -20,11 +20,19 @@ namespace Ubiquity.NET.Llvm.Values
             return self.Any( a => a.Id == id );
         }
 
+#if NET9_0_OR_GREATER
         /// <summary>Adds a range of values to a collection</summary>
         /// <typeparam name="T">Type of elements in the collection</typeparam>
         /// <param name="self">Collection to Add values to</param>
         /// <param name="range">values to add</param>
         public static void AddRange<T>( this ICollection<T> self, params IEnumerable<T>? range )
+#else
+        /// <summary>Adds a range of values to a collection</summary>
+        /// <typeparam name="T">Type of elements in the collection</typeparam>
+        /// <param name="self">Collection to Add values to</param>
+        /// <param name="range">values to add</param>
+        public static void AddRange<T>( this ICollection<T> self, params T[] range )
+#endif
         {
             ArgumentNullException.ThrowIfNull( self );
             if(range is null)
@@ -38,10 +46,17 @@ namespace Ubiquity.NET.Llvm.Values
             }
         }
 
+#if NET9_0_OR_GREATER
         /// <summary>Add a range of attributes to an attribute container</summary>
         /// <param name="self">Attribute container to add attributes to</param>
         /// <param name="range">Range of attributes to operate on</param>
         public static void AddAttributes( this IAttributeContainer self, params IEnumerable<LazyEncodedString>? range )
+#else
+        /// <summary>Add a range of attributes to an attribute container</summary>
+        /// <param name="self">Attribute container to add attributes to</param>
+        /// <param name="range">Range of attributes to operate on</param>
+        public static void AddAttributes( this IAttributeContainer self, params LazyEncodedString[] range )
+#endif
         {
             ArgumentNullException.ThrowIfNull( self );
             if(range is null)
@@ -55,10 +70,17 @@ namespace Ubiquity.NET.Llvm.Values
             }
         }
 
+#if NET9_0_OR_GREATER
         /// <summary>Add a range of attributes to an attribute container</summary>
         /// <param name="self">Attribute container to add attributes to</param>
         /// <param name="range">Range of attributes to operate on</param>
         public static void AddAttributes( this IAttributeContainer self, params IEnumerable<AttributeValue>? range )
+#else
+        /// <summary>Add a range of attributes to an attribute container</summary>
+        /// <param name="self">Attribute container to add attributes to</param>
+        /// <param name="range">Range of attributes to operate on</param>
+        public static void AddAttributes( this IAttributeContainer self, params AttributeValue[] range )
+#endif
         {
             ArgumentNullException.ThrowIfNull( self );
             if(range is null)
@@ -102,6 +124,7 @@ namespace Ubiquity.NET.Llvm.Values
             return self;
         }
 
+#if NET9_0_OR_GREATER
         /// <summary>Adds <see cref="AttributeValue"/>s to an <see cref="IFunctionAttributeAccessor"/></summary>
         /// <typeparam name="T">Accessor type</typeparam>
         /// <param name="self">Accessor to add the attribute to</param>
@@ -110,6 +133,16 @@ namespace Ubiquity.NET.Llvm.Values
         /// <returns><paramref name="self"/> for fluent use</returns>
         public static T AddAttributes<T>( this T self, FunctionAttributeIndex index, params IEnumerable<LazyEncodedString>? names )
             where T : notnull, IFunctionAttributeAccessor
+#else
+        /// <summary>Adds <see cref="AttributeValue"/>s to an <see cref="IFunctionAttributeAccessor"/></summary>
+        /// <typeparam name="T">Accessor type</typeparam>
+        /// <param name="self">Accessor to add the attribute to</param>
+        /// <param name="index"><see cref="FunctionAttributeIndex"/> to add the attributes to</param>
+        /// <param name="names">Names of a attributes to add to the accessor [All must be an enum with no args OR a string attribute that accepts an empty string]</param>
+        /// <returns><paramref name="self"/> for fluent use</returns>
+        public static T AddAttributes<T>( this T self, FunctionAttributeIndex index, IEnumerable<LazyEncodedString> names )
+            where T : notnull, IFunctionAttributeAccessor
+#endif
         {
             ArgumentNullException.ThrowIfNull( self );
 
@@ -124,6 +157,22 @@ namespace Ubiquity.NET.Llvm.Values
             return self;
         }
 
+#if !NET9_0_OR_GREATER
+        /// <summary>Adds <see cref="AttributeValue"/>s to an <see cref="IFunctionAttributeAccessor"/></summary>
+        /// <typeparam name="T">Accessor type</typeparam>
+        /// <param name="self">Accessor to add the attribute to</param>
+        /// <param name="index"><see cref="FunctionAttributeIndex"/> to add the attributes to</param>
+        /// <param name="names">Names of a attributes to add to the accessor [All must be an enum with no args OR a string attribute that accepts an empty string]</param>
+        /// <returns><paramref name="self"/> for fluent use</returns>
+        [MethodImpl( MethodImplOptions.AggressiveInlining )]
+        public static T AddAttributes<T>( this T self, FunctionAttributeIndex index, params LazyEncodedString[] names )
+            where T : notnull, IFunctionAttributeAccessor
+        {
+            return AddAttributes( self, index, (IEnumerable<LazyEncodedString>)names );
+        }
+#endif
+
+#if NET9_0_OR_GREATER
         /// <summary>Adds <see cref="AttributeValue"/>s to an <see cref="IFunctionAttributeAccessor"/></summary>
         /// <typeparam name="T">Container type</typeparam>
         /// <param name="self">Container to add the attribute to</param>
@@ -132,6 +181,16 @@ namespace Ubiquity.NET.Llvm.Values
         /// <returns><paramref name="self"/> for fluent use</returns>
         public static T AddAttributes<T>( this T self, FunctionAttributeIndex index, params IEnumerable<AttributeValue> attributes )
             where T : notnull, IFunctionAttributeAccessor
+#else
+        /// <summary>Adds <see cref="AttributeValue"/>s to an <see cref="IFunctionAttributeAccessor"/></summary>
+        /// <typeparam name="T">Container type</typeparam>
+        /// <param name="self">Container to add the attribute to</param>
+        /// <param name="index"><see cref="FunctionAttributeIndex"/> to add the attributes to</param>
+        /// <param name="attributes">Attribute to add to the container</param>
+        /// <returns><paramref name="self"/> for fluent use</returns>
+        public static T AddAttributes<T>( this T self, FunctionAttributeIndex index, IEnumerable<AttributeValue> attributes )
+            where T : notnull, IFunctionAttributeAccessor
+#endif
         {
             ArgumentNullException.ThrowIfNull( self );
 
@@ -145,6 +204,20 @@ namespace Ubiquity.NET.Llvm.Values
 
             return self;
         }
+
+#if !NET9_0_OR_GREATER
+        /// <summary>Adds <see cref="AttributeValue"/>s to an <see cref="IFunctionAttributeAccessor"/></summary>
+        /// <typeparam name="T">Container type</typeparam>
+        /// <param name="self">Container to add the attribute to</param>
+        /// <param name="index"><see cref="FunctionAttributeIndex"/> to add the attributes to</param>
+        /// <param name="attributes">Attribute to add to the container</param>
+        /// <returns><paramref name="self"/> for fluent use</returns>
+        public static T AddAttributes<T>( this T self, FunctionAttributeIndex index, params AttributeValue[] attributes )
+            where T : notnull, IFunctionAttributeAccessor
+        {
+            return AddAttributes(self, index, (IEnumerable<AttributeValue>)attributes);
+        }
+#endif
 
         /// <summary>Removes an <see cref="UInt32"/> from an <see cref="IFunctionAttributeAccessor"/></summary>
         /// <typeparam name="T">Container type</typeparam>

--- a/src/Ubiquity.NET.Llvm/Values/GlobalObject.cs
+++ b/src/Ubiquity.NET.Llvm/Values/GlobalObject.cs
@@ -30,7 +30,7 @@ namespace Ubiquity.NET.Llvm.Values
         /// empty string will remove any comdat setting for the
         /// global object.
         /// </remarks>
-        public Comdat Comdat
+        public Comdat? Comdat
         {
             get
             {
@@ -38,7 +38,7 @@ namespace Ubiquity.NET.Llvm.Values
                 return comdatRef == default ? default : new Comdat( comdatRef );
             }
 
-            set => LLVMSetComdat( Handle, value.Handle );
+            set => LLVMSetComdat( Handle, value?.Handle ?? default);
         }
 
         /// <summary>Sets metadata for this value</summary>


### PR DESCRIPTION
Removed all forward language and runtime versioning
* There are just too many problems with forward referencing of version to make it not worth even trying.
* Updated numerous cases where "field" or other newer runtime/language version syntax was used.
* Added extensions to support params array instead of `IEnumerable` and redirect to an IEnumerable variant.
    * This has the least impact as the consumers don't need to change except perhaps to include a `using` to reference the namespace containing the extensions.
* Comdat is no longer a ref struct

New Rules:
1) DO NOT set LangVersion to anything other than what is supported by the SDK in use. In other words don't set it to `preview` or ANY other value not supported by the targetted .NET runtime.
2) DO NOT set LangVersion at all unless mutli-targetting or explicity targetting downlevel (netstandard2.0) for plugin compatibility.