### PR TITLE
Added creation of AddressSpaceCast instruction to InstructionBuilder.

### DIFF
--- a/src/Interop/Ubiquity.NET.Llvm.Interop/Ubiquity.NET.Llvm.Interop.csproj
+++ b/src/Interop/Ubiquity.NET.Llvm.Interop/Ubiquity.NET.Llvm.Interop.csproj
@@ -24,6 +24,7 @@
         <PackageLicenseExpression>Apache-2.0 WITH LLVM-exception</PackageLicenseExpression>
         <IncludeSymbols Condition="'$(Configuration)'=='Release'">true</IncludeSymbols>
         <EmbedUntrackedSources>false</EmbedUntrackedSources>
+        <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
         <!-- This is an internal undocumented package ignore the analysis that complains about a missing ReadMe -->

--- a/src/Ubiquity.NET.Llvm/DebugInfo/DebugFunctionType.cs
+++ b/src/Ubiquity.NET.Llvm/DebugInfo/DebugFunctionType.cs
@@ -89,6 +89,12 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         }
 
         /// <inheritdoc/>
+        public override string? ToString( )
+        {
+            return NativeType?.ToString();
+        }
+
+        /// <inheritdoc/>
         public bool IsVarArg => NativeType.IsVarArg;
 
         /// <inheritdoc/>

--- a/src/Ubiquity.NET.Llvm/DebugInfo/DebugPointerType.cs
+++ b/src/Ubiquity.NET.Llvm/DebugInfo/DebugPointerType.cs
@@ -93,5 +93,11 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// opaque and the type it refers to is unknown.
         /// </remarks>
         public ITypeRef? ElementType { get; init; }
+
+        /// <inheritdoc/>
+        public override string? ToString( )
+        {
+            return NativeType?.ToString();
+        }
     }
 }

--- a/src/Ubiquity.NET.Llvm/Ubiquity.NET.Llvm.csproj
+++ b/src/Ubiquity.NET.Llvm/Ubiquity.NET.Llvm.csproj
@@ -22,6 +22,9 @@
         <RepositoryType>git</RepositoryType>
         <PackageLicenseExpression>Apache-2.0 WITH LLVM-exception</PackageLicenseExpression>
         <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
         <LLvmAnalyzerName>Ubiquity.NET.Llvm.Analyzer</LLvmAnalyzerName>
         <LLvmAnalyzerPath>$(BaseBuildOutputBinPath)\$(LLvmAnalyzerName)\$(Configuration)\netstandard2.0\$(LLvmAnalyzerName).dll</LLvmAnalyzerPath>
     </PropertyGroup>


### PR DESCRIPTION
Added creation of AddressSpaceCast instruction to InstructionBuilder.

All the plumbing existed for supporting this instruction but it could not be created via instances of `InstructionBuilder`
* Updated instruction builder methods to use `LazyEncodedString.Empty` as the default name to reduce overhead costs of marshaling an empty string.
* Added support for generating symbols as part of NuGetPackage generation so that they are available to consumers.
* Improved debugger reporting of `DebugFunctionType` and `DebugPointerType`
    - Fixes #368