### PR TITLE
Updates to support .NET 10 SDK

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -49,6 +49,12 @@ jobs:
            persist-credentials: false
            fetch-depth: 0
 
+      # .NET SDK 10 is not normally included in GH machine builds, yet so force it
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+            dotnet-version: '10.0.x'
+
       - name: Build Source
         run: ./Build-Source.ps1 -ForceClean
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -30,6 +30,12 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      # .NET SDK 10 is not normally included in GH machine builds, yet so force it
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+            dotnet-version: '10.0.x'
+
       - name: Build Source
         run: .\Build-Source.ps1 -FullInit -ForceClean
 

--- a/OneFlow/ReadMe.md
+++ b/OneFlow/ReadMe.md
@@ -1,8 +1,36 @@
 # GIT OneFlow support scripts
-The scripts in this folder are used for release and feature branch management.
-This repository follows the [OneFlow](https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow#develop-finishing-a-release-branch)
-model and work-flow. With one active long term branch 'develop'. The master branch is
-present and long term but is not active, it only points to the latest official release
-(including preview releases) of the project. This is a convenience to allow getting the
-latest released source quickly. Generally speaking, the scripts used here are only for
-release managers and are not required (or even an option) for most contributors.
+The scripts in this folder are used for release and feature branch management. This
+repository follows the [OneFlow](https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow#develop-finishing-a-release-branch)
+model and work-flow. With one active long term branch 'develop'. The main branch is present
+and long term but is not active, it only points to the latest official release (including
+preview releases) of the project. This is a convenience to allow getting the latest released
+source quickly. Generally speaking, the scripts used here are only for release managers and
+are not required (or even an option) for most contributors.
+
+Typical workflow:
+1. Modify `BuildVersion.xml` (But do ***NOT*** commit it)
+2. Run `Start-Release.ps1`
+    1. This will setup and push the various branches used for the release
+    2. The build version is NOT committed as the branches can allow CI/PR builds depending
+       on the nature of the release changes.
+3. Any changes needed for the release are made and pushed (via PR) to the `release/<releas name>`
+   branch.
+4. Commit, or remodify, `BuildVersion.xml` and push it to the official repo release branch.
+    1. This is typically done with git push official to direct push the changes to the
+       official repository
+5. Run `Publish-Release.ps1` to publish the release and begin the final release process.
+    1. This will trigger the automated release build action, which will publish the NuGet
+       packages etc... It also creates a merge-back branch for all changes that went into
+       the release.
+6. Once the release build completes, edit and publish the release in GitHub.
+    1. The "release" is created by the automated build as a draft and requires manual
+       publication. This is usually editing or selecting the base for auto generated release
+       notes.
+7. Apply the merge-back PR to the `develop` branch to update the `BuildVersion.xml` at a
+   minimum.
+
+---
+Step 3 & 4 are normally resolve to simply committing the changes to `BuildVersion.xml` and
+pushing that to the official repository. That is, in most cases there are no changes to the
+branch other than the bump of version number. That's actually the ideal as it eliminates (
+or dramatically reduces the complexity of) conflict resolution to merge the changes into.

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -22,4 +22,4 @@ documented. It is an internal implementation detail subject to change in the fut
 are plans to merge it with the OO wrapper library. Therefore, applications should NOT depend
 on it as it is likely to cease existing in the future.
 
-<a id="footnote_1"/><sup>2</sup> The analyzer is included in the `Ubiquity.NET.Llvm` package.
+<a id="footnote_2"/><sup>2</sup> The analyzer is included in the `Ubiquity.NET.Llvm` package.

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "9.0.305",
+        "version": "10.0.100",
         "rollForward": "latestMinor",
         "allowPrerelease": false
     },

--- a/src/Samples/Kaleidoscope/TextMate/ReadMe.md
+++ b/src/Samples/Kaleidoscope/TextMate/ReadMe.md
@@ -4,7 +4,7 @@ grammar used in the documentation template for the site docs. This allows highli
 an editor.
 
 ## VisualStudio
-In Visual Studio copies of sub-folders of this folder can be placed into the user profile
+For Visual Studio, copies of sub-folders of this folder can be placed into the user profile
 folder `.vs/Extensions` to enable syntax highlighting of the Kaleidoscope
 language files.
 

--- a/src/Ubiquity.NET.Llvm/IDataLayout.cs
+++ b/src/Ubiquity.NET.Llvm/IDataLayout.cs
@@ -19,28 +19,33 @@ namespace Ubiquity.NET.Llvm
     /// that are target dependent.</para>
     /// <para>The following table illustrates the differences in sizes and their meaning
     ///  for a sample set of types.</para>
-    /// |   Type  | SizeInBits | StoreSizeInBits | AbiSizeInBits |
-    /// |---------|------------|-----------------|---------------|
-    /// | i1      | 1          | 8               | 8             |
-    /// | i8      | 8          | 8               | 8             |
-    /// | i19     | 19         | 24              | 32            |
-    /// | i32     | 32         | 32              | 32            |
-    /// | i10     | 100        | 104             | 128           |
-    /// | i128    | 128        | 128             | 128           |
-    /// | Float   | 32         | 32              | 32            |
-    /// | Double  | 64         | 64              | 64            |
-    /// | X86_FP80| 80         | 80              | 96            |
+    /// <list type="table">
+    /// <listheader>
+    ///     <term> Type </term><term> SizeInBits </term><term> StoreSizeInBits </term><term> AbiSizeInBits </term>
+    /// </listheader>
+    /// <item> <description>i1      </description><description> 1   </description><description> 8   </description><description> 8   </description></item>
+    /// <item> <description>i8      </description><description> 8   </description><description> 8   </description><description> 8   </description></item>
+    /// <item> <description>i19     </description><description> 19  </description><description> 24  </description><description> 32  </description></item>
+    /// <item> <description>i32     </description><description> 32  </description><description> 32  </description><description> 32  </description></item>
+    /// <item> <description>i10     </description><description> 100 </description><description> 104 </description><description> 128 </description></item>
+    /// <item> <description>i128    </description><description> 128 </description><description> 128 </description><description> 128 </description></item>
+    /// <item> <description>Float   </description><description> 32  </description><description> 32  </description><description> 32  </description></item>
+    /// <item> <description>Double  </description><description> 64  </description><description> 64  </description><description> 64  </description></item>
+    /// <item> <description>X86_FP80</description><description> 80  </description><description> 80  </description><description> 96  </description></item>
+    /// </list>
     ///
     /// <note type="note">
     /// The allocation size depends on the alignment, and thus on the target.
     /// The values in the example table are for x86-32-linux.
     /// </note>
-    /// |   Property      | Definition |
-    /// |-----------------|------------|
-    /// | SizeInBits      | Minimum number of bits needed to represent the full range of values for the type |
-    /// | StoreSizeInBits | Minimum number of bits needed to actually store a *single* value of the type |
-    /// | AbiSizeInBits   | Total number of bits used to store a value in a sequence, including any alignment padding |
-    ///
+    /// <list type="table">
+    /// <listheader>
+    ///     <term>Property</term><term>Definition</term>
+    /// </listheader>
+    /// <item> <description>SizeInBits      </description><description> Minimum number of bits needed to represent the full range of values for the type </description></item>
+    /// <item> <description>StoreSizeInBits </description><description> Minimum number of bits needed to actually store a *single* value of the type </description></item>
+    /// <item> <description>AbiSizeInBits   </description><description> Total number of bits used to store a value in a sequence, including any alignment padding </description></item>
+    /// </list>
     /// The allocation size determines the total size of each entry in a sequence so that the "next" element is computed
     /// by adding the size to the start address of the current element.
     /// </remarks>
@@ -49,11 +54,11 @@ namespace Ubiquity.NET.Llvm
         /// <summary>Gets the byte ordering for this target</summary>
         public ByteOrdering Endianness { get; }
 
-        /// <summary>Gets the size of a pointer for the default address space of the target</summary>
+        /// <summary>Gets the size (in bytes) of a pointer for the default address space of the target</summary>
         /// <returns>Size of a pointer to the default address space</returns>
         public uint PointerSize( );
 
-        /// <summary>Retrieves the size of a pointer for a given address space of the target</summary>
+        /// <summary>Retrieves the size (in bytes) of a pointer for a given address space of the target</summary>
         /// <param name="addressSpace">Address space for the pointer</param>
         /// <returns>Size of a pointer</returns>
         public uint PointerSize( uint addressSpace );
@@ -109,7 +114,7 @@ namespace Ubiquity.NET.Llvm
         /// </remarks>
         public ulong StoreSizeOf( ITypeRef typeRef );
 
-        /// <summary>Retrieves the ABI specified size of the given type</summary>
+        /// <summary>Retrieves the ABI specified size (in bytes) of the given type</summary>
         /// <param name="typeRef">Type to get the size from</param>
         /// <returns>Size of the type</returns>
         /// <remarks>
@@ -123,17 +128,17 @@ namespace Ubiquity.NET.Llvm
         /// <returns>ABI specified alignment</returns>
         public uint AbiAlignmentOf( ITypeRef typeRef );
 
-        /// <summary>Retrieves the call frame alignment for a given type</summary>
+        /// <summary>Retrieves the call frame alignment (in bytes) for a given type</summary>
         /// <param name="typeRef">type to get the alignment of</param>
         /// <returns>Alignment for the type</returns>
         public uint CallFrameAlignmentOf( ITypeRef typeRef );
 
-        /// <summary>Gets the preferred alignment for an LLVM type</summary>
+        /// <summary>Gets the preferred alignment (in bytes) for an LLVM type</summary>
         /// <param name="typeRef">Type to get the alignment of</param>
         /// <returns>Preferred alignment</returns>
         public uint PreferredAlignmentOf( ITypeRef typeRef );
 
-        /// <summary>Gets the preferred alignment for a <see cref="Value"/></summary>
+        /// <summary>Gets the preferred alignment (in bytes) for a <see cref="Value"/></summary>
         /// <param name="value">Value to get the alignment of</param>
         /// <returns>Preferred alignment</returns>
         public uint PreferredAlignmentOf( Value value );


### PR DESCRIPTION
Updates to support .NET 10 SDK
* NOTE: Use of .NET 10 SDK requires use of VS2026 as .NET 10 SDK is not supported on older VS versions.

Clarification on note:
Targeting .NET 10 runtime is unsupported in VS2022 and earlier, currently the projects in this repository target .NET 8, which is fine in VS2022.

Fixes #386
Implements #361