### PR TITLE
Fixed Debug builds in IDE

### DIFF
--- a/src/Ubiquity.NET.Llvm.JIT.Tests/OrcJitTests.cs
+++ b/src/Ubiquity.NET.Llvm.JIT.Tests/OrcJitTests.cs
@@ -4,6 +4,10 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
+#if DEBUG
+using System.Linq;
+#endif
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Ubiquity.NET.Extensions;


### PR DESCRIPTION
Fixed Debug builds in IDE
* Debug builds of OrcJitTests are missing a using to allow debug only tests to work.