### PR TITLE
Call `Finish()` from `DIBuilder.Dispose()` to simplify usage

### DIFF
--- a/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/MetadataBindings.cs
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/ABI/libllvm-c/MetadataBindings.cs
@@ -215,6 +215,14 @@ namespace Ubiquity.NET.Llvm.Interop.ABI.libllvm_c
         [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
         public static unsafe partial LLVMDWARFEmissionKind LibLLVMDiCompileUnitGetEmissionKind( LLVMMetadataRef handle );
 
+#if FEATURE_366_IMPLEMENTED
+// See: https://github.com/UbiquityDotNET/Llvm.NET/issues/366
+        [LibraryImport( LibraryName )]
+        [UnmanagedCallConv( CallConvs = [ typeof( CallConvCdecl ) ] )]
+        [return: MarshalAs( UnmanagedType.Bool )]
+        public static partial bool LibLLVMDiBuilderGetAllowUnresolvedNodes( LLVMDIBuilderRefAlias builder );
+#endif
+
         [MethodImpl( MethodImplOptions.AggressiveInlining )]
         public static LLVMMetadataRef LibLLVMDIBuilderCreateTempFunctionFwdDecl(
             LLVMDIBuilderRefAlias D,

--- a/src/Samples/Kaleidoscope/TextMate/ReadMe.md
+++ b/src/Samples/Kaleidoscope/TextMate/ReadMe.md
@@ -4,12 +4,12 @@ grammar used in the documentation template for the site docs. This allows highli
 an editor.
 
 ## VisualStudio
-In Visual Studio copies of subfolders of this folder can be placed into the user profile
+In Visual Studio copies of sub-folders of this folder can be placed into the user profile
 folder `.vs/Extensions` to enable syntax highlighting of the Kaleidoscope
 language files.
 
 >[!NOTE]
-> For Windows the user profile is available in an environment varialbe. In PowerShell that
+> For Windows the user profile is available in an environment variable. In PowerShell that
 > is accessed as `$env:userprofile`. In classic CMD prompts it is `%USERPROFILE%`. Normally
 > it is `C:\Users\<UserName>` but can vary depending on how your system is set up.
 

--- a/src/Ubiquity.NET.Llvm/DebugInfo/DIBuilder.cs
+++ b/src/Ubiquity.NET.Llvm/DebugInfo/DIBuilder.cs
@@ -39,6 +39,10 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         {
             if(!Handle.IsNull)
             {
+                // TODO: detect if unresolved allowed and only take overhead of Finish() if they are allowed
+                // see: https://github.com/UbiquityDotNET/Llvm.NET/issues/366
+                // see: MetadataBindings.LibLLVMDiBuilderGetAllowUnresolvedNodes
+                Finish();
                 Handle.Dispose();
                 InvalidateAfterMove();
             }


### PR DESCRIPTION
Call `Finish()` from `DIBuilder.Dispose()` to simplify usage

This implements Feature request #365