### PR TITLE
Add parameter checks and tests for `IntructionBuilder.IntToPointer`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,20 @@
 #Primary settings apply to all files unless overridden below
+# NOTE: Just opening this file in the VS UI editor will make changes that are
+# not intended.
+#
+# DO-NOT allow such changes!
+#
+# Unfortunately, this requires a great deal of discipline and manual checking
+# of differences to ensure the changes made ONLY contains intentional changes
+# that really apply to all users of this repository.
+#
+# see: https://github.com/dotnet/roslyn/issues/59325
+#
+# Unfortunately, that has remained open for nearly 4 years, so not likely to
+# get a fix any time soon...
+
+# Analysis and refactoring rules for Ubiquity.NET
+# Description: Code analysis rules for Ubiquity.NET projects
 root = true
 
 [*]
@@ -107,11 +123,6 @@ dotnet_diagnostic.SA1202.severity = none
 csharp_style_prefer_local_over_anonymous_function = true:error
 csharp_style_prefer_index_operator = true:error
 csharp_style_prefer_range_operator = true:error
-
-# Analysis and refactoring rules for Ubiquity.NET
-# Description: Code analysis rules for Ubiquity.NET projects
-
-# NOTE: Requires **VS2019 16.3** or later
 
 # Code files
 [*.{cs,vb}]
@@ -1615,7 +1626,6 @@ dotnet_diagnostic.SA1651.severity = error
 dotnet_diagnostic.SA1652.severity = warning
 
 dotnet_diagnostic.SX1101.severity = error
-
 
 # IDE0045: Convert to conditional expression
 dotnet_diagnostic.IDE0045.severity = suggestion

--- a/src/Ubiquity.NET.Llvm.Tests/Instructions/PointerCasts.cs
+++ b/src/Ubiquity.NET.Llvm.Tests/Instructions/PointerCasts.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Licensed under the Apache-2.0 WITH LLVM-exception license. See the LICENSE.md file in the project root for full license information.
+
+using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Ubiquity.NET.Llvm.Instructions;
+using Ubiquity.NET.Llvm.Values;
+
+namespace Ubiquity.NET.Llvm.UT.Instructions
+{
+    [TestClass]
+    public class PointerCasts
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+        [TestMethod]
+        public void IntToPointer_throws_with_invalid_input( )
+        {
+            using var ctx = new Context();
+            using var module = ctx.CreateBitcodeModule("test"u8);
+            var doulbeFuncType = ctx.GetFunctionType(ctx.DoubleType);
+            var doubleFunc = module.CreateFunction("test"u8, doulbeFuncType);
+            var block = ctx.CreateBasicBlock("testBlock"u8);
+
+            using var irBuilder = new InstructionBuilder(block);
+            Value nonConstValue = irBuilder.Call(doubleFunc);
+            Value nonIntConstantValue = ctx.CreateConstant(1.23);
+
+            var ptrBoolType = ctx.BoolType.CreatePointerType();
+            var constInt = ctx.CreateConstant(0x1234u);
+            var argNullEx = Assert.ThrowsExactly<ArgumentNullException>(()=>
+            {
+                _ = irBuilder.IntToPointer( null, ptrBoolType );
+            });
+            Assert.AreEqual( "intValue", argNullEx.ParamName);
+
+            argNullEx = Assert.ThrowsExactly<ArgumentNullException>(()=>
+            {
+                _ = irBuilder.IntToPointer( constInt, null );
+            });
+            Assert.AreEqual( "ptrType", argNullEx.ParamName );
+
+            var argEx = Assert.ThrowsExactly<ArgumentException>( ( ) =>
+            {
+                _ = irBuilder.IntToPointer( nonIntConstantValue, ptrBoolType );
+            } );
+            Assert.AreEqual( "intValue", argEx.ParamName );
+
+            argEx = Assert.ThrowsExactly<ArgumentException>( ( ) =>
+            {
+                _ = irBuilder.IntToPointer( nonConstValue, ptrBoolType );
+            } );
+            Assert.AreEqual( "intValue", argEx.ParamName );
+        }
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+    }
+}

--- a/src/Ubiquity.NET.Llvm/Instructions/InstructionBuilder.cs
+++ b/src/Ubiquity.NET.Llvm/Instructions/InstructionBuilder.cs
@@ -920,6 +920,11 @@ namespace Ubiquity.NET.Llvm.Instructions
             ArgumentNullException.ThrowIfNull( intValue );
             ArgumentNullException.ThrowIfNull( ptrType );
 
+            if(!intValue.NativeType.IsInteger)
+            {
+                throw new ArgumentException( Resources.Expecting_an_integer_type, nameof( intValue ) );
+            }
+
             var handle = (intValue is Constant)
                          ? LLVMConstIntToPtr( intValue.Handle, ptrType.GetTypeRef( ) )
                          : LLVMBuildIntToPtr( Handle, intValue.Handle, ptrType.GetTypeRef( ), LazyEncodedString.Empty );


### PR DESCRIPTION
Add parameter checks and tests for `IntructionBuilder.IntToPointer`

Fixes #384

* Updated types to add parameter checks and report problems early
* Updated .editorconfig to describe problems with Broken GUI editor